### PR TITLE
feat: treasure effects, crocodile puzzle difficulty tuning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,19 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+For full architecture, conventions, workflows, and key file reference see **[agents.md](agents.md)**.
+
+## Quick Commands
+
+```bash
+yarn dev          # Dev server at http://localhost:9164
+yarn test         # Run all tests (Vitest)
+yarn test <file>  # Run a single test file
+yarn check-types  # TypeScript type checking
+yarn lint         # ESLint (includes Tailwind class order)
+yarn build        # Production build
+yarn storybook    # Component docs at http://localhost:6006
+```
+
+Always run `yarn check-types` and `yarn lint` before considering a change complete.

--- a/agents.md
+++ b/agents.md
@@ -88,12 +88,15 @@ The project uses strict TypeScript. Avoid `any` types; define proper interfaces 
 
 ```bash
 yarn dev          # Dev server at http://localhost:9164
-yarn test         # Run tests (Vitest)
+yarn test         # Run all tests (Vitest)
+yarn test <file>  # Run a single test file
 yarn check-types  # TypeScript type checking
 yarn lint         # ESLint (includes Tailwind class order)
 yarn build        # Production build
 yarn storybook    # Component docs at http://localhost:6006
 ```
+
+Always run `yarn check-types` and `yarn lint` before considering a change complete.
 
 ### Adding a New Journey or Tableau
 
@@ -148,6 +151,16 @@ Run all tests: `yarn test`
 - ❌ Skipping the Dutch translation when adding English strings
 - ❌ Committing without running `yarn check-types` and `yarn lint`
 - ❌ Managing game state locally in components (use state hooks instead)
+
+---
+
+## Feature Documentation
+
+Deeper design docs live in `docs/`:
+
+| Document | Topic |
+|----------|-------|
+| [`docs/crocodile-puzzle.md`](docs/crocodile-puzzle.md) | Crocodile lock mechanic for Treasure Tombs |
 
 ---
 

