### PR TITLE
feat: treasure passive effects system

### DIFF
--- a/docs/handover-treasure-effects-implementation.md
+++ b/docs/handover-treasure-effects-implementation.md
@@ -1,0 +1,167 @@
+# Handover: Treasure Effects Implementation
+
+This document briefs the next agent on implementing the treasure effects system. The design is fully resolved — types and effect assignments are in place. What remains is the gameplay mechanics and UI text.
+
+## What's Already Done
+
+- `TreasureEffects` type fully defined in `src/data/treasures.ts` with JSDoc on every field
+- `MaterialTier` type and `materialTierByDifficulty` / `difficultyByMaterialTier` lookup maps in `src/data/treasures.ts`
+- All 40 treasures have effects assigned in `src/data/treasures.ts`
+- Design documented in `docs/treasure-effects.md`
+
+## What Needs to Be Done
+
+### 1. Effect descriptions in translations
+
+Each treasure needs an `effectDescription` translation key added alongside its existing `name` and `description`. This text is shown to the player when they find the treasure (in the loot popup) and in the collection screen.
+
+Add `effectDescription` to every treasure entry in:
+- `public/locales/en/treasures.json`
+- `public/locales/nl/treasures.json`
+
+The structure per treasure becomes:
+```json
+{
+  "merchantCache": {
+    "t1": {
+      "name": "Silver Deben",
+      "description": "An ancient Egyptian silver coin...",
+      "effectDescription": "+10% map fragment chance"
+    }
+  }
+}
+```
+
+Write short, concrete effect descriptions (one line). Examples by effect type:
+- `mapFragmentChance: 0.1` → "+10% map fragment chance"
+- `higherLootChance: 0.1` → "+10% loot drop chance"
+- `moreLootChance { chance: 0.2, tier: "stone" }` → "20% chance of a bonus Stone item per pyramid"
+- `moreLootChance { chance: 0.2 }` → "20% chance of a bonus item per pyramid (adapts to current difficulty)"
+- `expeditionBonus { amount: 1, tier: "bronze" }` → "+1 Bronze item on expedition completion"
+- `errorHighlight: true` → "Highlights one wrong block while solving"
+- `earlyFeedback: true` → "Shows live feedback on checkpoint blocks"
+- `hieroglyphUnlock: true` → "Unlock one hidden block per pyramid to write your value"
+
+### 2. Show effectDescription in the loot popup
+
+The loot popup is triggered from `src/app/PyramidLevel/LevelCompletionHandler.tsx` and `src/app/TombLevel/useComparePuzzleControls.ts`. The `Loot` type has an `itemDescription` field — use `effectDescription` from the translation for treasure items.
+
+In `src/data/useTreasureTranslations.ts`, the `useTreasureItem()` hook returns `name`, `description`, and `symbol` for a treasure. Add `effectDescription` to what it returns, sourced from the new translation key.
+
+### 3. Implement `moreLootChance` (implement this first — it is the priority)
+
+**Where:** `src/app/PyramidLevel/useLootDetermination.tsx` (or the `inventoryLootLogic` it calls).
+
+**How to access owned treasures and compute the total chance:**
+```ts
+import { allTreasures, difficultyByMaterialTier } from "@/data/treasures"
+import { materialTierByDifficulty } from "@/data/treasures"
+
+// In the hook, read inventory to find owned treasures
+const ownedTreasures = allTreasures.filter(t => (inventory[t.id] ?? 0) > 0)
+
+// Sum moreLootChance for a given difficulty
+const totalChance = ownedTreasures.reduce((sum, t) => {
+  const effect = t.effects?.moreLootChance
+  if (!effect) return sum
+  const effectTier = effect.tier ?? materialTierByDifficulty[currentDifficulty]
+  if (effectTier !== materialTierByDifficulty[currentDifficulty]) return sum
+  return sum + effect.chance
+}, 0)
+```
+
+**Seeded roll:** Use `mulberry32` seeded from the level seed (same approach as the compare puzzle in `src/app/TombLevel/useComparePuzzleControls.ts`). The seed should be derived from `randomSeed + levelNr` or similar — stay consistent with existing patterns.
+
+**What to award:** Pick a random item from `difficultyTreasures` wait — from inventory items (not treasure items) of the matching difficulty. Use `itemLevelLookup` or equivalent to find items at that difficulty tier. Award via `addItems()` from `useInventory`.
+
+**Unit tests:** Add tests in a new file `src/app/PyramidLevel/lootEffects.spec.ts` (or alongside the existing loot logic). Test:
+- No owned treasures → no bonus loot
+- One treasure with 20% chance → rolls correctly with known seed
+- Two treasures with 20% each → 40% total chance
+- Tier-specific treasure only fires on matching difficulty
+- Tier-less treasure fires on any difficulty
+
+### 4. Implement `expeditionBonus`
+
+**Where:** `src/app/PyramidLevel/LevelCompletionHandler.tsx` — trigger on expedition completion (when `journey.levelNr >= journey.levelCount`).
+
+**How:** Sum `expeditionBonus.amount` across all owned treasures matching the current expedition's tier. Award that many items via `addItems()`. Items should come from the matching difficulty pool.
+
+No seeded randomness needed (the amount is guaranteed, but the specific items chosen should use seeded RNG).
+
+### 5. Implement `higherLootChance` and `mapFragmentChance`
+
+**Where:** `src/app/PyramidLevel/useLootDetermination.tsx`.
+
+These are additive bonuses applied to the existing base probability checks:
+- `higherLootChance`: sum across owned treasures and add to the base loot drop probability
+- `mapFragmentChance`: sum across owned treasures and add to the base map fragment probability
+
+Both use seeded rolls — same approach as `moreLootChance`.
+
+### 6. Implement `errorHighlight`
+
+**Where:** The pyramid puzzle block rendering — likely in `src/app/PyramidLevel/` block components.
+
+**How:** Count owned treasures with `errorHighlight: true`. That count = the number of wrong blocks to highlight in real-time. A block is "wrong" if the player has entered a value and it does not match the expected result.
+
+This requires:
+- Access to the player's current block values during solving
+- Comparison against the correct values
+- A way to mark the first N wrong blocks visually (border color or glow)
+
+### 7. Implement `earlyFeedback`
+
+**Where:** Same pyramid puzzle block rendering as `errorHighlight`.
+
+**How:** Count owned treasures with `earlyFeedback: true`. That count = how many checkpoint blocks get live borders. Checkpoint blocks are blocks that appear after a calculation chain — the pyramid level generator already marks which blocks are "key" intermediate results.
+
+### 8. Implement `hieroglyphUnlock`
+
+**Where:** The pyramid puzzle — hieroglyph blocks are currently uneditable. 
+
+**How:** Count owned treasures with `hieroglyphUnlock: true`. Once per level, the player can tap a hieroglyph block and enter a value. The chosen value is accepted as-is (not validated until full submission). The number of available unlocks equals the count of owned `hieroglyphUnlock` treasures.
+
+This likely requires:
+- New state in the pyramid level hook tracking how many unlocks remain this level
+- A tap-to-unlock gesture on hieroglyph blocks (distinct from normal block interaction)
+- Visual indicator showing the block is now writable
+
+## Key Files
+
+| File | Relevance |
+|------|-----------|
+| `src/data/treasures.ts` | Effect types and all 40 treasure definitions |
+| `src/data/useTreasureTranslations.ts` | Hook returning treasure name/description/symbol — add `effectDescription` |
+| `src/app/PyramidLevel/useLootDetermination.tsx` | Where `moreLootChance`, `higherLootChance`, `mapFragmentChance` hook in |
+| `src/app/PyramidLevel/LevelCompletionHandler.tsx` | Where `expeditionBonus` hooks in (expedition completion path) |
+| `src/app/Inventory/useInventory.ts` | `addItems()` for awarding items |
+| `src/game/random.ts` | `mulberry32`, `generateNewSeed` — use for all seeded rolls |
+| `public/locales/en/treasures.json` | Add `effectDescription` to every treasure |
+| `public/locales/nl/treasures.json` | Dutch translations — keep in sync |
+| `docs/treasure-effects.md` | Full design reference including effect assignment table |
+
+## Implementation Order
+
+1. **Translations first** — add `effectDescription` to all 40 treasures in both locales, show in loot popup
+2. **`moreLootChance`** — highest gameplay impact, has unit test requirement
+3. **`expeditionBonus`** — complements `moreLootChance`, same reward system
+4. **`higherLootChance` + `mapFragmentChance`** — simpler additive bonuses on existing probability checks
+5. **`hieroglyphUnlock`** — UI work on the pyramid puzzle blocks
+6. **`errorHighlight` + `earlyFeedback`** — UI work on the pyramid puzzle blocks, can be done together
+
+## Accessing Owned Treasures (Pattern)
+
+```ts
+import { allTreasures } from "@/data/treasures"
+import { useInventory } from "@/app/Inventory/useInventory"
+
+const { inventory } = useInventory()
+const ownedTreasures = allTreasures.filter(t => (inventory[t.id] ?? 0) > 0)
+
+// Boolean effect count (e.g. errorHighlight):
+const errorHighlightCount = ownedTreasures.filter(t => t.effects?.errorHighlight).length
+
+// Numeric stacking (e.g. mapFragmentChance):
+const bonusMapChance = ownedTreasures.reduce((sum, t) => sum + (t.effects?.mapFragmentChance ?? 0), 0)
+```

--- a/docs/treasure-effects.md
+++ b/docs/treasure-effects.md
@@ -1,0 +1,157 @@
+# Treasure Effects
+
+Treasures found in Treasure Tombs carry passive effects that alter gameplay. Effects are defined on the `TreasureEffects` type in `src/data/treasures.ts`, exported from `TreasureEffects`.
+
+## Material Tiers
+
+Inventory items (hieroglyphs) are grouped into material tiers that map to difficulty levels:
+
+| Tier | Difficulty | Code value |
+|------|------------|------------|
+| Stone | Starter | `"stone"` |
+| Bronze | Junior | `"bronze"` |
+| Silver | Expert | `"silver"` |
+| Gold | Master | `"gold"` |
+| Divine | Wizard | `"divine"` |
+
+Lookup helpers in `src/data/treasures.ts`:
+- `materialTierByDifficulty` — `Difficulty → MaterialTier`
+- `difficultyByMaterialTier` — `MaterialTier → Difficulty`
+
+## Effects Reference
+
+### `higherLootChance: number`
+Additive bonus to the base probability that any inventory loot drops when a pyramid level is completed. Multiple treasures stack additively.
+
+**Example:** `0.1` adds 10% on top of the base drop rate.  
+**Status:** Not yet implemented.
+
+---
+
+### `mapFragmentChance: number`
+Additive bonus to the base probability that a map fragment drops when a pyramid level is completed. Multiple treasures stack additively.
+
+**Example:** `0.1` adds 10% on top of the base map fragment drop rate.  
+**Status:** Not yet implemented.
+
+---
+
+### `moreLootChance: { chance: number; tier?: MaterialTier }`
+Per pyramid level completed, a seeded roll determines whether one extra inventory item drops. If `tier` is specified the bonus item is from that tier; if omitted the bonus item matches the current pyramid's difficulty tier. Multiple treasures stack additively on the total chance.
+
+**Example:** `{ chance: 0.2, tier: "stone" }` = 20% chance of an extra Stone item per level.  
+**Example:** `{ chance: 0.2 }` = 20% chance of an extra item matching the current pyramid's tier.  
+**Stacking:** Additive — two treasures at 20% for the same tier = 40% total.  
+**RNG:** Seeded (`mulberry32`), deterministic per run/level.  
+**Status:** Not yet implemented.
+
+---
+
+### `expeditionBonus: { amount: number; tier: MaterialTier }`
+At the end of a completed pyramid expedition, awards a guaranteed number of inventory items of the specified tier. Multiple treasures with the same tier stack additively.
+
+**Example:** `{ amount: 1, tier: "gold" }` = 1 extra Gold item on every expedition completion.  
+**Stacking:** Additive — two treasures with `{ amount: 1, tier: "gold" }` award 2 Gold items.  
+**Status:** Not yet implemented.
+
+---
+
+### `errorHighlight: boolean`
+Count the number of owned treasures with this effect to determine how many miscalculated blocks are highlighted in real-time while solving a pyramid puzzle, rather than waiting until all blocks are filled.
+
+**Stacking:** Count-based — owning 2 treasures highlights the first 2 wrong blocks.  
+**Status:** Not yet implemented.
+
+---
+
+### `earlyFeedback: boolean`
+Count the number of owned treasures with this effect to determine how many checkpoint blocks in the pyramid (after calculation chains) display a magical border with live correct/incorrect feedback.
+
+**Stacking:** Count-based — owning 2 treasures activates more checkpoint blocks.  
+**Status:** Not yet implemented.
+
+---
+
+### `hieroglyphUnlock: boolean`
+Count the number of owned treasures with this effect to determine how many hidden hieroglyph blocks the player may unlock per pyramid level. Unlocking a block lets the player write in their calculated value, removing the need to hold it in memory. The player chooses which block to unlock.
+
+**Stacking:** Count-based — owning 2 treasures allows writing down 2 hidden values per level.  
+**Status:** Not yet implemented.
+
+---
+
+## Implementation Notes
+
+- All effects are passive and always active once the treasure is in the player's inventory.
+- Numeric chances use a `0.0–1.0` scale (matching the rest of the reward system).
+- Boolean effects stack by counting: `allTreasures.filter(t => inventory[t.id] && t.effects?.errorHighlight).length`
+- `moreLootChance` totals per tier: sum `chance` across all owned treasures where `tier` matches or is undefined (adapts to current pyramid tier).
+- `expeditionBonus` totals per tier: sum `amount` across all owned treasures for that tier.
+- Player treasure inventory uses the same `Record<string, number>` store as hieroglyph items; treasure IDs are `t1`–`t40`.
+
+## Full Effect Assignment
+
+### Starter Tomb — Forgotten Merchant's Cache
+
+| ID | Name | Effect |
+|----|------|--------|
+| t1 | Silver Deben | `mapFragmentChance: 0.1` |
+| t2 | Papyrus Scroll | `higherLootChance: 0.1` |
+| t3 | Ivory Comb | `moreLootChance` stone 20% |
+| t4 | Ceramic Oil Lamp | `expeditionBonus` stone ×1 |
+
+### Junior Tomb — Noble's Hidden Vault
+
+| ID | Name | Effect |
+|----|------|--------|
+| t5 | Golden Bracelet | `moreLootChance` stone 20% |
+| t6 | Ceremonial Dagger | `mapFragmentChance: 0.1` |
+| t7 | Jade Scarab | `higherLootChance: 0.1` |
+| t8 | Alabaster Canopic Jar | `expeditionBonus` stone ×1 |
+| t9 | Ebony Walking Stick | `moreLootChance` bronze 20% |
+| t10 | Lapis Lazuli Necklace | `expeditionBonus` bronze ×1 |
+
+### Expert Tomb — High Priest's Treasury
+
+| ID | Name | Effect |
+|----|------|--------|
+| t11 | Sacred Ankh | `errorHighlight` |
+| t12 | Copper Mirror | `earlyFeedback` |
+| t13 | Incense Burner | `mapFragmentChance: 0.1` |
+| t14 | Ritual Chalice | `moreLootChance` bronze 20% |
+| t15 | Ceremonial Fan | `expeditionBonus` bronze ×1 |
+| t16 | Prayer Beads | `moreLootChance` silver 20% |
+| t17 | Holy Water Vessel | `expeditionBonus` silver ×1 |
+| t18 | Temple Bell | `mapFragmentChance: 0.1` |
+
+### Master Tomb — Pharaoh's Secret Hoard
+
+| ID | Name | Effect |
+|----|------|--------|
+| t19 | Pharaoh's Seal | `moreLootChance` silver 20% |
+| t20 | Crystal Orb | `expeditionBonus` silver ×1 |
+| t21 | Hieroglyphic Tablet | `moreLootChance` gold 20% |
+| t22 | Golden Scepter | `expeditionBonus` gold ×1 |
+| t23 | Obsidian Knife | `errorHighlight` |
+| t24 | Meteorite Fragment | `hieroglyphUnlock` |
+| t25 | Ancient Compass | `moreLootChance` gold 20% |
+| t26 | Time Crystal | `hieroglyphUnlock` |
+| t27 | Ritual Mask | `expeditionBonus` gold ×1 |
+| t28 | Eternal Flame Torch | `earlyFeedback` |
+
+### Wizard Tomb — Vault of the Gods
+
+| ID | Name | Effect |
+|----|------|--------|
+| t29 | Crown of Ra | `moreLootChance` divine 20% |
+| t30 | Staff of Thoth | `expeditionBonus` divine ×1 |
+| t31 | Feather of Ma'at | `moreLootChance` current tier 20% |
+| t32 | Tears of Isis | `moreLootChance` current tier 20% |
+| t33 | Heart of Osiris | `moreLootChance` current tier 20% |
+| t34 | Eye of Horus Amulet | `moreLootChance` current tier 20% |
+| t35 | Serpent of Apep | `moreLootChance` current tier 20% |
+| t36 | Breath of Shu | `moreLootChance` current tier 20% |
+| t37 | Scale of Sobek | `moreLootChance` divine 20% |
+| t38 | Anubis Guardian Statue | `expeditionBonus` divine ×1 |
+| t39 | Book of the Dead | `moreLootChance` current tier 20% |
+| t40 | Pyramid Capstone | `moreLootChance` current tier 20% |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pyramid-scheme",
   "private": true,
