### PR TITLE
fix: start next expedition button infinite loop (0.23.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pyramid-scheme",
   "private": true,
-  "version": "0.23.0",
+  "version": "0.23.1",
   "type": "module",
   "scripts": {
     "dev": "vite --port 9164",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,6 +32,7 @@ function App() {
         )}
         {inGame && journeyInfo && journeyInfo.journey.type === "pyramid" && (
           <PyramidExpedition
+            key={activeJourneyId}
             activeJourney={journeyInfo}
             runNr={runNr}
             onLevelComplete={completeLevel}

--- a/src/support/useOfflineStorage.ts
+++ b/src/support/useOfflineStorage.ts
@@ -1,5 +1,5 @@
 import type { SetStateAction } from "react"
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import localForage from "localforage"
 
 const isSetFunction = <T>(v: SetStateAction<T>): v is (prevValue: T) => T => typeof v === "function"
@@ -83,6 +83,10 @@ export const useOfflineStorage = <T>(
     typeof initialValue === "function" ? (initialValue as () => T)() : initialValue
   )
   const store = getStore(storeName)
+  // Ref always holds the latest value so multiple synchronous setValue(fn)
+  // calls chain correctly without waiting for a re-render or async DB read.
+  const localStateRef = useRef(localState)
+  localStateRef.current = localState
 
   useEffect(() => {
     store
@@ -110,20 +114,21 @@ export const useOfflineStorage = <T>(
   const setValue = useCallback(
     async (value: SetStateAction<T>) => {
       if (isSetFunction(value)) {
-        const previousValue = await store.getItem<T>(key)
-        const nextValue = value(previousValue ?? localState)
-        setLocalState(nextValue) // Optimistic
-        await store.setItem<T>(key, nextValue)
+        // Compute next value from the ref (always up-to-date) and update the
+        // ref synchronously so chained calls each see the previous result.
+        const nextValue = value(localStateRef.current)
+        localStateRef.current = nextValue
         setLocalState(nextValue)
+        await store.setItem<T>(key, nextValue)
         return nextValue
       } else {
-        setLocalState(value) // Optimistic
-        await store.setItem<T>(key, value)
+        localStateRef.current = value as T
         setLocalState(value)
+        await store.setItem<T>(key, value)
         return value
       }
     },
-    [key, localState, store]
+    [key, store]
   )
 
   const deleteValue = useCallback(


### PR DESCRIPTION
## Summary

- Fixes "Start [expedition]" button in expedition completion overlay looping back to the same completion screen
- Bumps version 0.23.0 → 0.23.1

## Root causes

**1. `useOfflineStorage` race condition (root cause)**

`setValue(fn)` was reading from IndexedDB to obtain the previous value for functional updates. When `completeJourney()` and `startJourney()` were called synchronously back-to-back, both reads hit the DB before either write landed — the second call received stale state and silently overwrote the first call's changes, leaving the old journey still marked as active.

Fixed by introducing a `localStateRef` that tracks the latest value synchronously. Each `setValue(fn)` call reads from the ref, computes the next value, and immediately writes back — so chained calls chain correctly without waiting for a re-render or async DB round-trip.

**2. Stale `PyramidExpedition` internal state**

Without a `key`, React reused the same component instance when the active journey changed. Internal state like `transitionToLevel` carried over from the completed expedition, putting the new expedition into a broken animation state.

Fixed by adding `key={activeJourneyId}` to `PyramidExpedition` in `App.tsx`.

## Test plan

- [ ] Complete a first-time expedition → click "Start [next expedition]" → new expedition loads at level 1, no loop
- [ ] "Terug naar basis" button still works normally
- [ ] Level-by-level progression within an expedition still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)