--- a/docs/crocodile-puzzle.md
+++ b/docs/crocodile-puzzle.md
@@ -1,0 +1,82 @@
+# Crocodile Puzzle
+
+The crocodile puzzle is the lock mechanic guarding Treasure Tombs. It is themed around **Sobek**, the Egyptian crocodile god of the Nile.
+
+## Player Experience
+
+1. **Comparison phase** — The player is shown a series of pairs of math formulas and must tap the one with the **largest result** for the crocodile to eat. The crocodile faces the chosen side and snaps its mouth shut to confirm each answer.
+2. **Lock phase** — After all comparisons are resolved, the player is asked: *"What digit did the crocodile always/never eat?"* They must identify a single digit (0–9) that consistently appeared (or never appeared) in the results the crocodile chose.
+3. **Reward** — A correct digit opens the chest and awards a random uncollected treasure from that tomb's loot table.
+
+If the player doesn't remember, an "I don't know" button resets the comparison phase so they can replay it with fresh attention.
+
+## Puzzle Generation
+
+Each run through a tomb generates a deterministic puzzle from `levelSeed = randomSeed + runNumber * 3210`.
+
+`generateCompareLevel` (`src/game/generateCompareLevel.ts`) produces a `CompareLevel`:
+
+```ts
+type Requirements = {
+  digit: number      // 0–9, randomly chosen
+  largest: "always" | "never"
+}
+
+type CompareLevel = {
+  requirements: Requirements
+  comparisons: { left: Formula; right: Formula }[]
+}
+```
+
+For each comparison, `createCompare` regenerates formula pairs until the constraint is satisfied:
+- `largest: "always"` — the digit appears in the **larger** result but not the smaller
+- `largest: "never"` — the digit appears in the **smaller** result but not the larger
+
+The number of comparisons is set by `journey.levelSettings.compareAmount`. If generation exceeds 50 iterations, `numberOfSymbols` is incrementally increased to make the constraint easier to satisfy. Failure after 200 iterations throws.
+
+## Validation
+
+On lock submission (`handleLockSubmit` in `useComparePuzzleControls.ts`), the entered digit is compared against `levelData.requirements.digit`. A mismatch resets both the lock state and all comparison answers so the player must redo the full puzzle.
+
+## Loot Selection
+
+The treasure awarded is selected deterministically from `randomSeed + 12345` at the start of the hook — before the puzzle is shown. Only treasures not already in the player's inventory are eligible.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `src/app/TombLevel/ComparePuzzle.tsx` | UI: comparison cards, crocodile animation, lock input |
+| `src/app/TombLevel/useComparePuzzleControls.ts` | All puzzle state, answer handling, lock validation, loot award |
+| `src/game/generateCompareLevel.ts` | Deterministic level generation from seed + requirements |
+| `src/assets/crocodile-250.png` | Crocodile with open mouth |
+| `src/assets/crocodile-closed-250.png` | Crocodile with closed mouth (after eating) |
+| `public/locales/en/common.json` | UI strings under `tomb.crocodile*` |
+
+## Journey Configuration
+
+The following fields on a `TreasureTombJourney.levelSettings` control puzzle difficulty:
+
+| Field | Effect |
+|-------|--------|
+| `compareAmount` | Number of comparison pairs shown |
+| `numberRange` | Min/max values used in formula numbers |
+| `operators` | Operators used by the pyramid tableau formula generator for this tomb |
+| `compareOperators` | Operators used in the crocodile comparison formulas — overrides `operators` when set |
+| `maxMultiplyOperandResult` | Maximum value either operand of a `*` may evaluate to; prevents unmanageable products |
+
+`operators` and `compareOperators` are intentionally separate because the pyramid tableau generator and the compare puzzle have different complexity needs. For example, the master and wizard tombs include `/` in `operators` so their tableau formulas can be generated, but set `compareOperators: ["+", "-", "*"]` to keep the mental arithmetic in the comparison phase tractable.
+
+### Current settings per tier
+
+| Tomb | `compareOperators` | `maxMultiplyOperandResult` | `compareAmount` | `numberRange` |
+|------|--------------------|---------------------------|-----------------|---------------|
+| Starter | `["+"]` | — | 0 (no puzzle) | 1–5 |
+| Junior | `["+", "-"]` | — | 2 | 1–10 |
+| Expert | `["+", "-", "*"]` | 5 | 3 | 1–10 |
+| Master | `["+", "-", "*"]` | 10 | 4 | 1–10 |
+| Wizard | `["+", "-", "*"]` | 12 | 5 | 1–15 |
+
+Division is excluded from all compare puzzles. The `maxMultiplyOperandResult` limits ensure that multiplication stays mentally manageable for the target age group (8–11): Expert keeps both sides of `*` ≤ 5 (e.g. `(2+3) * 4`), Master ≤ 10, and Wizard ≤ 12.
+
+A matching tableau entry (keyed by `tombJourneyId` + `runNumber` in `src/data/tableaus.ts`) can override `symbolCount` to control how many numbers appear per formula side.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pyramid-scheme",
   "private": true,