-  "version": "0.21.0",
+  "version": "0.22.0",
   "type": "module",
   "scripts": {
     "dev": "vite --port 9164",

--- a/public/locales/en/treasures.json
+++ b/public/locales/en/treasures.json
@@ -1,4 +1,21 @@
 {
+  "effects": {
+    "mapFragmentChance": "+{{chance}}% map fragment chance",
+    "higherLootChance": "+{{chance}}% loot drop chance",
+    "moreLootChanceTier": "{{chance}}% chance of a bonus {{tier}} hieroglyph per pyramid",
+    "moreLootChanceAdaptive": "{{chance}}% chance of a bonus hieroglyph per pyramid (adapts to current difficulty)",
+    "expeditionBonus": "+{{amount}} {{tier}} hieroglyph on expedition completion",
+    "errorHighlight": "Highlights one wrong block while solving",
+    "earlyFeedback": "Shows live feedback on checkpoint blocks",
+    "hieroglyphUnlock": "Unlock one hidden block per pyramid to write your value"
+  },
+  "tiers": {
+    "stone": "Stone",
+    "bronze": "Bronze",
+    "silver": "Silver",
+    "gold": "Gold",
+    "divine": "Divine"
+  },
   "merchantCache": {
     "t1": {
       "name": "Silver Deben",

--- a/public/locales/en/treasures.json
+++ b/public/locales/en/treasures.json
@@ -1,4 +1,7 @@
 {
+  "hieroglyphUnlockPanel": {
+    "instruction": "Slide the artifact onto the stone to unlock it"
+  },
   "effects": {
     "mapFragmentChance": "+{{chance}}% map fragment chance",
     "higherLootChance": "+{{chance}}% loot drop chance",

--- a/public/locales/nl/treasures.json
+++ b/public/locales/nl/treasures.json
@@ -1,4 +1,21 @@
 {
+  "effects": {
+    "mapFragmentChance": "+{{chance}}% kans op kaartfragment",
+    "higherLootChance": "+{{chance}}% kans op buit",
+    "moreLootChanceTier": "{{chance}}% kans op een extra {{tier}} hieroglyph per piramide",
+    "moreLootChanceAdaptive": "{{chance}}% kans op een extra hieroglyph per piramide (past aan bij huidige moeilijkheid)",
+    "expeditionBonus": "+{{amount}} {{tier}} hieroglyph bij voltooiing van expeditie",
+    "errorHighlight": "Markeert één fout blok tijdens het oplossen",
+    "earlyFeedback": "Toont directe feedback op controlepunt-blokken",
+    "hieroglyphUnlock": "Ontgrendel één verborgen blok per piramide om je waarde op te schrijven"
+  },
+  "tiers": {
+    "stone": "stenen",
+    "bronze": "bronzen",
+    "silver": "zilveren",
+    "gold": "gouden",
+    "divine": "goddelijke"
+  },
   "merchantCache": {
     "t1": {
       "name": "Zilveren Deben",

--- a/public/locales/nl/treasures.json
+++ b/public/locales/nl/treasures.json
@@ -1,4 +1,7 @@
 {
+  "hieroglyphUnlockPanel": {
+    "instruction": "Schuif het artefact op de steen om het te ontgrendelen"
+  },
   "effects": {
     "mapFragmentChance": "+{{chance}}% kans op kaartfragment",
     "higherLootChance": "+{{chance}}% kans op buit",

--- a/src/app/PyramidExpedition.tsx
+++ b/src/app/PyramidExpedition.tsx
@@ -46,6 +46,9 @@ export const PyramidExpedition: FC<{
     tr => (inventory[tr.id] ?? 0) > 0 && tr.effects?.errorHighlight
   ).length
   const earlyFeedbackCount = allTreasures.filter(tr => (inventory[tr.id] ?? 0) > 0 && tr.effects?.earlyFeedback).length
+  const hieroglyphUnlockCount = allTreasures.filter(
+    tr => (inventory[tr.id] ?? 0) > 0 && tr.effects?.hieroglyphUnlock
+  ).length
   const [transitionToLevel, setTransitionToLevel] = useState(activeJourney.levelNr)
   const [levelCompleted, setLevelCompleted] = useState(false)
   const scrollContainerRef = useRef<HTMLDivElement>(null)
@@ -272,6 +275,8 @@ export const PyramidExpedition: FC<{
                   dayTime={dayTime}
                   errorHighlightCount={errorHighlightCount}
                   earlyFeedbackBlockIds={earlyFeedbackBlockIds}
+                  hieroglyphUnlockCount={hieroglyphUnlockCount}
+                  pyramidDifficulty={activeJourney.journey.difficulty}
                 />
               )}
             </div>

--- a/src/app/PyramidExpedition.tsx
+++ b/src/app/PyramidExpedition.tsx
@@ -19,6 +19,7 @@ import { DeveloperButton } from "@/ui/DeveloperButton"
 import { Header } from "@/ui/Header"
 import { allTreasures } from "@/data/treasures"
 import { useInventory } from "@/app/Inventory/useInventory"
+import { computeEarlyFeedbackBlockIds } from "@/app/PyramidLevel/earlyFeedbackLogic"
 
 const generateExpeditionLevel = (activeJourney: CombinedJourneyState, levelNr: number): PyramidLevel | null => {
   const randomSeed = generateNewSeed(activeJourney.randomSeed, levelNr)
@@ -44,6 +45,7 @@ export const PyramidExpedition: FC<{
   const errorHighlightCount = allTreasures.filter(
     tr => (inventory[tr.id] ?? 0) > 0 && tr.effects?.errorHighlight
   ).length
+  const earlyFeedbackCount = allTreasures.filter(tr => (inventory[tr.id] ?? 0) > 0 && tr.effects?.earlyFeedback).length
   const [transitionToLevel, setTransitionToLevel] = useState(activeJourney.levelNr)
   const [levelCompleted, setLevelCompleted] = useState(false)
   const scrollContainerRef = useRef<HTMLDivElement>(null)
@@ -57,6 +59,14 @@ export const PyramidExpedition: FC<{
   const nextNextLevelContent = generateExpeditionLevel(activeJourney, activeJourney.levelNr + 2)
 
   const width = levelContent ? getLevelWidth(levelContent.pyramid.floorCount) : 0
+  const earlyFeedbackBlockIds = levelContent
+    ? computeEarlyFeedbackBlockIds(
+        levelContent.pyramid,
+        activeJourney.randomSeed,
+        activeJourney.levelNr,
+        earlyFeedbackCount
+      )
+    : []
 
   const storageKey = `level-${activeJourney.journeyId}-${activeJourney.levelNr}-${activeJourney.randomSeed}`
   const { showConversation } = use(FezContext)
@@ -261,6 +271,7 @@ export const PyramidExpedition: FC<{
                   onComplete={onComplete}
                   dayTime={dayTime}
                   errorHighlightCount={errorHighlightCount}
+                  earlyFeedbackBlockIds={earlyFeedbackBlockIds}
                 />
               )}
             </div>

--- a/src/app/PyramidExpedition.tsx
+++ b/src/app/PyramidExpedition.tsx
@@ -17,6 +17,8 @@ import type { PyramidLevel } from "@/game/types"
 import { DevelopContext } from "@/contexts/DevelopMode"
 import { DeveloperButton } from "@/ui/DeveloperButton"
 import { Header } from "@/ui/Header"
+import { allTreasures } from "@/data/treasures"
+import { useInventory } from "@/app/Inventory/useInventory"
 
 const generateExpeditionLevel = (activeJourney: CombinedJourneyState, levelNr: number): PyramidLevel | null => {
   const randomSeed = generateNewSeed(activeJourney.randomSeed, levelNr)
@@ -38,6 +40,10 @@ export const PyramidExpedition: FC<{
 }> = ({ activeJourney, runNr, onLevelComplete: onNextLevel, onJourneyComplete, onClose }) => {
   const { t } = useTranslation("common")
   const { isDevelopMode } = use(DevelopContext)
+  const { inventory } = useInventory()
+  const errorHighlightCount = allTreasures.filter(
+    tr => (inventory[tr.id] ?? 0) > 0 && tr.effects?.errorHighlight
+  ).length
   const [transitionToLevel, setTransitionToLevel] = useState(activeJourney.levelNr)
   const [levelCompleted, setLevelCompleted] = useState(false)
   const scrollContainerRef = useRef<HTMLDivElement>(null)
@@ -254,6 +260,7 @@ export const PyramidExpedition: FC<{
                   decorationOffset={activeJourney.randomSeed}
                   onComplete={onComplete}
                   dayTime={dayTime}
+                  errorHighlightCount={errorHighlightCount}
                 />
               )}
             </div>

--- a/src/app/PyramidLevel/Level.tsx
+++ b/src/app/PyramidLevel/Level.tsx
@@ -12,7 +12,16 @@ export const Level: FC<{
   decorationOffset?: number
   dayTime?: DayNightCycleStep
   errorHighlightCount?: number
-}> = ({ content, storageKey, onComplete, decorationOffset = 0, dayTime, errorHighlightCount }) => {
+  earlyFeedbackBlockIds?: string[]
+}> = ({
+  content,
+  storageKey,
+  onComplete,
+  decorationOffset = 0,
+  dayTime,
+  errorHighlightCount,
+  earlyFeedbackBlockIds,
+}) => {
   const [storedAnswers, setAnswers] = useGameStorage<{
     key: string
     values: Record<string, number | undefined>
@@ -48,6 +57,7 @@ export const Level: FC<{
           values={answers}
           completed={completed}
           errorHighlightCount={errorHighlightCount}
+          earlyFeedbackBlockIds={earlyFeedbackBlockIds}
           onAnswer={
             storageKey
               ? (blockId: string, value: number | undefined) => {

--- a/src/app/PyramidLevel/Level.tsx
+++ b/src/app/PyramidLevel/Level.tsx
@@ -11,7 +11,8 @@ export const Level: FC<{
   onComplete?: () => void
   decorationOffset?: number
   dayTime?: DayNightCycleStep
-}> = ({ content, storageKey, onComplete, decorationOffset = 0, dayTime }) => {
+  errorHighlightCount?: number
+}> = ({ content, storageKey, onComplete, decorationOffset = 0, dayTime, errorHighlightCount }) => {
   const [storedAnswers, setAnswers] = useGameStorage<{
     key: string
     values: Record<string, number | undefined>
@@ -46,6 +47,7 @@ export const Level: FC<{
           decorationOffset={decorationOffset}
           values={answers}
           completed={completed}
+          errorHighlightCount={errorHighlightCount}
           onAnswer={
             storageKey
               ? (blockId: string, value: number | undefined) => {

--- a/src/app/PyramidLevel/Level.tsx
+++ b/src/app/PyramidLevel/Level.tsx
@@ -13,6 +13,8 @@ export const Level: FC<{
   dayTime?: DayNightCycleStep
   errorHighlightCount?: number
   earlyFeedbackBlockIds?: string[]
+  hieroglyphUnlockCount?: number
+  pyramidDifficulty?: import("@/data/difficultyLevels").Difficulty
 }> = ({
   content,
   storageKey,
@@ -21,6 +23,8 @@ export const Level: FC<{
   dayTime,
   errorHighlightCount,
   earlyFeedbackBlockIds,
+  hieroglyphUnlockCount,
+  pyramidDifficulty,
 }) => {
   const [storedAnswers, setAnswers] = useGameStorage<{
     key: string
@@ -58,6 +62,8 @@ export const Level: FC<{
           completed={completed}
           errorHighlightCount={errorHighlightCount}
           earlyFeedbackBlockIds={earlyFeedbackBlockIds}
+          hieroglyphUnlockCount={hieroglyphUnlockCount}
+          pyramidDifficulty={pyramidDifficulty}
           onAnswer={
             storageKey
               ? (blockId: string, value: number | undefined) => {

--- a/src/app/PyramidLevel/PyramidDisplay.tsx
+++ b/src/app/PyramidLevel/PyramidDisplay.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, type FC } from "react"
+import { useMemo, useRef, useState, type FC } from "react"
 import { usePyramidNavigation } from "@/app/PyramidLevel/usePyramidNavigation"
 import type { Pyramid } from "@/game/types"
 import { Block } from "@/ui/Block"
@@ -41,8 +41,18 @@ export const PyramidDisplay: FC<{
   values: Record<string, number | undefined>
   completed?: boolean
   dayTime?: DayNightCycleStep
+  errorHighlightCount?: number
   onAnswer?: (blockId: string, value: number | undefined) => void
-}> = ({ pyramid, values, completed = false, onAnswer, levelNr, decorationOffset = 0, dayTime = "afternoon" }) => {
+}> = ({
+  pyramid,
+  values,
+  completed = false,
+  onAnswer,
+  levelNr,
+  decorationOffset = 0,
+  dayTime = "afternoon",
+  errorHighlightCount = 0,
+}) => {
   const { blocks } = pyramid
 
   // Render the pyramid blocks
@@ -55,6 +65,7 @@ export const PyramidDisplay: FC<{
     blocks,
     onAnswer
   )
+  const [checkedBlocks, setCheckedBlocks] = useState<Set<string>>(new Set())
   const complete = !focusInput && isComplete({ levelNr: 1, pyramid, values })
   const correctAnswers = useMemo(() => getAnswers(pyramid), [pyramid])
   const decorationNumber = levelNr + decorationOffset
@@ -80,15 +91,34 @@ export const PyramidDisplay: FC<{
             {Array.from({ length: floor + 1 }, (_, index) => {
               const blockIndex = startIndex + index
               const block = blocks[blockIndex]
+              const blockValue = values[block.id]
+              const isChecked = checkedBlocks.has(block.id)
+              const blockFeedback = isChecked
+                ? blockValue === correctAnswers?.[block.id]
+                  ? "correct"
+                  : "incorrect"
+                : undefined
+
               return block.isOpen ? (
                 <InputBlock
                   key={block.id}
-                  value={values[block.id]}
+                  value={blockValue}
                   selected={selectedBlockIndex === startIndex + index && !completed}
                   disabled={complete && isCorrect}
                   shouldFocus={selectedBlockIndex === startIndex + index && focusInput}
+                  feedback={blockFeedback}
                   onSelect={() => setSelectedBlockIndex(startIndex + index)}
                   onBlur={() => {
+                    // earlyFeedback blocks will not consume a slot (handled when earlyFeedback is implemented)
+                    if (
+                      errorHighlightCount > 0 &&
+                      blockValue !== undefined &&
+                      blockValue !== correctAnswers?.[block.id] &&
+                      !isChecked &&
+                      checkedBlocks.size < errorHighlightCount
+                    ) {
+                      setCheckedBlocks(prev => new Set([...prev, block.id]))
+                    }
                     setFocusInput(false)
                     containerRef.current?.focus()
                   }}

--- a/src/app/PyramidLevel/PyramidDisplay.tsx
+++ b/src/app/PyramidLevel/PyramidDisplay.tsx
@@ -3,12 +3,15 @@ import { usePyramidNavigation } from "@/app/PyramidLevel/usePyramidNavigation"
 import type { Pyramid } from "@/game/types"
 import { Block } from "@/ui/Block"
 import { InputBlock } from "@/ui/InputBlock"
+import { HieroglyphUnlockPanel } from "@/ui/HieroglyphUnlockPanel"
 import { getAnswers, isComplete } from "@/game/state"
 import clsx from "clsx"
 import { mulberry32 } from "@/game/random"
 import { hieroglyphs } from "@/data/hieroglyphs"
 import { createFloorStartIndices } from "./support"
 import type { DayNightCycleStep } from "@/ui/backdropSelection"
+import type { Difficulty } from "@/data/difficultyLevels"
+import { allTreasures } from "@/data/treasures"
 
 const decorationEmoji = ["🐫", "🐪", "🐐", "🌴", "🪨"]
 
@@ -43,6 +46,8 @@ export const PyramidDisplay: FC<{
   dayTime?: DayNightCycleStep
   errorHighlightCount?: number
   earlyFeedbackBlockIds?: string[]
+  hieroglyphUnlockCount?: number
+  pyramidDifficulty?: Difficulty
   onAnswer?: (blockId: string, value: number | undefined) => void
 }> = ({
   pyramid,
@@ -54,6 +59,8 @@ export const PyramidDisplay: FC<{
   dayTime = "afternoon",
   errorHighlightCount = 0,
   earlyFeedbackBlockIds = [],
+  hieroglyphUnlockCount = 0,
+  pyramidDifficulty = "starter",
 }) => {
   const { blocks } = pyramid
 
@@ -68,6 +75,10 @@ export const PyramidDisplay: FC<{
     onAnswer
   )
   const [checkedBlocks, setCheckedBlocks] = useState<Set<string>>(new Set())
+  const [unlockedBlocks, setUnlockedBlocks] = useState<Set<string>>(new Set())
+  const [pendingUnlockBlockId, setPendingUnlockBlockId] = useState<string | null>(null)
+  const remainingCharges = hieroglyphUnlockCount - unlockedBlocks.size
+  const artifactId = allTreasures.find(t => t.effects?.hieroglyphUnlock)?.id ?? ""
   const complete = !focusInput && isComplete({ levelNr: 1, pyramid, values })
   const correctAnswers = useMemo(() => getAnswers(pyramid), [pyramid])
   const decorationNumber = levelNr + decorationOffset
@@ -133,10 +144,44 @@ export const PyramidDisplay: FC<{
                   }}
                   onChange={value => onAnswer?.(block.id, value)}
                 />
+              ) : block.value === undefined && unlockedBlocks.has(block.id) ? (
+                // Hieroglyph block that has been unlocked — behaves as InputBlock
+                <InputBlock
+                  key={block.id}
+                  value={blockValue}
+                  selected={selectedBlockIndex === startIndex + index && !completed}
+                  disabled={complete && isCorrect}
+                  shouldFocus={selectedBlockIndex === startIndex + index && focusInput}
+                  feedback={
+                    isChecked ? (blockValue === correctAnswers?.[block.id] ? "correct" : "incorrect") : undefined
+                  }
+                  onSelect={() => setSelectedBlockIndex(startIndex + index)}
+                  onBlur={() => {
+                    if (
+                      errorHighlightCount > 0 &&
+                      !isEarlyFeedback &&
+                      blockValue !== undefined &&
+                      blockValue !== correctAnswers?.[block.id] &&
+                      !isChecked &&
+                      checkedBlocks.size < errorHighlightCount
+                    ) {
+                      setCheckedBlocks(prev => new Set([...prev, block.id]))
+                    }
+                    setFocusInput(false)
+                    containerRef.current?.focus()
+                  }}
+                  onChange={value => onAnswer?.(block.id, value)}
+                />
               ) : (
                 <Block
                   key={block.id}
                   selected={selectedBlockIndex === startIndex + index}
+                  unlockable={block.value === undefined && remainingCharges > 0}
+                  onClick={
+                    block.value === undefined && remainingCharges > 0
+                      ? () => setPendingUnlockBlockId(block.id)
+                      : undefined
+                  }
                   className={clsx(dayTimeBlockColors[dayTime], "transition-colors duration-1000")}
                 >
                   {block.value !== undefined ? (
@@ -160,6 +205,21 @@ export const PyramidDisplay: FC<{
           </div>
         )
       })}
+      {pendingUnlockBlockId !== null && artifactId && (
+        <HieroglyphUnlockPanel
+          hieroglyphSymbol={
+            hieroglyphs[pyramid.blocks.findIndex(b => b.id === pendingUnlockBlockId) % hieroglyphs.length]
+          }
+          hieroglyphDifficulty={pyramidDifficulty}
+          artifactId={artifactId}
+          onUnlock={() => {
+            setUnlockedBlocks(prev => new Set([...prev, pendingUnlockBlockId]))
+            setPendingUnlockBlockId(null)
+          }}
+          onDismiss={() => setPendingUnlockBlockId(null)}
+        />
+      )}
+
       <div className="absolute top-full right-12 left-0 h-0 overflow-visible">
         <div
           className={clsx(

--- a/src/app/PyramidLevel/PyramidDisplay.tsx
+++ b/src/app/PyramidLevel/PyramidDisplay.tsx
@@ -80,7 +80,8 @@ export const PyramidDisplay: FC<{
   const [pendingUnlockBlockId, setPendingUnlockBlockId] = useState<string | null>(null)
   const remainingCharges = hieroglyphUnlockCount - unlockedBlocks.size
   const { inventory } = useInventory()
-  const artifactId = allTreasures.find(t => (inventory[t.id] ?? 0) > 0 && t.effects?.hieroglyphUnlock)?.id ?? ""
+  const ownedUnlockArtifacts = allTreasures.filter(t => (inventory[t.id] ?? 0) > 0 && t.effects?.hieroglyphUnlock)
+  const artifactId = (ownedUnlockArtifacts[unlockedBlocks.size] ?? ownedUnlockArtifacts[0])?.id ?? ""
   const complete = !focusInput && isComplete({ levelNr: 1, pyramid, values })
   const correctAnswers = useMemo(() => getAnswers(pyramid), [pyramid])
   const decorationNumber = levelNr + decorationOffset

--- a/src/app/PyramidLevel/PyramidDisplay.tsx
+++ b/src/app/PyramidLevel/PyramidDisplay.tsx
@@ -42,6 +42,7 @@ export const PyramidDisplay: FC<{
   completed?: boolean
   dayTime?: DayNightCycleStep
   errorHighlightCount?: number
+  earlyFeedbackBlockIds?: string[]
   onAnswer?: (blockId: string, value: number | undefined) => void
 }> = ({
   pyramid,
@@ -52,6 +53,7 @@ export const PyramidDisplay: FC<{
   decorationOffset = 0,
   dayTime = "afternoon",
   errorHighlightCount = 0,
+  earlyFeedbackBlockIds = [],
 }) => {
   const { blocks } = pyramid
 
@@ -92,12 +94,19 @@ export const PyramidDisplay: FC<{
               const blockIndex = startIndex + index
               const block = blocks[blockIndex]
               const blockValue = values[block.id]
+              const isEarlyFeedback = earlyFeedbackBlockIds.includes(block.id)
               const isChecked = checkedBlocks.has(block.id)
-              const blockFeedback = isChecked
-                ? blockValue === correctAnswers?.[block.id]
-                  ? "correct"
-                  : "incorrect"
-                : undefined
+              const blockFeedback = isEarlyFeedback
+                ? blockValue === undefined
+                  ? "pending"
+                  : blockValue === correctAnswers?.[block.id]
+                    ? "correct"
+                    : "incorrect"
+                : isChecked
+                  ? blockValue === correctAnswers?.[block.id]
+                    ? "correct"
+                    : "incorrect"
+                  : undefined
 
               return block.isOpen ? (
                 <InputBlock
@@ -109,9 +118,9 @@ export const PyramidDisplay: FC<{
                   feedback={blockFeedback}
                   onSelect={() => setSelectedBlockIndex(startIndex + index)}
                   onBlur={() => {
-                    // earlyFeedback blocks will not consume a slot (handled when earlyFeedback is implemented)
                     if (
                       errorHighlightCount > 0 &&
+                      !isEarlyFeedback &&
                       blockValue !== undefined &&
                       blockValue !== correctAnswers?.[block.id] &&
                       !isChecked &&

--- a/src/app/PyramidLevel/PyramidDisplay.tsx
+++ b/src/app/PyramidLevel/PyramidDisplay.tsx
@@ -12,6 +12,7 @@ import { createFloorStartIndices } from "./support"
 import type { DayNightCycleStep } from "@/ui/backdropSelection"
 import type { Difficulty } from "@/data/difficultyLevels"
 import { allTreasures } from "@/data/treasures"
+import { useInventory } from "@/app/Inventory/useInventory"
 
 const decorationEmoji = ["🐫", "🐪", "🐐", "🌴", "🪨"]
 
@@ -78,7 +79,8 @@ export const PyramidDisplay: FC<{
   const [unlockedBlocks, setUnlockedBlocks] = useState<Set<string>>(new Set())
   const [pendingUnlockBlockId, setPendingUnlockBlockId] = useState<string | null>(null)
   const remainingCharges = hieroglyphUnlockCount - unlockedBlocks.size
-  const artifactId = allTreasures.find(t => t.effects?.hieroglyphUnlock)?.id ?? ""
+  const { inventory } = useInventory()
+  const artifactId = allTreasures.find(t => (inventory[t.id] ?? 0) > 0 && t.effects?.hieroglyphUnlock)?.id ?? ""
   const complete = !focusInput && isComplete({ levelNr: 1, pyramid, values })
   const correctAnswers = useMemo(() => getAnswers(pyramid), [pyramid])
   const decorationNumber = levelNr + decorationOffset

--- a/src/app/PyramidLevel/PyramidDisplay.tsx
+++ b/src/app/PyramidLevel/PyramidDisplay.tsx
@@ -11,8 +11,8 @@ import { hieroglyphs } from "@/data/hieroglyphs"
 import { createFloorStartIndices } from "./support"
 import type { DayNightCycleStep } from "@/ui/backdropSelection"
 import type { Difficulty } from "@/data/difficultyLevels"
-import { allTreasures } from "@/data/treasures"
 import { useInventory } from "@/app/Inventory/useInventory"
+import { getUnlockArtifactId } from "./hieroglyphUnlockLogic"
 
 const decorationEmoji = ["🐫", "🐪", "🐐", "🌴", "🪨"]
 
@@ -80,8 +80,7 @@ export const PyramidDisplay: FC<{
   const [pendingUnlockBlockId, setPendingUnlockBlockId] = useState<string | null>(null)
   const remainingCharges = hieroglyphUnlockCount - unlockedBlocks.size
   const { inventory } = useInventory()
-  const ownedUnlockArtifacts = allTreasures.filter(t => (inventory[t.id] ?? 0) > 0 && t.effects?.hieroglyphUnlock)
-  const artifactId = (ownedUnlockArtifacts[unlockedBlocks.size] ?? ownedUnlockArtifacts[0])?.id ?? ""
+  const artifactId = getUnlockArtifactId(inventory, unlockedBlocks.size)
   const complete = !focusInput && isComplete({ levelNr: 1, pyramid, values })
   const correctAnswers = useMemo(() => getAnswers(pyramid), [pyramid])
   const decorationNumber = levelNr + decorationOffset

--- a/src/app/PyramidLevel/earlyFeedbackLogic.spec.ts
+++ b/src/app/PyramidLevel/earlyFeedbackLogic.spec.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from "vitest"
+import { computeEarlyFeedbackBlockIds } from "./earlyFeedbackLogic"
+import type { Pyramid, PyramidBlock } from "@/game/types"
+
+// Build a pyramid from a compact description.
+// Each entry: { open?: true, value?: number }
+// IDs are assigned "1".."N" matching array index + 1.
+const makePyramid = (blocks: Partial<PyramidBlock>[]): Pyramid => {
+  const floorCount = Math.round((-1 + Math.sqrt(1 + 8 * blocks.length)) / 2)
+  return {
+    floorCount,
+    blocks: blocks.map((b, i) => ({
+      id: (i + 1).toString(),
+      isOpen: b.isOpen ?? false,
+      value: b.isOpen ? undefined : b.value,
+    })),
+  }
+}
+
+// 3-floor pyramid (6 blocks): apex open, floor-1 open, floor-2 closed (given values)
+//      [1]         open
+//    [2] [3]       open
+//  [4] [5] [6]     closed: 1, 2, 3
+const make3FloorPyramid = (): Pyramid =>
+  makePyramid([{ isOpen: true }, { isOpen: true }, { isOpen: true }, { value: 1 }, { value: 2 }, { value: 3 }])
+
+// 4-floor pyramid (10 blocks): top 6 open, bottom 4 closed
+//        [1]           open  (depth 5)
+//      [2] [3]         open  (depth 3)
+//    [4] [5] [6]       open  (depth 0)
+//  [7] [8] [9][10]     closed: 1,2,3,4
+const make4FloorPyramid = (): Pyramid =>
+  makePyramid([
+    { isOpen: true },
+    { isOpen: true },
+    { isOpen: true },
+    { isOpen: true },
+    { isOpen: true },
+    { isOpen: true },
+    { value: 1 },
+    { value: 2 },
+    { value: 3 },
+    { value: 4 },
+  ])
+
+describe("computeEarlyFeedbackBlockIds", () => {
+  it("returns [] when earlyFeedbackCount is 0", () => {
+    expect(computeEarlyFeedbackBlockIds(make4FloorPyramid(), 12345, 1, 0)).toEqual([])
+  })
+
+  it("returns [] when pyramid has no open blocks", () => {
+    const pyramid = makePyramid([{ value: 3 }, { value: 1 }, { value: 2 }])
+    expect(computeEarlyFeedbackBlockIds(pyramid, 12345, 1, 1)).toEqual([])
+  })
+
+  it("returns [] when no open block reaches depth ≥ 4 (3-floor pyramid)", () => {
+    // In a 3-floor pyramid, max depth is 2 — never reaches threshold 4
+    expect(computeEarlyFeedbackBlockIds(make3FloorPyramid(), 12345, 1, 1)).toEqual([])
+  })
+
+  it("picks one block at depth ≥ 4 in a 4-floor pyramid", () => {
+    // Only block "1" (apex) reaches depth 5 in a 4-floor all-open pyramid
+    const result = computeEarlyFeedbackBlockIds(make4FloorPyramid(), 12345, 1, 1)
+    expect(result).toHaveLength(1)
+    expect(result[0]).toBe("1")
+  })
+
+  it("returns [] for second treasure when no block reaches depth ≥ 8 in a 4-floor pyramid", () => {
+    // Max depth in a 4-floor pyramid is 5 — never reaches threshold 8
+    const result = computeEarlyFeedbackBlockIds(make4FloorPyramid(), 12345, 1, 2)
+    expect(result).toHaveLength(1) // only the depth-≥4 pick; no depth-≥8 candidate
+    expect(result[0]).toBe("1")
+  })
+
+  it("is deterministic for the same seed and level", () => {
+    const r1 = computeEarlyFeedbackBlockIds(make4FloorPyramid(), 99999, 3, 1)
+    const r2 = computeEarlyFeedbackBlockIds(make4FloorPyramid(), 99999, 3, 1)
+    expect(r1).toEqual(r2)
+  })
+
+  it("produces different results for different seeds", () => {
+    // Build a bigger pyramid where multiple blocks compete at depth ≥ 4
+    // 5-floor pyramid: 15 blocks, bottom 5 closed
+    const pyramid = makePyramid([
+      { isOpen: true },
+      { isOpen: true },
+      { isOpen: true },
+      { isOpen: true },
+      { isOpen: true },
+      { isOpen: true },
+      { isOpen: true },
+      { isOpen: true },
+      { isOpen: true },
+      { isOpen: true },
+      { value: 1 },
+      { value: 2 },
+      { value: 3 },
+      { value: 4 },
+      { value: 5 },
+    ])
+    const results = new Set(
+      Array.from({ length: 10 }, (_, i) => computeEarlyFeedbackBlockIds(pyramid, (i + 1) * 1000, 1, 1)[0])
+    )
+    // With multiple candidates and different seeds, expect more than one distinct pick
+    expect(results.size).toBeGreaterThan(1)
+  })
+
+  it("never picks the same block for two different thresholds", () => {
+    // 5-floor pyramid has blocks deep enough for both threshold 4 and 8
+    const pyramid = makePyramid([
+      { isOpen: true },
+      { isOpen: true },
+      { isOpen: true },
+      { isOpen: true },
+      { isOpen: true },
+      { isOpen: true },
+      { isOpen: true },
+      { isOpen: true },
+      { isOpen: true },
+      { isOpen: true },
+      { value: 1 },
+      { value: 2 },
+      { value: 3 },
+      { value: 4 },
+      { value: 5 },
+    ])
+    const result = computeEarlyFeedbackBlockIds(pyramid, 12345, 1, 2)
+    if (result.length === 2) {
+      expect(result[0]).not.toBe(result[1])
+    }
+  })
+})

--- a/src/app/PyramidLevel/earlyFeedbackLogic.ts
+++ b/src/app/PyramidLevel/earlyFeedbackLogic.ts
@@ -1,0 +1,101 @@
+import type { Pyramid } from "@/game/types"
+import { getBlockChildIndices } from "@/game/state"
+import { generateNewSeed, mulberry32, shuffle } from "@/game/random"
+
+export const computeEarlyFeedbackBlockIds = (
+  pyramid: Pyramid,
+  randomSeed: number,
+  levelNr: number,
+  earlyFeedbackCount: number
+): string[] => {
+  if (earlyFeedbackCount === 0) return []
+
+  // Build parent map: childId → parentId
+  const parentOf: Record<string, string> = {}
+  for (const block of pyramid.blocks) {
+    for (const childIndex of getBlockChildIndices(pyramid, block.id)) {
+      parentOf[pyramid.blocks[childIndex].id] = block.id
+    }
+  }
+
+  // Seed known values from all closed blocks with a value
+  const knownValues: Record<string, number> = {}
+  for (const block of pyramid.blocks) {
+    if (!block.isOpen && block.value !== undefined) {
+      knownValues[block.id] = block.value
+    }
+  }
+
+  const openBlocks = pyramid.blocks.filter(b => b.isOpen)
+  const depth: Record<string, number> = {}
+  let solved = 0
+
+  // Wave propagation: each wave discovers newly reachable open blocks
+  let changed = true
+  while (changed) {
+    changed = false
+    const wave: string[] = []
+
+    for (const block of openBlocks) {
+      if (block.id in depth) continue
+
+      const childIndices = getBlockChildIndices(pyramid, block.id)
+      const childIds = childIndices.map(i => pyramid.blocks[i].id)
+
+      // Rule 1: both children known → sum
+      if (childIds.length === 2 && childIds.every(id => id in knownValues)) {
+        wave.push(block.id)
+        continue
+      }
+
+      // Rule 2: parent and sibling known → subtraction
+      const pid = parentOf[block.id]
+      if (pid !== undefined && pid in knownValues) {
+        const parentChildIndices = getBlockChildIndices(pyramid, pid)
+        const siblingIndex = parentChildIndices.find(i => pyramid.blocks[i].id !== block.id)
+        if (siblingIndex !== undefined && pyramid.blocks[siblingIndex].id in knownValues) {
+          wave.push(block.id)
+          continue
+        }
+      }
+    }
+
+    if (wave.length > 0) {
+      changed = true
+      for (const blockId of wave) {
+        depth[blockId] = solved
+
+        // Compute and store this block's value so subsequent waves can use it
+        const childIndices = getBlockChildIndices(pyramid, blockId)
+        const childIds = childIndices.map(i => pyramid.blocks[i].id)
+
+        if (childIds.length === 2 && childIds.every(id => id in knownValues)) {
+          knownValues[blockId] = knownValues[childIds[0]] + knownValues[childIds[1]]
+        } else {
+          const pid = parentOf[blockId]
+          const parentChildIndices = getBlockChildIndices(pyramid, pid)
+          const siblingIndex = parentChildIndices.find(i => pyramid.blocks[i].id !== blockId)!
+          knownValues[blockId] = knownValues[pid] - knownValues[pyramid.blocks[siblingIndex].id]
+        }
+      }
+      solved += wave.length
+    }
+  }
+
+  // Pick one block per threshold using a single seeded RNG sequence
+  const random = mulberry32(generateNewSeed(randomSeed, levelNr + 4000))
+  const picks: string[] = []
+
+  for (let i = 0; i < earlyFeedbackCount; i++) {
+    const threshold = (i + 1) * 4
+    const candidates = openBlocks
+      .map(b => b.id)
+      .filter(id => id in depth && depth[id] >= threshold && !picks.includes(id))
+      .sort() // stable order before shuffle so result is seed-determined
+
+    if (candidates.length === 0) continue
+    picks.push(shuffle(candidates, random)[0])
+  }
+
+  return picks
+}

--- a/src/app/PyramidLevel/expeditionBonusLogic.ts
+++ b/src/app/PyramidLevel/expeditionBonusLogic.ts
@@ -1,0 +1,33 @@
+import type { CombinedJourneyState } from "@/app/state/useJourneys"
+import type { Treasure, MaterialTier } from "@/data/treasures"
+import { difficultyByMaterialTier } from "@/data/treasures"
+import { TOMB_SYMBOLS } from "@/data/tableaus"
+import { generateNewSeed, mulberry32, shuffle } from "@/game/random"
+
+export const determineExpeditionBonus = (activeJourney: CombinedJourneyState, ownedTreasures: Treasure[]): string[] => {
+  const isLastLevel = activeJourney.levelNr >= activeJourney.journey.levelCount
+  if (!isLastLevel) return []
+
+  const bonusByTier: Partial<Record<MaterialTier, number>> = {}
+  for (const treasure of ownedTreasures) {
+    const effect = treasure.effects?.expeditionBonus
+    if (!effect) continue
+    bonusByTier[effect.tier] = (bonusByTier[effect.tier] ?? 0) + effect.amount
+  }
+
+  if (Object.keys(bonusByTier).length === 0) return []
+
+  const expSeed = generateNewSeed(activeJourney.randomSeed, activeJourney.levelNr + 3000)
+  const expRandom = mulberry32(expSeed)
+  const itemIds: string[] = []
+
+  for (const [tier, amount] of Object.entries(bonusByTier) as [MaterialTier, number][]) {
+    const tierItems = TOMB_SYMBOLS[difficultyByMaterialTier[tier]]
+    const shuffledItems = shuffle(tierItems, expRandom)
+    for (let i = 0; i < amount; i++) {
+      itemIds.push(shuffledItems[i % shuffledItems.length])
+    }
+  }
+
+  return itemIds
+}

--- a/src/app/PyramidLevel/hieroglyphUnlockLogic.spec.ts
+++ b/src/app/PyramidLevel/hieroglyphUnlockLogic.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest"
+import { getUnlockArtifactId } from "./hieroglyphUnlockLogic"
+
+// t24 = Meteorite Fragment (hieroglyphUnlock), t26 = Time Crystal (hieroglyphUnlock)
+// These are the two real artifacts in the game data with hieroglyphUnlock: true
+
+describe("getUnlockArtifactId", () => {
+  it("returns empty string when no unlock artifacts are owned", () => {
+    expect(getUnlockArtifactId({}, 0)).toBe("")
+    expect(getUnlockArtifactId({ t1: 1, t2: 1 }, 0)).toBe("")
+  })
+
+  it("returns the owned artifact when only one is owned and 0 have been used", () => {
+    expect(getUnlockArtifactId({ t24: 1 }, 0)).toBe("t24")
+    expect(getUnlockArtifactId({ t26: 1 }, 0)).toBe("t26")
+  })
+
+  it("returns t24 (first in list) for the first unlock when both are owned", () => {
+    expect(getUnlockArtifactId({ t24: 1, t26: 1 }, 0)).toBe("t24")
+  })
+
+  it("returns t26 (second in list) for the second unlock when both are owned", () => {
+    expect(getUnlockArtifactId({ t24: 1, t26: 1 }, 1)).toBe("t26")
+  })
+
+  it("falls back to first owned artifact when unlockedCount exceeds owned count", () => {
+    // Only t24 owned, but 1 already used — still shows t24
+    expect(getUnlockArtifactId({ t24: 1 }, 1)).toBe("t24")
+    // Both owned, 2 already used — falls back to t24
+    expect(getUnlockArtifactId({ t24: 1, t26: 1 }, 2)).toBe("t24")
+  })
+})

--- a/src/app/PyramidLevel/hieroglyphUnlockLogic.ts
+++ b/src/app/PyramidLevel/hieroglyphUnlockLogic.ts
@@ -1,0 +1,6 @@
+import { allTreasures } from "@/data/treasures"
+
+export const getUnlockArtifactId = (inventory: Record<string, number>, unlockedCount: number): string => {
+  const owned = allTreasures.filter(t => (inventory[t.id] ?? 0) > 0 && t.effects?.hieroglyphUnlock)
+  return (owned[unlockedCount] ?? owned[0])?.id ?? ""
+}

--- a/src/app/PyramidLevel/inventoryLootLogic.ts
+++ b/src/app/PyramidLevel/inventoryLootLogic.ts
@@ -1,10 +1,11 @@
 import { type CombinedJourneyState } from "@/app/state/useJourneys"
 import { journeys, type TreasureTombJourney } from "@/data/journeys"
-import { tableauLevels } from "@/data/tableaus"
+import { tableauLevels, TOMB_SYMBOLS } from "@/data/tableaus"
 import { generateRewardCalculation } from "@/game/generateRewardCalculation"
 import { generateNewSeed, mulberry32, shuffle } from "@/game/random"
 import { getItemFirstLevel } from "@/data/itemLevelLookup"
 import { type Difficulty, difficultyCompare } from "@/data/difficultyLevels"
+import { type Treasure, materialTierByDifficulty, difficultyByMaterialTier, type MaterialTier } from "@/data/treasures"
 
 export type InventoryLootResult = {
   shouldAwardInventoryItem: boolean
@@ -27,9 +28,37 @@ export const determineInventoryLootForCurrentRuns = (
   journeySeedGenerator: (journeyId: string) => number,
   baseInventoryChance: number = 0.4, // 40% base chance - higher since it's more targeted
   maxItemsToAward: number = 1,
-  maxPerItem: number = 3 // NEW: configurable max per item
+  maxPerItem: number = 3, // configurable max per item
+  ownedTreasures: Treasure[] = []
 ): InventoryLootResult => {
   const currentDifficulty = pyramidExpedition.journey.difficulty
+
+  // Apply higherLootChance bonus from owned treasures
+  const higherLootBonus = ownedTreasures.reduce((sum, t) => sum + (t.effects?.higherLootChance ?? 0), 0)
+  const effectiveBaseChance = baseInventoryChance + higherLootBonus
+
+  // Compute moreLootChance bonus items (grouped by resolved tier)
+  const moreLootGroups: Partial<Record<MaterialTier, number>> = {}
+  for (const t of ownedTreasures) {
+    const effect = t.effects?.moreLootChance
+    if (!effect) continue
+    const tier = effect.tier ?? materialTierByDifficulty[currentDifficulty]
+    moreLootGroups[tier] = (moreLootGroups[tier] ?? 0) + effect.chance
+  }
+
+  // Seeded roll for each tier group (offset 2000 to avoid collision with main loot seed)
+  const bonusSeed = generateNewSeed(pyramidExpedition.randomSeed, pyramidExpedition.levelNr + 2000)
+  const bonusRandom = mulberry32(bonusSeed)
+  const bonusItemIds: string[] = []
+
+  for (const [tier, totalChance] of Object.entries(moreLootGroups) as [MaterialTier, number][]) {
+    if (bonusRandom() < totalChance) {
+      const tierDifficulty = difficultyByMaterialTier[tier]
+      const tierItems = TOMB_SYMBOLS[tierDifficulty]
+      const shuffledTierItems = shuffle(tierItems, bonusRandom)
+      bonusItemIds.push(shuffledTierItems[0])
+    }
+  }
 
   const tombIds = journeys
     .filter(j => j.type === "treasure_tomb" && difficultyCompare(j.difficulty, maxDifficulty) <= 0)
@@ -146,9 +175,9 @@ export const determineInventoryLootForCurrentRuns = (
 
     if (filteredInterestingItems.length === 0) {
       return {
-        shouldAwardInventoryItem: false,
-        itemIds: [],
-        baseChance: baseInventoryChance,
+        shouldAwardInventoryItem: bonusItemIds.length > 0,
+        itemIds: bonusItemIds,
+        baseChance: effectiveBaseChance,
         adjustedChance: 0,
         needMultiplier: 0,
         itemsWithCounts: {},
@@ -188,15 +217,19 @@ export const determineInventoryLootForCurrentRuns = (
 
   // Calculate adjusted chance based on average urgency
   const needMultiplier = Math.max(Math.min(3, avgUrgency / 5), 1) // Cap at 3x multiplier
-  const adjustedChance = Math.min(Math.max(0.8, baseInventoryChance), baseInventoryChance * needMultiplier) // Cap at 80% by default, but can be higher for high base chance
+  const adjustedChance = Math.min(Math.max(0.8, effectiveBaseChance), effectiveBaseChance * needMultiplier) // Cap at 80% by default, but can be higher for high base chance
 
   // Generate deterministic random number based on journey state
   const shouldAward = random() < adjustedChance
 
+  const mainItemIds = shouldAward
+    ? Object.entries(itemsToAward).flatMap(([itemId, count]) => Array(count).fill(itemId))
+    : []
+
   return {
-    shouldAwardInventoryItem: shouldAward,
-    itemIds: shouldAward ? Object.entries(itemsToAward).flatMap(([itemId, count]) => Array(count).fill(itemId)) : [],
-    baseChance: baseInventoryChance,
+    shouldAwardInventoryItem: shouldAward || bonusItemIds.length > 0,
+    itemIds: [...mainItemIds, ...bonusItemIds],
+    baseChance: effectiveBaseChance,
     adjustedChance,
     needMultiplier,
     itemsWithCounts: shouldAward ? itemsToAward : {},

--- a/src/app/PyramidLevel/lootEffects.spec.ts
+++ b/src/app/PyramidLevel/lootEffects.spec.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from "vitest"
 import { determineInventoryLootForCurrentRuns } from "./inventoryLootLogic"
+import { determineExpeditionBonus } from "./expeditionBonusLogic"
+import { TOMB_SYMBOLS } from "@/data/tableaus"
 import type { CombinedJourneyState } from "@/app/state/useJourneys"
 import type { Treasure } from "@/data/treasures"
 
@@ -153,6 +155,68 @@ describe("moreLootChance treasure effects", () => {
     const result2 = determineInventoryLootForCurrentRuns(...args)
     expect(result1.itemIds).toEqual(result2.itemIds)
     expect(result1.shouldAwardInventoryItem).toBe(result2.shouldAwardInventoryItem)
+  })
+})
+
+describe("expeditionBonus treasure effects", () => {
+  const lastLevelJourney = makeJourney(3) // levelNr 3 = levelCount 3 → last level
+
+  it("not on last level → no bonus items", () => {
+    const treasure = makeTreasure("t_test", { expeditionBonus: { amount: 1, tier: "stone" } })
+    expect(determineExpeditionBonus(makeJourney(1), [treasure])).toHaveLength(0)
+    expect(determineExpeditionBonus(makeJourney(2), [treasure])).toHaveLength(0)
+  })
+
+  it("last level, no treasures with expeditionBonus → no bonus items", () => {
+    const treasure = makeTreasure("t_test", { moreLootChance: { chance: 1.0 } })
+    expect(determineExpeditionBonus(lastLevelJourney, [treasure])).toHaveLength(0)
+    expect(determineExpeditionBonus(lastLevelJourney, [])).toHaveLength(0)
+  })
+
+  it("last level with one expedition bonus treasure awards one item", () => {
+    const treasure = makeTreasure("t_test", { expeditionBonus: { amount: 1, tier: "stone" } })
+    const items = determineExpeditionBonus(lastLevelJourney, [treasure])
+    expect(items).toHaveLength(1)
+    expect(TOMB_SYMBOLS["starter"]).toContain(items[0])
+  })
+
+  it("two treasures with same tier stack — awards two items of that tier", () => {
+    const treasures = [
+      makeTreasure("t1", { expeditionBonus: { amount: 1, tier: "stone" } }),
+      makeTreasure("t2", { expeditionBonus: { amount: 1, tier: "stone" } }),
+    ]
+    const items = determineExpeditionBonus(lastLevelJourney, treasures)
+    expect(items).toHaveLength(2)
+    items.forEach(id => expect(TOMB_SYMBOLS["starter"]).toContain(id))
+  })
+
+  it("two treasures with different tiers each award one item of their own tier", () => {
+    const treasures = [
+      makeTreasure("t1", { expeditionBonus: { amount: 1, tier: "stone" } }),
+      makeTreasure("t2", { expeditionBonus: { amount: 1, tier: "bronze" } }),
+    ]
+    const items = determineExpeditionBonus(lastLevelJourney, treasures)
+    expect(items).toHaveLength(2)
+    const stoneItems = items.filter(id => TOMB_SYMBOLS["starter"].includes(id))
+    const bronzeItems = items.filter(id => TOMB_SYMBOLS["junior"].includes(id))
+    expect(stoneItems).toHaveLength(1)
+    expect(bronzeItems).toHaveLength(1)
+  })
+
+  it("result is deterministic for the same seed and level", () => {
+    const treasure = makeTreasure("t_test", { expeditionBonus: { amount: 1, tier: "stone" } })
+    const result1 = determineExpeditionBonus(lastLevelJourney, [treasure])
+    const result2 = determineExpeditionBonus(lastLevelJourney, [treasure])
+    expect(result1).toEqual(result2)
+  })
+
+  it("different seeds produce independent results", () => {
+    const treasure = makeTreasure("t_test", { expeditionBonus: { amount: 1, tier: "stone" } })
+    const results = new Set(
+      Array.from({ length: 10 }, (_, i) => determineExpeditionBonus(makeJourney(3, i * 1000 + 1), [treasure])[0])
+    )
+    // With 7 possible stone items and 10 different seeds, expect more than one distinct item
+    expect(results.size).toBeGreaterThan(1)
   })
 })
 

--- a/src/app/PyramidLevel/lootEffects.spec.ts
+++ b/src/app/PyramidLevel/lootEffects.spec.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from "vitest"
+import { determineInventoryLootForCurrentRuns } from "./inventoryLootLogic"
+import type { CombinedJourneyState } from "@/app/state/useJourneys"
+import type { Treasure } from "@/data/treasures"
+
+const makeJourney = (levelNr = 1, seed = 12345): CombinedJourneyState =>
+  ({
+    journeyId: "starter_pyramid_1",
+    levelNr,
+    completionCount: 0,
+    foundMapPiece: false,
+    inProgress: true,
+    active: true,
+    randomSeed: seed,
+    progressPercentage: 0,
+    journey: {
+      id: "starter_pyramid_1",
+      type: "pyramid",
+      difficulty: "starter",
+      levelCount: 3,
+    },
+  }) as unknown as CombinedJourneyState
+
+const makeTreasure = (id: string, effects: Treasure["effects"]): Treasure => ({
+  id,
+  name: "Test Treasure",
+  symbol: "𓀀",
+  description: "test",
+  effects,
+})
+
+describe("moreLootChance treasure effects", () => {
+  it("no owned treasures → no bonus loot from moreLootChance", () => {
+    // base chance 0 so only moreLootChance could produce items
+    const result = determineInventoryLootForCurrentRuns(
+      makeJourney(),
+      "starter",
+      {},
+      () => undefined,
+      () => 0,
+      0,
+      1,
+      3,
+      []
+    )
+    expect(result.shouldAwardInventoryItem).toBe(false)
+    expect(result.itemIds).toHaveLength(0)
+  })
+
+  it("100% moreLootChance always awards a bonus item", () => {
+    const treasure = makeTreasure("t_test", { moreLootChance: { chance: 1.0, tier: "stone" } })
+    const result = determineInventoryLootForCurrentRuns(
+      makeJourney(),
+      "starter",
+      {},
+      () => undefined,
+      () => 0,
+      0, // base chance 0 so only bonus items
+      1,
+      3,
+      [treasure]
+    )
+    expect(result.shouldAwardInventoryItem).toBe(true)
+    expect(result.itemIds.length).toBeGreaterThan(0)
+  })
+
+  it("0% moreLootChance never awards a bonus item", () => {
+    const treasure = makeTreasure("t_test", { moreLootChance: { chance: 0.0, tier: "stone" } })
+    const result = determineInventoryLootForCurrentRuns(
+      makeJourney(),
+      "starter",
+      {},
+      () => undefined,
+      () => 0,
+      0,
+      1,
+      3,
+      [treasure]
+    )
+    expect(result.shouldAwardInventoryItem).toBe(false)
+    expect(result.itemIds).toHaveLength(0)
+  })
+
+  it("two 50% same-tier treasures stack to 100% and always award a bonus item", () => {
+    const treasures = [
+      makeTreasure("t1", { moreLootChance: { chance: 0.5, tier: "stone" } }),
+      makeTreasure("t2", { moreLootChance: { chance: 0.5, tier: "stone" } }),
+    ]
+    const result = determineInventoryLootForCurrentRuns(
+      makeJourney(),
+      "starter",
+      {},
+      () => undefined,
+      () => 0,
+      0,
+      1,
+      3,
+      treasures
+    )
+    expect(result.shouldAwardInventoryItem).toBe(true)
+    expect(result.itemIds.length).toBeGreaterThan(0)
+  })
+
+  it("tier-specific treasure awards item from that tier regardless of current pyramid difficulty", () => {
+    // Bronze-tier treasure played on a starter (stone) pyramid
+    const treasure = makeTreasure("t_test", { moreLootChance: { chance: 1.0, tier: "bronze" } })
+    const result = determineInventoryLootForCurrentRuns(
+      makeJourney(),
+      "starter",
+      {},
+      () => undefined,
+      () => 0,
+      0,
+      1,
+      3,
+      [treasure]
+    )
+    expect(result.shouldAwardInventoryItem).toBe(true)
+    expect(result.itemIds.length).toBeGreaterThan(0)
+  })
+
+  it("tier-less moreLootChance resolves to current pyramid difficulty tier", () => {
+    const treasure = makeTreasure("t_test", { moreLootChance: { chance: 1.0 } }) // no tier = adapts
+    const result = determineInventoryLootForCurrentRuns(
+      makeJourney(),
+      "starter",
+      {},
+      () => undefined,
+      () => 0,
+      0,
+      1,
+      3,
+      [treasure]
+    )
+    expect(result.shouldAwardInventoryItem).toBe(true)
+    expect(result.itemIds.length).toBeGreaterThan(0)
+  })
+
+  it("result is deterministic for the same seed and level", () => {
+    const treasure = makeTreasure("t_test", { moreLootChance: { chance: 0.5, tier: "stone" } })
+    const args: Parameters<typeof determineInventoryLootForCurrentRuns> = [
+      makeJourney(1, 99999),
+      "starter",
+      {},
+      () => undefined,
+      () => 0,
+      0,
+      1,
+      3,
+      [treasure],
+    ]
+    const result1 = determineInventoryLootForCurrentRuns(...args)
+    const result2 = determineInventoryLootForCurrentRuns(...args)
+    expect(result1.itemIds).toEqual(result2.itemIds)
+    expect(result1.shouldAwardInventoryItem).toBe(result2.shouldAwardInventoryItem)
+  })
+})
+
+describe("higherLootChance treasure effects", () => {
+  it("higherLootChance adds to base inventory chance", () => {
+    const treasure = makeTreasure("t_test", { higherLootChance: 0.1 })
+    const result = determineInventoryLootForCurrentRuns(
+      makeJourney(),
+      "starter",
+      {},
+      () => undefined,
+      () => 0,
+      0.4,
+      1,
+      3,
+      [treasure]
+    )
+    // effectiveBaseChance should be 0.5 (0.4 + 0.1)
+    expect(result.baseChance).toBeCloseTo(0.5)
+  })
+
+  it("multiple higherLootChance treasures stack additively", () => {
+    const treasures = [makeTreasure("t1", { higherLootChance: 0.1 }), makeTreasure("t2", { higherLootChance: 0.1 })]
+    const result = determineInventoryLootForCurrentRuns(
+      makeJourney(),
+      "starter",
+      {},
+      () => undefined,
+      () => 0,
+      0.4,
+      1,
+      3,
+      treasures
+    )
+    expect(result.baseChance).toBeCloseTo(0.6)
+  })
+})

--- a/src/app/PyramidLevel/mapPieceLogic.ts
+++ b/src/app/PyramidLevel/mapPieceLogic.ts
@@ -16,7 +16,8 @@ const getMapPieceChance = (journey: Journey, journeyCount: number): number => {
 
 export const determineMapPieceLoot = (
   activeJourney: CombinedJourneyState,
-  getJourney: (journeyId: string) => CombinedJourneyState | undefined
+  getJourney: (journeyId: string) => CombinedJourneyState | undefined,
+  bonusMapFragmentChance: number = 0
 ): MapPieceResult => {
   const journeyInfo = getJourney(activeJourney.journeyId)
   const journeyCount = journeyInfo?.completionCount || 0
@@ -27,7 +28,7 @@ export const determineMapPieceLoot = (
 
   const journey = activeJourney.journey
 
-  const mapPieceChance = foundMapPiece ? 0 : getMapPieceChance(journey, journeyCount)
+  const mapPieceChance = foundMapPiece ? 0 : getMapPieceChance(journey, journeyCount) + bonusMapFragmentChance
 
   const shouldAwardMapPiece = random() < mapPieceChance
 

--- a/src/app/PyramidLevel/useLootDetermination.tsx
+++ b/src/app/PyramidLevel/useLootDetermination.tsx
@@ -3,13 +3,12 @@ import { useMemo } from "react"
 import { useTranslation } from "react-i18next"
 import { determineMapPieceLoot } from "./mapPieceLogic"
 import { determineInventoryLootForCurrentRuns } from "./inventoryLootLogic"
+import { determineExpeditionBonus } from "./expeditionBonusLogic"
 import { useInventory } from "@/app/Inventory/useInventory"
 import { useInventoryItem } from "@/data/useInventoryTranslations"
 import { HieroglyphTile } from "@/ui/HieroglyphTile"
 import { getItemFirstLevel } from "@/data/itemLevelLookup"
-import { allTreasures, difficultyByMaterialTier, type MaterialTier } from "@/data/treasures"
-import { TOMB_SYMBOLS } from "@/data/tableaus"
-import { generateNewSeed, mulberry32, shuffle } from "@/game/random"
+import { allTreasures } from "@/data/treasures"
 
 export type Loot = {
   itemId: string
@@ -19,6 +18,36 @@ export type Loot = {
   rarity?: "common" | "rare" | "epic" | "legendary"
 }
 
+const toItemCounts = (itemIds: string[]): Record<string, number> =>
+  itemIds.reduce(
+    (acc, id) => {
+      acc[id] = (acc[id] || 0) + 1
+      return acc
+    },
+    {} as Record<string, number>
+  )
+
+const makeInventoryLoot = (
+  itemIds: string[],
+  rarity: Loot["rarity"],
+  getItem: (id: string) => { name: string; description: string; symbol: string } | null,
+  addItems: (items: Record<string, number>) => void
+): { loot: Loot; collectLoot: () => void } | null => {
+  const firstId = itemIds[0]
+  const item = getItem(firstId)
+  if (!item) return null
+  return {
+    loot: {
+      itemId: firstId,
+      itemName: item.name,
+      itemDescription: item.description,
+      itemComponent: <HieroglyphTile symbol={item.symbol} difficulty={getItemFirstLevel(firstId)} size="md" />,
+      rarity,
+    },
+    collectLoot: () => addItems(toItemCounts(itemIds)),
+  }
+}
+
 export const useLootDetermination = (
   activeJourney: CombinedJourneyState
 ): { loot: Loot | null; collectLoot: () => void } => {
@@ -26,10 +55,9 @@ export const useLootDetermination = (
   const { inventory, addItems } = useInventory()
   const { t } = useTranslation("treasures")
 
-  const ownedTreasures = allTreasures.filter(t => (inventory[t.id] ?? 0) > 0)
-  const bonusMapFragmentChance = ownedTreasures.reduce((sum, t) => sum + (t.effects?.mapFragmentChance ?? 0), 0)
+  const ownedTreasures = allTreasures.filter(tr => (inventory[tr.id] ?? 0) > 0)
+  const bonusMapFragmentChance = ownedTreasures.reduce((sum, tr) => sum + (tr.effects?.mapFragmentChance ?? 0), 0)
 
-  // Pre-calculate loot determination outside of useMemo
   const mapPieceResult = determineMapPieceLoot(activeJourney, getJourney, bonusMapFragmentChance)
   const inventoryResult = determineInventoryLootForCurrentRuns(
     activeJourney,
@@ -42,125 +70,43 @@ export const useLootDetermination = (
     3,
     ownedTreasures
   )
+  const expeditionItemIds = determineExpeditionBonus(activeJourney, ownedTreasures)
 
   const inventoryItemHook = useInventoryItem()
 
-  const isLastLevel = activeJourney.levelNr >= activeJourney.journey.levelCount
-
-  return useMemo((): {
-    loot: Loot | null
-    collectLoot: () => void
-  } => {
-    // First, check for map piece loot
+  return useMemo((): { loot: Loot | null; collectLoot: () => void } => {
     if (mapPieceResult.shouldAwardMapPiece) {
-      const journey = activeJourney.journey
       return {
         loot: {
           itemId: "mapPiece",
           itemName: t("mapPieces.name"),
-          itemDescription: t(`mapPieces.descriptions.${journey.difficulty}`),
+          itemDescription: t(`mapPieces.descriptions.${activeJourney.journey.difficulty}`),
           itemComponent: "📜",
           rarity: "rare",
         },
-        collectLoot: () => {
-          findMapPiece()
-        },
+        collectLoot: findMapPiece,
       }
     }
 
-    // If no map piece, check for inventory items (includes moreLootChance bonus items)
-    const firstItemId = inventoryResult.itemIds[0]
-    const inventoryItem = inventoryItemHook(firstItemId)
-    if (inventoryResult.shouldAwardInventoryItem && inventoryResult.itemIds.length > 0 && inventoryItem) {
-      const itemDifficulty = getItemFirstLevel(firstItemId)
-
-      return {
-        loot: {
-          itemId: firstItemId,
-          itemName: inventoryItem?.name,
-          itemDescription: inventoryItem?.description,
-          itemComponent: <HieroglyphTile symbol={inventoryItem?.symbol} difficulty={itemDifficulty} size="md" />,
-          rarity: "common",
-        },
-        collectLoot: () => {
-          // Award all items from the result in a single batch operation
-          if (inventoryResult.itemIds.length > 0) {
-            const itemsToAdd = inventoryResult.itemIds.reduce(
-              (acc, itemId) => {
-                acc[itemId] = (acc[itemId] || 0) + 1
-                return acc
-              },
-              {} as Record<string, number>
-            )
-            addItems(itemsToAdd)
-          }
-        },
-      }
+    if (inventoryResult.shouldAwardInventoryItem && inventoryResult.itemIds.length > 0) {
+      const result = makeInventoryLoot(inventoryResult.itemIds, "common", inventoryItemHook, addItems)
+      if (result) return result
     }
 
-    // Check for expedition bonus (guaranteed items on last level of expedition)
-    if (isLastLevel) {
-      const bonusByTier: Partial<Record<MaterialTier, number>> = {}
-      for (const treasure of ownedTreasures) {
-        const effect = treasure.effects?.expeditionBonus
-        if (!effect) continue
-        bonusByTier[effect.tier] = (bonusByTier[effect.tier] ?? 0) + effect.amount
-      }
-
-      const expeditionBonusItemIds: string[] = []
-      if (Object.keys(bonusByTier).length > 0) {
-        const expSeed = generateNewSeed(activeJourney.randomSeed, activeJourney.levelNr + 3000)
-        const expRandom = mulberry32(expSeed)
-        for (const [tier, amount] of Object.entries(bonusByTier) as [MaterialTier, number][]) {
-          const tierDifficulty = difficultyByMaterialTier[tier]
-          const tierItems = TOMB_SYMBOLS[tierDifficulty]
-          const shuffledItems = shuffle(tierItems, expRandom)
-          for (let i = 0; i < amount; i++) {
-            expeditionBonusItemIds.push(shuffledItems[i % shuffledItems.length])
-          }
-        }
-      }
-
-      if (expeditionBonusItemIds.length > 0) {
-        const firstBonusId = expeditionBonusItemIds[0]
-        const bonusItem = inventoryItemHook(firstBonusId)
-        if (bonusItem) {
-          const itemDifficulty = getItemFirstLevel(firstBonusId)
-          return {
-            loot: {
-              itemId: firstBonusId,
-              itemName: bonusItem.name,
-              itemDescription: bonusItem.description,
-              itemComponent: <HieroglyphTile symbol={bonusItem.symbol} difficulty={itemDifficulty} size="md" />,
-              rarity: "epic",
-            },
-            collectLoot: () => {
-              const itemsToAdd = expeditionBonusItemIds.reduce(
-                (acc, id) => {
-                  acc[id] = (acc[id] || 0) + 1
-                  return acc
-                },
-                {} as Record<string, number>
-              )
-              addItems(itemsToAdd)
-            },
-          }
-        }
-      }
+    if (expeditionItemIds.length > 0) {
+      const result = makeInventoryLoot(expeditionItemIds, "epic", inventoryItemHook, addItems)
+      if (result) return result
     }
 
     return { loot: null, collectLoot: () => {} }
   }, [
     mapPieceResult,
     inventoryResult,
+    expeditionItemIds,
     inventoryItemHook,
     activeJourney.journey,
-    activeJourney.randomSeed,
-    activeJourney.levelNr,
     t,
     findMapPiece,
     addItems,
-    isLastLevel,
-    ownedTreasures,
   ])
 }

--- a/src/app/PyramidLevel/useLootDetermination.tsx
+++ b/src/app/PyramidLevel/useLootDetermination.tsx
@@ -7,6 +7,9 @@ import { useInventory } from "@/app/Inventory/useInventory"
 import { useInventoryItem } from "@/data/useInventoryTranslations"
 import { HieroglyphTile } from "@/ui/HieroglyphTile"
 import { getItemFirstLevel } from "@/data/itemLevelLookup"
+import { allTreasures, difficultyByMaterialTier, type MaterialTier } from "@/data/treasures"
+import { TOMB_SYMBOLS } from "@/data/tableaus"
+import { generateNewSeed, mulberry32, shuffle } from "@/game/random"
 
 export type Loot = {
   itemId: string
@@ -23,17 +26,26 @@ export const useLootDetermination = (
   const { inventory, addItems } = useInventory()
   const { t } = useTranslation("treasures")
 
+  const ownedTreasures = allTreasures.filter(t => (inventory[t.id] ?? 0) > 0)
+  const bonusMapFragmentChance = ownedTreasures.reduce((sum, t) => sum + (t.effects?.mapFragmentChance ?? 0), 0)
+
   // Pre-calculate loot determination outside of useMemo
-  const mapPieceResult = determineMapPieceLoot(activeJourney, getJourney)
+  const mapPieceResult = determineMapPieceLoot(activeJourney, getJourney, bonusMapFragmentChance)
   const inventoryResult = determineInventoryLootForCurrentRuns(
     activeJourney,
     maxDifficulty,
     inventory,
     getJourney,
-    nextJourneySeed
+    nextJourneySeed,
+    0.4,
+    1,
+    3,
+    ownedTreasures
   )
 
   const inventoryItemHook = useInventoryItem()
+
+  const isLastLevel = activeJourney.levelNr >= activeJourney.journey.levelCount
 
   return useMemo((): {
     loot: Loot | null
@@ -56,7 +68,7 @@ export const useLootDetermination = (
       }
     }
 
-    // If no map piece, check for inventory items
+    // If no map piece, check for inventory items (includes moreLootChance bonus items)
     const firstItemId = inventoryResult.itemIds[0]
     const inventoryItem = inventoryItemHook(firstItemId)
     if (inventoryResult.shouldAwardInventoryItem && inventoryResult.itemIds.length > 0 && inventoryItem) {
@@ -86,6 +98,69 @@ export const useLootDetermination = (
       }
     }
 
+    // Check for expedition bonus (guaranteed items on last level of expedition)
+    if (isLastLevel) {
+      const bonusByTier: Partial<Record<MaterialTier, number>> = {}
+      for (const treasure of ownedTreasures) {
+        const effect = treasure.effects?.expeditionBonus
+        if (!effect) continue
+        bonusByTier[effect.tier] = (bonusByTier[effect.tier] ?? 0) + effect.amount
+      }
+
+      const expeditionBonusItemIds: string[] = []
+      if (Object.keys(bonusByTier).length > 0) {
+        const expSeed = generateNewSeed(activeJourney.randomSeed, activeJourney.levelNr + 3000)
+        const expRandom = mulberry32(expSeed)
+        for (const [tier, amount] of Object.entries(bonusByTier) as [MaterialTier, number][]) {
+          const tierDifficulty = difficultyByMaterialTier[tier]
+          const tierItems = TOMB_SYMBOLS[tierDifficulty]
+          const shuffledItems = shuffle(tierItems, expRandom)
+          for (let i = 0; i < amount; i++) {
+            expeditionBonusItemIds.push(shuffledItems[i % shuffledItems.length])
+          }
+        }
+      }
+
+      if (expeditionBonusItemIds.length > 0) {
+        const firstBonusId = expeditionBonusItemIds[0]
+        const bonusItem = inventoryItemHook(firstBonusId)
+        if (bonusItem) {
+          const itemDifficulty = getItemFirstLevel(firstBonusId)
+          return {
+            loot: {
+              itemId: firstBonusId,
+              itemName: bonusItem.name,
+              itemDescription: bonusItem.description,
+              itemComponent: <HieroglyphTile symbol={bonusItem.symbol} difficulty={itemDifficulty} size="md" />,
+              rarity: "epic",
+            },
+            collectLoot: () => {
+              const itemsToAdd = expeditionBonusItemIds.reduce(
+                (acc, id) => {
+                  acc[id] = (acc[id] || 0) + 1
+                  return acc
+                },
+                {} as Record<string, number>
+              )
+              addItems(itemsToAdd)
+            },
+          }
+        }
+      }
+    }
+
     return { loot: null, collectLoot: () => {} }
-  }, [mapPieceResult, inventoryResult, inventoryItemHook, activeJourney.journey, t, findMapPiece, addItems])
+  }, [
+    mapPieceResult,
+    inventoryResult,
+    inventoryItemHook,
+    activeJourney.journey,
+    activeJourney.randomSeed,
+    activeJourney.levelNr,
+    t,
+    findMapPiece,
+    addItems,
+    isLastLevel,
+    ownedTreasures,
+  ])
 }

--- a/src/app/pages/Collection.tsx
+++ b/src/app/pages/Collection.tsx
@@ -24,6 +24,7 @@ type InventoryItem = {
   symbol: string
   name: string
   description: string
+  effectDescription?: string
 }
 
 // Map treasure categories to their corresponding difficulty levels
@@ -152,6 +153,9 @@ const DetailPanel: FC<{
                 </p>
               )}
               <p className="leading-relaxed text-gray-700">{item.description}</p>
+              {item.effectDescription && (
+                <p className="mt-1 font-serif text-sm text-amber-700 italic">{item.effectDescription}</p>
+              )}
               {debug && (
                 <div>
                   <DeveloperButton onClick={onAdd} label="Add Item" />

--- a/src/data/treasures.ts
+++ b/src/data/treasures.ts
@@ -3,21 +3,84 @@
 
 import type { Difficulty } from "./difficultyLevels"
 
+/**
+ * Material tier of inventory items, mapped to difficulty levels:
+ * stone=starter, bronze=junior, silver=expert, gold=master, divine=wizard
+ */
+export type MaterialTier = "stone" | "bronze" | "silver" | "gold" | "divine"
+
+export const materialTierByDifficulty: Record<Difficulty, MaterialTier> = {
+  starter: "stone",
+  junior: "bronze",
+  expert: "silver",
+  master: "gold",
+  wizard: "divine",
+}
+
+export const difficultyByMaterialTier: Record<MaterialTier, Difficulty> = {
+  stone: "starter",
+  bronze: "junior",
+  silver: "expert",
+  gold: "master",
+  divine: "wizard",
+}
+
+export type TreasureEffects = {
+  /**
+   * Additive bonus added to the base map fragment drop probability per pyramid level completed.
+   * E.g. 0.1 adds a 10% chance on top of the base chance.
+   * Stacks additively across multiple treasures.
+   */
+  mapFragmentChance?: number
+  /**
+   * Additive bonus added to the base probability that any inventory loot drops per pyramid level completed.
+   * E.g. 0.1 adds a 10% chance on top of the base drop chance.
+   * Stacks additively across multiple treasures.
+   */
+  higherLootChance?: number
+  /**
+   * Count the number of owned treasures with this effect to determine how many miscalculated blocks
+   * are highlighted in real-time while solving a pyramid puzzle.
+   * E.g. owning 2 treasures with errorHighlight highlights the first 2 wrong blocks.
+   */
+  errorHighlight?: boolean
+  /**
+   * Count the number of owned treasures with this effect to determine how many checkpoint blocks
+   * in the pyramid display a magical border with live correct/incorrect feedback.
+   * E.g. owning 2 treasures with earlyFeedback activates more checkpoint blocks.
+   */
+  earlyFeedback?: boolean
+  /**
+   * Per pyramid level completed, rolls a seeded chance to drop one extra inventory item.
+   * If tier is specified, the bonus item is from that material tier.
+   * If tier is omitted, the bonus item matches the current pyramid's difficulty tier.
+   * Multiple treasures with this effect stack additively on the chance.
+   * E.g. { chance: 0.2, tier: "stone" } = 20% chance of an extra Stone item per level.
+   * E.g. { chance: 0.2 } = 20% chance of an extra item matching the current pyramid tier.
+   */
+  moreLootChance?: { chance: number; tier?: MaterialTier }
+  /**
+   * At the end of a completed pyramid expedition, awards a guaranteed number of inventory items
+   * of the specified material tier.
+   * Stacks additively — owning two treasures with the same tier doubles the bonus.
+   * E.g. { amount: 1, tier: "gold" } = 1 extra Gold item on expedition completion.
+   */
+  expeditionBonus?: { amount: number; tier: MaterialTier }
+  /**
+   * Count the number of owned treasures with this effect to determine how many hidden hieroglyph
+   * blocks the player may unlock per pyramid level. Unlocking a block lets the player write in
+   * their calculated value, removing the need to hold it in memory.
+   * E.g. owning 2 treasures with hieroglyphUnlock allows writing down 2 hidden block values per level.
+   */
+  hieroglyphUnlock?: boolean
+}
+
 export type Treasure = {
   id: string
   name: string
   symbol: string
   description: string
-  effects?: {
-    language?: number
-    dailyReward?: number
-    dailyRewardLevel?: number
-    mapFragmentChance?: number
-    higherLootChance?: number
-    errorHighlight?: number
-    earlyFeedback?: number
-    moreLootChance?: number
-  }
+  effects?: TreasureEffects
 }
 
 export const merchantCacheTreasures: Treasure[] = [
@@ -26,24 +89,28 @@ export const merchantCacheTreasures: Treasure[] = [
     name: "Silver Deben",
     symbol: "𓈖",
     description: "An ancient Egyptian silver coin used by merchants for trade along the Nile.",
+    effects: { mapFragmentChance: 0.1 },
   },
   {
     id: "t2",
     name: "Papyrus Scroll",
     symbol: "𓅱",
     description: "A merchant's record scroll detailing trade routes and precious cargo manifests.",
+    effects: { higherLootChance: 0.1 },
   },
   {
     id: "t3",
     name: "Ivory Comb",
     symbol: "𓌴",
     description: "An intricately carved ivory comb, a luxury item traded from distant lands.",
+    effects: { moreLootChance: { chance: 0.2, tier: "stone" } },
   },
   {
     id: "t4",
     name: "Ceramic Oil Lamp",
     symbol: "𓈗",
     description: "A simple yet elegant oil lamp used to light the merchant's quarters.",
+    effects: { expeditionBonus: { amount: 1, tier: "stone" } },
   },
 ]
 
@@ -53,36 +120,42 @@ export const nobleVaultTreasures: Treasure[] = [
     name: "Golden Bracelet",
     symbol: "𓈾",
     description: "An ornate golden bracelet adorned with precious stones, worn by Egyptian nobility.",
+    effects: { moreLootChance: { chance: 0.2, tier: "stone" } },
   },
   {
     id: "t6",
     name: "Ceremonial Dagger",
     symbol: "𓌑",
     description: "A ritual dagger with a jeweled handle, used in noble ceremonies.",
+    effects: { mapFragmentChance: 0.1 },
   },
   {
     id: "t7",
     name: "Jade Scarab",
     symbol: "𓆣",
     description: "A protective jade scarab amulet, symbol of rebirth and eternal life.",
+    effects: { higherLootChance: 0.1 },
   },
   {
     id: "t8",
     name: "Alabaster Canopic Jar",
     symbol: "𓎯",
     description: "An elegant alabaster jar used to store precious oils and perfumes.",
+    effects: { expeditionBonus: { amount: 1, tier: "stone" } },
   },
   {
     id: "t9",
     name: "Ebony Walking Stick",
     symbol: "𓋴",
     description: "A polished ebony walking stick topped with a golden ankh symbol.",
+    effects: { moreLootChance: { chance: 0.2, tier: "bronze" } },
   },
   {
     id: "t10",
     name: "Lapis Lazuli Necklace",
     symbol: "𓍿",
     description: "A stunning necklace made from rare lapis lazuli stones, prized by the wealthy.",
+    effects: { expeditionBonus: { amount: 1, tier: "bronze" } },
   },
 ]
 
@@ -92,48 +165,56 @@ export const templeSecretsTreasures: Treasure[] = [
     name: "Sacred Ankh",
     symbol: "𓎬",
     description: "A golden ankh symbol representing eternal life, blessed by the temple priests.",
+    effects: { errorHighlight: true },
   },
   {
     id: "t12",
     name: "Copper Mirror",
     symbol: "𓈭",
     description: "A polished copper mirror used for ritual purification ceremonies.",
+    effects: { earlyFeedback: true },
   },
   {
     id: "t13",
     name: "Incense Burner",
     symbol: "𓌃",
     description: "An ornate bronze incense burner used in temple worship rituals.",
+    effects: { mapFragmentChance: 0.1 },
   },
   {
     id: "t14",
     name: "Ritual Chalice",
     symbol: "𓊃",
     description: "A sacred silver chalice used for libation offerings to the gods.",
+    effects: { moreLootChance: { chance: 0.2, tier: "bronze" } },
   },
   {
     id: "t15",
     name: "Ceremonial Fan",
     symbol: "𓈂",
     description: "An ornate feathered fan used by priests during temple ceremonies.",
+    effects: { expeditionBonus: { amount: 1, tier: "bronze" } },
   },
   {
     id: "t16",
     name: "Prayer Beads",
     symbol: "𓏓",
     description: "A string of blessed prayer beads used for meditation and worship.",
+    effects: { moreLootChance: { chance: 0.2, tier: "silver" } },
   },
   {
     id: "t17",
     name: "Holy Water Vessel",
     symbol: "𓍵",
     description: "A vessel containing blessed water from the sacred temple well.",
+    effects: { expeditionBonus: { amount: 1, tier: "silver" } },
   },
   {
     id: "t18",
     name: "Temple Bell",
     symbol: "𓏁",
     description: "A bronze bell used to call the faithful to prayer and announce ceremonies.",
+    effects: { mapFragmentChance: 0.1 },
   },
 ]
 
@@ -143,60 +224,70 @@ export const ancientRelicsTreasures: Treasure[] = [
     name: "Pharaoh's Seal",
     symbol: "𓈯",
     description: "An ancient royal seal bearing the cartouche of a forgotten pharaoh.",
+    effects: { moreLootChance: { chance: 0.2, tier: "silver" } },
   },
   {
     id: "t20",
     name: "Crystal Orb",
     symbol: "𓋑",
     description: "A mystical crystal orb said to reveal visions of the past and future.",
+    effects: { expeditionBonus: { amount: 1, tier: "silver" } },
   },
   {
     id: "t21",
     name: "Hieroglyphic Tablet",
     symbol: "𓁷",
     description: "An ancient stone tablet inscribed with mysterious hieroglyphic prophecies.",
+    effects: { moreLootChance: { chance: 0.2, tier: "gold" } },
   },
   {
     id: "t22",
     name: "Golden Scepter",
     symbol: "𓌂",
     description: "A magnificent golden scepter topped with the eye of Horus.",
+    effects: { expeditionBonus: { amount: 1, tier: "gold" } },
   },
   {
     id: "t23",
     name: "Obsidian Knife",
     symbol: "𓍊",
     description: "A razor-sharp obsidian ceremonial knife used in ancient rituals.",
+    effects: { errorHighlight: true },
   },
   {
     id: "t24",
     name: "Meteorite Fragment",
     symbol: "𓍗",
     description: "A piece of sacred meteorite believed to contain divine power.",
+    effects: { hieroglyphUnlock: true },
   },
   {
     id: "t25",
     name: "Ancient Compass",
     symbol: "𓌻",
     description: "A mystical navigation device that always points toward hidden treasures.",
+    effects: { moreLootChance: { chance: 0.2, tier: "gold" } },
   },
   {
     id: "t26",
     name: "Time Crystal",
     symbol: "𓆕",
     description: "A legendary crystal that glows with the power of ages past.",
+    effects: { hieroglyphUnlock: true },
   },
   {
     id: "t27",
     name: "Ritual Mask",
     symbol: "𓆜",
     description: "An ornate golden mask worn by high priests during sacred ceremonies.",
+    effects: { expeditionBonus: { amount: 1, tier: "gold" } },
   },
   {
     id: "t28",
     name: "Eternal Flame Torch",
     symbol: "𓆘",
     description: "A torch that burns with an eternal flame, never extinguished since ancient times.",
+    effects: { earlyFeedback: true },
   },
 ]
 
@@ -206,72 +297,84 @@ export const mythicalArtifactsTreasures: Treasure[] = [
     name: "Crown of Ra",
     symbol: "𓆰",
     description: "The legendary crown of the sun god Ra, radiating divine light and power.",
+    effects: { moreLootChance: { chance: 0.2, tier: "divine" } },
   },
   {
     id: "t30",
     name: "Staff of Thoth",
     symbol: "𓎘",
     description: "The wisdom staff of Thoth, god of knowledge, containing all ancient secrets.",
+    effects: { expeditionBonus: { amount: 1, tier: "divine" } },
   },
   {
     id: "t31",
     name: "Feather of Ma'at",
     symbol: "𓆃",
     description: "The sacred feather of Ma'at, goddess of truth, used to weigh souls in the afterlife.",
+    effects: { moreLootChance: { chance: 0.2 } },
   },
   {
     id: "t32",
     name: "Tears of Isis",
     symbol: "𓁺",
     description: "Crystallized tears of the goddess Isis, said to grant eternal protection.",
+    effects: { moreLootChance: { chance: 0.2 } },
   },
   {
     id: "t33",
     name: "Heart of Osiris",
     symbol: "𓇺",
     description: "The preserved heart of Osiris, lord of the underworld, pulsing with life force.",
+    effects: { moreLootChance: { chance: 0.2 } },
   },
   {
     id: "t34",
     name: "Eye of Horus Amulet",
     symbol: "𓃮",
     description: "The ultimate protective amulet containing the complete power of Horus.",
+    effects: { moreLootChance: { chance: 0.2 } },
   },
   {
     id: "t35",
     name: "Serpent of Apep",
     symbol: "𓍝",
     description: "A bound fragment of the chaos serpent Apep, contained within a sacred vessel.",
+    effects: { moreLootChance: { chance: 0.2 } },
   },
   {
     id: "t36",
     name: "Breath of Shu",
     symbol: "𓊪",
     description: "A vial containing the breath of Shu, god of air, granting power over the winds.",
+    effects: { moreLootChance: { chance: 0.2 } },
   },
   {
     id: "t37",
     name: "Scale of Sobek",
     symbol: "𓆎",
     description: "A single scale from the crocodile god Sobek, providing protection in water.",
+    effects: { moreLootChance: { chance: 0.2, tier: "divine" } },
   },
   {
     id: "t38",
     name: "Anubis Guardian Statue",
     symbol: "𓃣",
     description: "A miniature statue of Anubis that comes alive to guard its owner's treasures.",
+    effects: { expeditionBonus: { amount: 1, tier: "divine" } },
   },
   {
     id: "t39",
     name: "Book of the Dead",
     symbol: "𓆲",
     description: "The complete Book of the Dead, containing all spells needed for the afterlife journey.",
+    effects: { moreLootChance: { chance: 0.2 } },
   },
   {
     id: "t40",
     name: "Pyramid Capstone",
     symbol: "𓂻",
     description: "The golden capstone of the Great Pyramid, containing the concentrated power of all pharaohs.",
+    effects: { moreLootChance: { chance: 0.2 } },
   },
 ]
 

--- a/src/data/useTreasureTranslations.ts
+++ b/src/data/useTreasureTranslations.ts
@@ -1,11 +1,40 @@
 import { useTranslation } from "react-i18next"
+import type { TFunction } from "i18next"
 import {
   merchantCacheTreasures,
   nobleVaultTreasures,
   templeSecretsTreasures,
   ancientRelicsTreasures,
   mythicalArtifactsTreasures,
+  type TreasureEffects,
 } from "@/data/treasures"
+
+const getEffectDescription = (effects: TreasureEffects | undefined, t: TFunction): string | undefined => {
+  if (!effects) return undefined
+  if (effects.mapFragmentChance !== undefined) {
+    return t("effects.mapFragmentChance", { chance: Math.round(effects.mapFragmentChance * 100) })
+  }
+  if (effects.higherLootChance !== undefined) {
+    return t("effects.higherLootChance", { chance: Math.round(effects.higherLootChance * 100) })
+  }
+  if (effects.moreLootChance !== undefined) {
+    const { chance, tier } = effects.moreLootChance
+    if (tier) {
+      return t("effects.moreLootChanceTier", { chance: Math.round(chance * 100), tier: t(`tiers.${tier}`) })
+    }
+    return t("effects.moreLootChanceAdaptive", { chance: Math.round(chance * 100) })
+  }
+  if (effects.expeditionBonus !== undefined) {
+    return t("effects.expeditionBonus", {
+      amount: effects.expeditionBonus.amount,
+      tier: t(`tiers.${effects.expeditionBonus.tier}`),
+    })
+  }
+  if (effects.errorHighlight) return t("effects.errorHighlight")
+  if (effects.earlyFeedback) return t("effects.earlyFeedback")
+  if (effects.hieroglyphUnlock) return t("effects.hieroglyphUnlock")
+  return undefined
+}
 
 // Hook to get translated treasure item
 export const useTreasureItem = () => {
@@ -40,6 +69,7 @@ export const useTreasureItem = () => {
       symbol: treasure.symbol,
       name: t(`${category}.${id}.name`),
       description: t(`${category}.${id}.description`),
+      effectDescription: getEffectDescription(treasure.effects, t),
     }
   }
 }
@@ -74,5 +104,6 @@ export const useTreasureCategory = (
     symbol: treasure.symbol,
     name: t(`${category}.${treasure.id}.name`),
     description: t(`${category}.${treasure.id}.description`),
+    effectDescription: getEffectDescription(treasure.effects, t),
   }))
 }

--- a/src/index.css
+++ b/src/index.css
@@ -100,6 +100,14 @@ html, body {
     }
   }
 
+  --animate-magic-flow: magic-flow 2s linear infinite;
+  @keyframes magic-flow {
+    0%   { border-color: rgb(168, 85, 247); }
+    33%  { border-color: rgb(6, 182, 212); }
+    66%  { border-color: rgb(245, 158, 11); }
+    100% { border-color: rgb(168, 85, 247); }
+  }
+
   --animate-shake: shake 0.5s ease-in-out 2;
   @keyframes shake {
     0%,

--- a/src/index.css
+++ b/src/index.css
@@ -100,6 +100,12 @@ html, body {
     }
   }
 
+  --animate-unlock-glow: unlock-glow 2s ease-in-out infinite;
+  @keyframes unlock-glow {
+    0%, 100% { border-color: rgb(245, 158, 11); }
+    50%       { border-color: rgb(234, 179, 8); }
+  }
+
   --animate-magic-flow: magic-flow 2s linear infinite;
   @keyframes magic-flow {
     0%   { border-color: rgb(168, 85, 247); }

--- a/src/ui/Block.stories.tsx
+++ b/src/ui/Block.stories.tsx
@@ -12,6 +12,9 @@ const meta = {
     selected: {
       control: "boolean",
     },
+    unlockable: {
+      control: "boolean",
+    },
     feedback: {
       control: "select",
       options: [undefined, "pending", "correct", "incorrect"],
@@ -58,6 +61,13 @@ export const LongText: Story = {
 }
 
 // earlyFeedback states
+
+export const Unlockable: Story = {
+  args: {
+    children: "𓆕",
+    unlockable: true,
+  },
+}
 
 export const FeedbackPending: Story = {
   args: {

--- a/src/ui/Block.stories.tsx
+++ b/src/ui/Block.stories.tsx
@@ -12,6 +12,10 @@ const meta = {
     selected: {
       control: "boolean",
     },
+    feedback: {
+      control: "select",
+      options: [undefined, "pending", "correct", "incorrect"],
+    },
     className: {
       control: "text",
     },
@@ -50,5 +54,28 @@ export const Empty: Story = {
 export const LongText: Story = {
   args: {
     children: "1000",
+  },
+}
+
+// earlyFeedback states
+
+export const FeedbackPending: Story = {
+  args: {
+    children: "?",
+    feedback: "pending",
+  },
+}
+
+export const FeedbackCorrect: Story = {
+  args: {
+    children: "42",
+    feedback: "correct",
+  },
+}
+
+export const FeedbackIncorrect: Story = {
+  args: {
+    children: "99",
+    feedback: "incorrect",
   },
 }

--- a/src/ui/Block.tsx
+++ b/src/ui/Block.tsx
@@ -1,9 +1,12 @@
 import clsx from "clsx"
 import type { FC, PropsWithChildren } from "react"
 
-export const Block: FC<PropsWithChildren<{ className?: string; selected?: boolean }>> = ({
+export type BlockFeedback = "correct" | "incorrect" | "pending"
+
+export const Block: FC<PropsWithChildren<{ className?: string; selected?: boolean; feedback?: BlockFeedback }>> = ({
   children,
   selected,
+  feedback,
   className = "",
 }) => {
   return (
@@ -11,8 +14,11 @@ export const Block: FC<PropsWithChildren<{ className?: string; selected?: boolea
       className={clsx(
         "ml-[-1px] flex h-10 w-15 items-center justify-center rounded text-center",
         {
-          "border-2": selected,
-          border: !selected,
+          "border-2": selected || !!feedback,
+          border: !selected && !feedback,
+          "animate-magic-flow": feedback === "pending",
+          "border-green-500": feedback === "correct",
+          "border-red-500": feedback === "incorrect",
         },
         className
       )}

--- a/src/ui/Block.tsx
+++ b/src/ui/Block.tsx
@@ -3,22 +3,27 @@ import type { FC, PropsWithChildren } from "react"
 
 export type BlockFeedback = "correct" | "incorrect" | "pending"
 
-export const Block: FC<PropsWithChildren<{ className?: string; selected?: boolean; feedback?: BlockFeedback }>> = ({
-  children,
-  selected,
-  feedback,
-  className = "",
-}) => {
+export const Block: FC<
+  PropsWithChildren<{
+    className?: string
+    selected?: boolean
+    feedback?: BlockFeedback
+    unlockable?: boolean
+    onClick?: () => void
+  }>
+> = ({ children, selected, feedback, unlockable, onClick, className = "" }) => {
   return (
     <div
+      onClick={onClick}
       className={clsx(
         "ml-[-1px] flex h-10 w-15 items-center justify-center rounded text-center",
         {
-          "border-2": selected || !!feedback,
-          border: !selected && !feedback,
+          "border-2": selected || !!feedback || unlockable,
+          border: !selected && !feedback && !unlockable,
           "animate-magic-flow": feedback === "pending",
           "border-green-500": feedback === "correct",
           "border-red-500": feedback === "incorrect",
+          "animate-unlock-glow cursor-pointer": unlockable && !feedback,
         },
         className
       )}

--- a/src/ui/HieroglyphUnlockPanel.stories.tsx
+++ b/src/ui/HieroglyphUnlockPanel.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import { HieroglyphUnlockPanel } from "./HieroglyphUnlockPanel"
+
+const meta = {
+  title: "UI/HieroglyphUnlockPanel",
+  component: HieroglyphUnlockPanel,
+  parameters: {
+    layout: "fullscreen",
+  },
+  argTypes: {
+    hieroglyphDifficulty: {
+      control: "select",
+      options: ["starter", "junior", "expert", "master", "wizard"],
+    },
+    artifactId: {
+      control: "select",
+      options: ["t24", "t26"],
+      description: "t24 = Meteorite Fragment, t26 = Time Crystal",
+    },
+  },
+} satisfies Meta<typeof HieroglyphUnlockPanel>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const MeteoriteFragment: Story = {
+  args: {
+    hieroglyphSymbol: "𓁺",
+    hieroglyphDifficulty: "master",
+    artifactId: "t24",
+    onUnlock: () => console.log("Unlocked!"),
+    onDismiss: () => console.log("Dismissed"),
+  },
+}
+
+export const TimeCrystal: Story = {
+  args: {
+    hieroglyphSymbol: "𓆕",
+    hieroglyphDifficulty: "master",
+    artifactId: "t26",
+    onUnlock: () => console.log("Unlocked!"),
+    onDismiss: () => console.log("Dismissed"),
+  },
+}
+
+export const StarterDifficulty: Story = {
+  args: {
+    hieroglyphSymbol: "𓀀",
+    hieroglyphDifficulty: "starter",
+    artifactId: "t24",
+    onUnlock: () => console.log("Unlocked!"),
+    onDismiss: () => console.log("Dismissed"),
+  },
+}

--- a/src/ui/HieroglyphUnlockPanel.tsx
+++ b/src/ui/HieroglyphUnlockPanel.tsx
@@ -1,0 +1,119 @@
+import { useState, useRef, type FC } from "react"
+import { useTranslation } from "react-i18next"
+import { HieroglyphTile } from "@/ui/HieroglyphTile"
+import { useTreasureItem } from "@/data/useTreasureTranslations"
+import { getItemFirstLevel } from "@/data/itemLevelLookup"
+import type { Difficulty } from "@/data/difficultyLevels"
+
+type HieroglyphUnlockPanelProps = {
+  hieroglyphSymbol: string
+  hieroglyphDifficulty: Difficulty
+  artifactId: string
+  onUnlock: () => void
+  onDismiss: () => void
+}
+
+const TILE_WIDTH = 48 // w-12 = 48px
+const GAP = 48 // gap between tiles (arrow area)
+const UNLOCK_THRESHOLD = TILE_WIDTH * 0.8
+
+export const HieroglyphUnlockPanel: FC<HieroglyphUnlockPanelProps> = ({
+  hieroglyphSymbol,
+  hieroglyphDifficulty,
+  artifactId,
+  onUnlock,
+  onDismiss,
+}) => {
+  const { t } = useTranslation("treasures")
+  const getTreasureItem = useTreasureItem()
+  const artifact = getTreasureItem(artifactId)
+  const artifactDifficulty = getItemFirstLevel(artifactId)
+
+  const [dragX, setDragX] = useState(0)
+  const [isDragging, setIsDragging] = useState(false)
+  const startXRef = useRef(0)
+  const isOverThreshold = dragX <= -UNLOCK_THRESHOLD
+
+  const handlePointerDown = (e: React.PointerEvent) => {
+    e.currentTarget.setPointerCapture(e.pointerId)
+    startXRef.current = e.clientX
+    setIsDragging(true)
+  }
+
+  const handlePointerMove = (e: React.PointerEvent) => {
+    if (!isDragging) return
+    const delta = e.clientX - startXRef.current
+    // Only allow leftward drag, clamp to tile+gap distance
+    setDragX(Math.max(-(TILE_WIDTH + GAP), Math.min(0, delta)))
+  }
+
+  const handlePointerUp = () => {
+    setIsDragging(false)
+    if (isOverThreshold) {
+      onUnlock()
+    } else {
+      setDragX(0)
+    }
+  }
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div className="fixed inset-0 z-40 bg-black/30" onClick={onDismiss} />
+
+      {/* Bottom sheet */}
+      <div className="fixed right-0 bottom-0 left-0 z-50 animate-slide-in-up rounded-t-2xl bg-white/95 p-6 shadow-2xl backdrop-blur-sm">
+        {/* Drag handle */}
+        <div className="mx-auto mb-4 h-1 w-12 rounded-full bg-gray-300" />
+
+        <div className="flex flex-col items-center gap-6">
+          {/* Tile row: [Hieroglyph] ← [Artifact] */}
+          <div className="flex items-center gap-6">
+            {/* Hieroglyph target tile */}
+            <div
+              className={
+                isOverThreshold
+                  ? "rounded-lg ring-4 ring-amber-400 ring-offset-2 transition-all duration-150"
+                  : "transition-all duration-150"
+              }
+            >
+              <HieroglyphTile symbol={hieroglyphSymbol} difficulty={hieroglyphDifficulty} size="lg" />
+            </div>
+
+            {/* Arrow */}
+            <span className="text-2xl text-amber-600 select-none">←</span>
+
+            {/* Artifact tile — draggable */}
+            {artifact && (
+              <div
+                className="cursor-grab touch-none active:cursor-grabbing"
+                style={{
+                  transform: `translateX(${dragX}px)`,
+                  transition: isDragging ? "none" : "transform 0.2s ease-out",
+                  userSelect: "none",
+                }}
+                onPointerDown={handlePointerDown}
+                onPointerMove={handlePointerMove}
+                onPointerUp={handlePointerUp}
+                onPointerCancel={handlePointerUp}
+              >
+                <HieroglyphTile symbol={artifact.symbol} difficulty={artifactDifficulty} size="lg" />
+              </div>
+            )}
+          </div>
+
+          {/* Artifact name */}
+          {artifact && <p className="font-pyramid text-base font-semibold text-amber-800">{artifact.name}</p>}
+
+          {/* Instruction */}
+          <p className="text-center text-sm text-gray-500">{t("hieroglyphUnlockPanel.instruction")}</p>
+
+          {/* Dismiss button */}
+          <button onClick={onDismiss} className="mt-2 rounded-lg px-6 py-2 text-sm text-gray-400 hover:text-gray-600">
+            ✕
+          </button>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/ui/InputBlock.stories.tsx
+++ b/src/ui/InputBlock.stories.tsx
@@ -21,8 +21,9 @@ const meta = {
     disabled: {
       control: "boolean",
     },
-    hasError: {
-      control: "boolean",
+    feedback: {
+      control: "select",
+      options: [undefined, "correct", "incorrect"],
     },
   },
 } satisfies Meta<typeof InputBlock>
@@ -75,11 +76,18 @@ export const Interactive: Story = {
 }
 
 // errorHighlight state — shown when a wrong value has been entered
-
 export const ErrorHighlight: Story = {
   args: {
     value: 99,
-    hasError: true,
+    feedback: "incorrect",
+    onChange: value => console.log("Value changed:", value),
+  },
+}
+
+export const FeedbackCorrect: Story = {
+  args: {
+    value: 42,
+    feedback: "correct",
     onChange: value => console.log("Value changed:", value),
   },
 }

--- a/src/ui/InputBlock.stories.tsx
+++ b/src/ui/InputBlock.stories.tsx
@@ -23,7 +23,7 @@ const meta = {
     },
     feedback: {
       control: "select",
-      options: [undefined, "correct", "incorrect"],
+      options: [undefined, "pending", "correct", "incorrect"],
     },
   },
 } satisfies Meta<typeof InputBlock>
@@ -72,6 +72,14 @@ export const Interactive: Story = {
     onChange: value => console.log("Value changed:", value),
     onSelect: () => console.log("Selected"),
     onBlur: () => console.log("Blurred"),
+  },
+}
+
+// earlyFeedback pending state — shown from level start, glows to signal live feedback incoming
+export const FeedbackPending: Story = {
+  args: {
+    feedback: "pending",
+    onChange: value => console.log("Value changed:", value),
   },
 }
 

--- a/src/ui/InputBlock.stories.tsx
+++ b/src/ui/InputBlock.stories.tsx
@@ -21,6 +21,9 @@ const meta = {
     disabled: {
       control: "boolean",
     },
+    hasError: {
+      control: "boolean",
+    },
   },
 } satisfies Meta<typeof InputBlock>
 
@@ -68,5 +71,15 @@ export const Interactive: Story = {
     onChange: value => console.log("Value changed:", value),
     onSelect: () => console.log("Selected"),
     onBlur: () => console.log("Blurred"),
+  },
+}
+
+// errorHighlight state — shown when a wrong value has been entered
+
+export const ErrorHighlight: Story = {
+  args: {
+    value: 99,
+    hasError: true,
+    onChange: value => console.log("Value changed:", value),
   },
 }

--- a/src/ui/InputBlock.tsx
+++ b/src/ui/InputBlock.tsx
@@ -9,7 +9,7 @@ export const InputBlock: FC<{
   selected?: boolean
   shouldFocus?: boolean
   disabled?: boolean
-  feedback?: Exclude<BlockFeedback, "pending">
+  feedback?: BlockFeedback
   onSelect?: () => void
   onBlur?: () => void
   onChange: (value: number | undefined) => void

--- a/src/ui/InputBlock.tsx
+++ b/src/ui/InputBlock.tsx
@@ -2,17 +2,18 @@ import type { FC } from "react"
 import { useRef, useEffect } from "react"
 import clsx from "clsx"
 import { Block } from "@/ui/Block"
+import type { BlockFeedback } from "@/ui/Block"
 
 export const InputBlock: FC<{
   value?: number
   selected?: boolean
   shouldFocus?: boolean
   disabled?: boolean
-  hasError?: boolean
+  feedback?: Exclude<BlockFeedback, "pending">
   onSelect?: () => void
   onBlur?: () => void
   onChange: (value: number | undefined) => void
-}> = ({ value, selected, disabled, shouldFocus, hasError, onChange, onSelect, onBlur }) => {
+}> = ({ value, selected, disabled, shouldFocus, feedback, onChange, onSelect, onBlur }) => {
   const inputRef = useRef<HTMLInputElement>(null)
   const hasFocus = useRef(false)
   useEffect(() => {
@@ -29,12 +30,13 @@ export const InputBlock: FC<{
   return (
     <Block
       selected={selected}
-      feedback={hasError ? "incorrect" : undefined}
+      feedback={feedback}
       className={clsx(
         "bg-blue-100 text-blue-800 focus-within:bg-orange-300 focus-within:font-bold focus-within:text-orange-800",
         {
-          "bg-red-100 text-red-800": hasError,
-          "bg-orange-300 text-orange-800": !hasError && value !== undefined,
+          "bg-red-100 text-red-800": feedback === "incorrect",
+          "bg-green-100 text-green-800": feedback === "correct",
+          "bg-orange-300 text-orange-800": !feedback && value !== undefined,
         }
       )}
     >

--- a/src/ui/InputBlock.tsx
+++ b/src/ui/InputBlock.tsx
@@ -1,5 +1,6 @@
 import type { FC } from "react"
 import { useRef, useEffect } from "react"
+import clsx from "clsx"
 import { Block } from "@/ui/Block"
 
 export const InputBlock: FC<{
@@ -7,10 +8,11 @@ export const InputBlock: FC<{
   selected?: boolean
   shouldFocus?: boolean
   disabled?: boolean
+  hasError?: boolean
   onSelect?: () => void
   onBlur?: () => void
   onChange: (value: number | undefined) => void
-}> = ({ value, selected, disabled, shouldFocus, onChange, onSelect, onBlur }) => {
+}> = ({ value, selected, disabled, shouldFocus, hasError, onChange, onSelect, onBlur }) => {
   const inputRef = useRef<HTMLInputElement>(null)
   const hasFocus = useRef(false)
   useEffect(() => {
@@ -27,9 +29,14 @@ export const InputBlock: FC<{
   return (
     <Block
       selected={selected}
-      className={`bg-blue-100 text-blue-800 focus-within:bg-orange-300 focus-within:font-bold focus-within:text-orange-800 ${
-        value !== undefined ? "bg-orange-300 text-orange-800" : ""
-      }`}
+      feedback={hasError ? "incorrect" : undefined}
+      className={clsx(
+        "bg-blue-100 text-blue-800 focus-within:bg-orange-300 focus-within:font-bold focus-within:text-orange-800",
+        {
+          "bg-red-100 text-red-800": hasError,
+          "bg-orange-300 text-orange-800": !hasError && value !== undefined,
+        }
+      )}
     >
       <input
         ref={inputRef}


### PR DESCRIPTION
## Summary

Implements all 7 passive treasure effects that activate once a treasure is in the player's inventory. Each effect is backed by unit tests and Storybook stories for the new visual states.

### Loot effects (fire on pyramid/expedition completion)
- **`moreLootChance`** — seeded per-tier bonus item roll each pyramid level; stacks additively across treasures
- **`higherLootChance`** — additive bonus to the base inventory loot drop probability
- **`mapFragmentChance`** — additive bonus to map fragment drop probability
- **`expeditionBonus`** — guaranteed item(s) awarded on the final level of an expedition, by tier

### Puzzle effects (active while solving)
- **`errorHighlight`** — on blur with a wrong value, consumes one slot to permanently mark that block with live correct/incorrect feedback; earlyFeedback blocks are excluded
- **`earlyFeedback`** — at level load, selects open blocks at calculation depth ≥4/8/12 (one per owned treasure, seeded random); those blocks glow with a magic animation from the start and switch to live correct/incorrect feedback as the player types
- **`hieroglyphUnlock`** — N charges per level (resets each level) to convert blocked hieroglyph blocks into editable InputBlocks; triggered by tapping the block and sliding the artifact tile onto the hieroglyph tile in a bottom-sheet panel; cycles through owned artifacts per use

### UI
- `Block`: `feedback` prop (`pending` / `correct` / `incorrect`) with `animate-magic-flow` border; `unlockable` prop with `animate-unlock-glow` amber border
- `InputBlock`: `feedback` prop (all three states including `pending`)
- `HieroglyphUnlockPanel`: bottom-sheet with pointer-events drag gesture
- Collection detail panel shows `effectDescription` derived from treasure data (no duplication)

### Effect descriptions
Translation templates in `en/` and `nl/` with interpolated values — changing a treasure's numeric effect in `treasures.ts` automatically updates the displayed text.

## Test plan
- [ ] `lootEffects.spec.ts` — moreLootChance (6 cases), higherLootChance (2 cases)
- [ ] `expeditionBonusLogic.spec.ts` — 6 cases covering tiers, stacking, determinism
- [ ] `earlyFeedbackLogic.spec.ts` — 8 cases covering depth thresholds, seed variance, edge cases
- [ ] `hieroglyphUnlockLogic.spec.ts` — 5 cases covering artifact cycling and fallback
- [ ] Storybook: Block (Unlockable, FeedbackPending/Correct/Incorrect), InputBlock (FeedbackPending/Correct/Incorrect, ErrorHighlight)
- [ ] In-game: own t11/t23 and make errors to verify errorHighlight slot consumption
- [ ] In-game: own t12/t28 and verify earlyFeedback blocks glow at level start then switch live
- [ ] In-game: own t24/t26 and verify hieroglyph block unlock panel with drag gesture; second unlock shows t26

🤖 Generated with [Claude Code](https://claude.com/claude-code)