### PR TITLE
fix: tomb tutorial ? button silently ignored after first play (0.23.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pyramid-scheme",
   "private": true,
-  "version": "0.23.1",
+  "version": "0.23.2",
   "type": "module",
   "scripts": {
     "dev": "vite --port 9164",

--- a/src/app/TombExpedition.tsx
+++ b/src/app/TombExpedition.tsx
@@ -124,7 +124,7 @@ export const TombExpedition: FC<{
             </h1>
             <span className="flex items-center gap-2">
               <button
-                onClick={() => showConversation("tombTutorial")}
+                onClick={() => showConversation("tombTutorial", undefined, { forceReplay: true })}
                 className="flex size-7 cursor-pointer items-center justify-center rounded-full bg-white/20 text-sm font-bold text-white hover:bg-white/30"
                 aria-label={t("ui.howToPlay")}
               >

--- a/src/app/fez/FezCompanion.tsx
+++ b/src/app/fez/FezCompanion.tsx
@@ -18,11 +18,15 @@ export const FezCompanion: React.FC<{
 
   const contextValue = useMemo(
     () => ({
-      showConversation: (conversationId: string, onComplete?: (result: FezConversationResult) => void) => {
+      showConversation: (
+        conversationId: string,
+        onComplete?: (result: FezConversationResult) => void,
+        options?: { forceReplay?: boolean }
+      ) => {
         if (!loaded) {
           return onComplete?.("not-loaded")
         }
-        if (conversations[conversationId]) {
+        if (conversations[conversationId] && !options?.forceReplay) {
           return onComplete?.("seen-earlier")
         }
         const entry = {

--- a/src/app/fez/context.ts
+++ b/src/app/fez/context.ts
@@ -3,7 +3,11 @@ import { createContext } from "react"
 export type FezConversationResult = "not-loaded" | "complete" | "skipped" | "seen-earlier"
 
 export const FezContext = createContext<{
-  showConversation: (conversationId: string, onComplete?: (result: FezConversationResult) => void) => void
+  showConversation: (
+    conversationId: string,
+    onComplete?: (result: FezConversationResult) => void,
+    options?: { forceReplay?: boolean }
+  ) => void
 }>({
   showConversation: () => {
     throw new Error("FezContext not provided")


### PR DESCRIPTION
## Summary

- Fixes the `?` button in the tomb expedition header — clicking it after the tutorial had already played once did nothing
- Bumps version 0.23.1 → 0.23.2

## Root cause

`FezCompanion` tracks seen conversations and calls `onComplete("seen-earlier")` immediately for any conversation already in the seen log. The `?` button called `showConversation("tombTutorial")` without any way to override this, so it was silently skipped.

## Fix

Added an optional `options: { forceReplay?: boolean }` parameter to `showConversation`. When `forceReplay: true`, the seen-earlier check is bypassed and the conversation plays again without clearing the seen flag (so auto-triggers on entry still fire only once).

## Test plan

- [ ] Enter a tomb for the first time → tutorial plays automatically
- [ ] Click `?` button → tutorial replays
- [ ] Leave and re-enter tomb → tutorial does NOT auto-play again
- [ ] Click `?` button again → tutorial replays again

🤖 Generated with [Claude Code](https://claude.com/claude-code)