-  "version": "0.20.0",
+  "version": "0.21.0",
   "type": "module",
   "scripts": {
     "dev": "vite --port 9164",

--- a/src/app/Formulas/formulas.ts
+++ b/src/app/Formulas/formulas.ts
@@ -15,6 +15,7 @@ export type FormulaSettings = {
   operations: Operation[]
   useResult?: "avoid" | "force" | "allow"
   maxMultiplications?: number
+  maxMultiplyOperandResult?: number
 }
 
 const getNumberValue = (value: number | { symbol: number } | Formula): number => {
@@ -24,7 +25,7 @@ const getNumberValue = (value: number | { symbol: number } | Formula): number =>
 }
 
 export const createFormula = (settings: FormulaSettings, random: () => number): Formula => {
-  const { pickedNumbers, operations, useResult = "avoid", maxMultiplications } = settings
+  const { pickedNumbers, operations, useResult = "avoid", maxMultiplications, maxMultiplyOperandResult } = settings
 
   if (useResult === "allow" || useResult === "force") {
     // take largest result from picked numbers and remove it from the pool
@@ -61,11 +62,11 @@ export const createFormula = (settings: FormulaSettings, random: () => number): 
   const leftFormula =
     leftNumbers.length === 1
       ? { symbol: leftNumbers[0] }
-      : createVerifiedFormula({ pickedNumbers: leftNumbers, operations, maxMultiplications }, random)
+      : createVerifiedFormula({ pickedNumbers: leftNumbers, operations, maxMultiplications, maxMultiplyOperandResult }, random)
   const rightFormula =
     rightNumbers.length === 1
       ? { symbol: rightNumbers[0] }
-      : createVerifiedFormula({ pickedNumbers: rightNumbers, operations, maxMultiplications }, random)
+      : createVerifiedFormula({ pickedNumbers: rightNumbers, operations, maxMultiplications, maxMultiplyOperandResult }, random)
 
   // Pick a random operation
   const operation = operations[Math.floor(random() * operations.length)]
@@ -132,12 +133,25 @@ export const createVerifiedFormula = (settings: FormulaSettings, random: () => n
     }
     return true
   }
+  const verifyMultiplyOperands = (formula: Formula): boolean => {
+    if (settings.maxMultiplyOperandResult === undefined) return true
+    if (formula.operation === "*") {
+      if (getNumberValue(formula.left) > settings.maxMultiplyOperandResult) return false
+      if (getNumberValue(formula.right) > settings.maxMultiplyOperandResult) return false
+    }
+    const leftOk =
+      typeof formula.left !== "number" && !("symbol" in formula.left) ? verifyMultiplyOperands(formula.left) : true
+    const rightOk =
+      typeof formula.right !== "number" && !("symbol" in formula.right) ? verifyMultiplyOperands(formula.right) : true
+    return leftOk && rightOk
+  }
 
   while (
     !verifyOperand(formula.result) ||
     !verifyOperand(formula.left) ||
     !verifyOperand(formula.right) ||
     !verifySelfDivision(formula) ||
+    !verifyMultiplyOperands(formula) ||
     (settings.maxMultiplications !== undefined && countMultiplicativeOps(formula) > settings.maxMultiplications)
   ) {
     iteration++

--- a/src/app/Formulas/formulas.ts
+++ b/src/app/Formulas/formulas.ts
@@ -62,11 +62,17 @@ export const createFormula = (settings: FormulaSettings, random: () => number): 
   const leftFormula =
     leftNumbers.length === 1
       ? { symbol: leftNumbers[0] }
-      : createVerifiedFormula({ pickedNumbers: leftNumbers, operations, maxMultiplications, maxMultiplyOperandResult }, random)
+      : createVerifiedFormula(
+          { pickedNumbers: leftNumbers, operations, maxMultiplications, maxMultiplyOperandResult },
+          random
+        )
   const rightFormula =
     rightNumbers.length === 1
       ? { symbol: rightNumbers[0] }
-      : createVerifiedFormula({ pickedNumbers: rightNumbers, operations, maxMultiplications, maxMultiplyOperandResult }, random)
+      : createVerifiedFormula(
+          { pickedNumbers: rightNumbers, operations, maxMultiplications, maxMultiplyOperandResult },
+          random
+        )
 
   // Pick a random operation
   const operation = operations[Math.floor(random() * operations.length)]

--- a/src/app/TombLevel/useComparePuzzleControls.ts
+++ b/src/app/TombLevel/useComparePuzzleControls.ts
@@ -69,7 +69,8 @@ export const useCrocodilePuzzleControls = ({
         compareAmount: journey.levelSettings.compareAmount,
         numberOfSymbols: tableau?.symbolCount ?? 2,
         numberRange: journey.levelSettings.numberRange,
-        operators: journey.levelSettings.operators,
+        operators: journey.levelSettings.compareOperators ?? journey.levelSettings.operators,
+        maxMultiplyOperandResult: journey.levelSettings.maxMultiplyOperandResult,
       },
       { digit, largest: always ? "always" : "never" },
       random

--- a/src/app/TombLevel/useComparePuzzleControls.ts
+++ b/src/app/TombLevel/useComparePuzzleControls.ts
@@ -79,6 +79,8 @@ export const useCrocodilePuzzleControls = ({
   }, [
     journey.id,
     journey.levelSettings.compareAmount,
+    journey.levelSettings.compareOperators,
+    journey.levelSettings.maxMultiplyOperandResult,
     journey.levelSettings.numberRange,
     journey.levelSettings.operators,
     runNumber,

--- a/src/data/journeys.ts
+++ b/src/data/journeys.ts
@@ -67,7 +67,9 @@ export type TreasureTombJourney = {
     symbolCount: number
     numberRange: [min: number, max: number]
     operators: Operation[]
+    compareOperators?: Operation[]
     compareAmount: number
+    maxMultiplyOperandResult?: number
   }
 }
 
@@ -487,6 +489,7 @@ export const journeys: Journey[] = [
       numberRange: [1, 10],
       operators: ["+", "-", "*"],
       compareAmount: 3,
+      maxMultiplyOperandResult: 5,
     },
   },
 
@@ -625,7 +628,9 @@ export const journeys: Journey[] = [
       symbolCount: 4,
       numberRange: [1, 10],
       operators: ["+", "-", "*", "/"],
+      compareOperators: ["+", "-", "*"],
       compareAmount: 4,
+      maxMultiplyOperandResult: 10,
     },
   },
 
@@ -775,7 +780,9 @@ export const journeys: Journey[] = [
       symbolCount: 5,
       numberRange: [1, 15],
       operators: ["+", "-", "*", "/"],
+      compareOperators: ["+", "-", "*"],
       compareAmount: 5,
+      maxMultiplyOperandResult: 12,
     },
   },
 ]

--- a/src/game/generateCompareLevel.ts
+++ b/src/game/generateCompareLevel.ts
@@ -33,7 +33,12 @@ const generateCompareFormula = (settings: CompareFormulaSettings, random: () => 
   const maxMultiplications = settings.operators.some(op => op === "*" || op === "/") ? 1 : undefined
 
   return createVerifiedFormula(
-    { pickedNumbers: numbers, operations: settings.operators, maxMultiplications, maxMultiplyOperandResult: settings.maxMultiplyOperandResult },
+    {
+      pickedNumbers: numbers,
+      operations: settings.operators,
+      maxMultiplications,
+      maxMultiplyOperandResult: settings.maxMultiplyOperandResult,
+    },
     random
   )
 }

--- a/src/game/generateCompareLevel.ts
+++ b/src/game/generateCompareLevel.ts
@@ -4,6 +4,7 @@ export type CompareFormulaSettings = {
   numberOfSymbols: number
   numberRange: [min: number, max: number]
   operators: Operation[]
+  maxMultiplyOperandResult?: number
 }
 
 export type CompareLevelSettings = CompareFormulaSettings & {
@@ -31,7 +32,10 @@ const generateCompareFormula = (settings: CompareFormulaSettings, random: () => 
   // Limit to at most 1 multiplicative op (* or /) per formula side when those operators are present
   const maxMultiplications = settings.operators.some(op => op === "*" || op === "/") ? 1 : undefined
 
-  return createVerifiedFormula({ pickedNumbers: numbers, operations: settings.operators, maxMultiplications }, random)
+  return createVerifiedFormula(
+    { pickedNumbers: numbers, operations: settings.operators, maxMultiplications, maxMultiplyOperandResult: settings.maxMultiplyOperandResult },
+    random
+  )
 }
 
 const createCompare = (settings: CompareFormulaSettings, requirements: Requirements, random: () => number) => {


### PR DESCRIPTION
## Summary

- **Crocodile puzzle difficulty**: Division removed from Expert/Master/Wizard compare puzzles; added `maxMultiplyOperandResult` constraint so multiplication operands stay mentally manageable for ages 8–11 (Expert ≤ 5, Master ≤ 10, Wizard ≤ 12). A new `compareOperators` field separates compare-puzzle operators from the tableau formula operators, so the tableau generator is unaffected.
- **Formula constraint**: `maxMultiplyOperandResult` is enforced in `createVerifiedFormula` — any formula where a `*` operand evaluates above the limit is rejected and regenerated.
- **Treasure effects**: TombTreasures Storybook story, new treasures, map fragment chance reduction, CI tweaks, sharp version pin.
- **Documentation**: Added `CLAUDE.md`, `agents.md`, and `docs/crocodile-puzzle.md` documenting the crocodile mechanic, configuration fields, and per-tier difficulty rationale.

## Test plan

- [ ] Run `yarn test` — all 351 tests pass
- [ ] Run `yarn check-types` — no errors
- [ ] Open an Expert/Master/Wizard tomb and verify compare formulas no longer contain division
- [ ] Verify multiplication operands in Expert tomb are small (e.g. `(2+3) * 4`, not `(8+9) * (3+5+8+5)`)
- [ ] Confirm Master and Wizard tombs show progressively larger but still manageable multiplication operands

🤖 Generated with [Claude Code](https://claude.com/claude-code)