### PR TITLE
feat: scroll to suggested journey when list opens (0.23.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pyramid-scheme",
   "private": true,
-  "version": "0.23.2",
+  "version": "0.23.3",
   "type": "module",
   "scripts": {
     "dev": "vite --port 9164",

--- a/src/app/pages/Travel.tsx
+++ b/src/app/pages/Travel.tsx
@@ -118,6 +118,17 @@ export const TravelPage: FC<{
     })
   }, [journeys, getJourney])
 
+  const scrollContainerRef = useRef<HTMLDivElement>(null)
+  const suggestedCardRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!showJourneySelection || !suggestedJourneyId) return
+    const timer = setTimeout(() => {
+      suggestedCardRef.current?.scrollIntoView({ behavior: "smooth", block: "nearest" })
+    }, 750)
+    return () => clearTimeout(timer)
+  }, [showJourneySelection, suggestedJourneyId])
+
   return (
     <Page
       className="flex flex-col items-center justify-center overflow-y-auto bg-gradient-to-b from-blue-100 to-blue-300 text-black"
@@ -217,7 +228,7 @@ export const TravelPage: FC<{
             showJourneySelection ? "translate-x-0 opacity-100" : "translate-x-[100%] opacity-0"
           }`}
         >
-          <div className="flex-1 overflow-y-auto pb-8">
+          <div ref={scrollContainerRef} className="flex-1 overflow-y-auto pb-8">
             <div className="sticky top-0 z-10 flex w-full items-center justify-between bg-blue-100/70 px-8 py-4 backdrop-blur-sm">
               <h2 className="font-pyramid text-xl font-bold">{t("ui.chooseYourJourney")}</h2>
               <button
@@ -265,24 +276,26 @@ export const TravelPage: FC<{
                 }
                 const disabled = journey.type === "treasure_tomb" && journey.treasures.length <= completionCount
 
+                const isSuggested = journey.id === suggestedJourneyId
                 return (
-                  <JourneyCard
-                    key={journey.id}
-                    showDetails={index === unlocked - 1}
-                    journey={journey}
-                    disabled={disabled}
-                    completionCount={completionCount}
-                    progressLevelNr={journeyInfo?.inProgress ? progressLevelNr : undefined}
-                    index={index}
-                    showAnimation={showJourneySelection}
-                    hasMapPiece={hasMapPiece}
-                    suggested={journey.id === suggestedJourneyId}
-                    onClick={handleJourneySelect}
-                  >
-                    {journey.type === "treasure_tomb" && journeyInfo?.inProgress ? (
-                      <TableauInventory journeyInfo={journeyInfo} />
-                    ) : null}
-                  </JourneyCard>
+                  <div key={journey.id} ref={isSuggested ? suggestedCardRef : undefined}>
+                    <JourneyCard
+                      showDetails={index === unlocked - 1}
+                      journey={journey}
+                      disabled={disabled}
+                      completionCount={completionCount}
+                      progressLevelNr={journeyInfo?.inProgress ? progressLevelNr : undefined}
+                      index={index}
+                      showAnimation={showJourneySelection}
+                      hasMapPiece={hasMapPiece}
+                      suggested={isSuggested}
+                      onClick={handleJourneySelect}
+                    >
+                      {journey.type === "treasure_tomb" && journeyInfo?.inProgress ? (
+                        <TableauInventory journeyInfo={journeyInfo} />
+                      ) : null}
+                    </JourneyCard>
+                  </div>
                 )
               })}
             </div>


### PR DESCRIPTION
## Summary

- When a journey is marked as suggested, the journey selection list now auto-scrolls to that card after the panel slides in
- Bumps version 0.23.2 → 0.23.3

## Details

The scroll fires 750ms after `showJourneySelection` becomes true (just after the 700ms CSS slide-in transition). Uses `scrollIntoView({ behavior: "smooth", block: "nearest" })` so it only scrolls as far as needed and doesn't overshoot if the card is already in view.

The suggested card is wrapped in a `div` with a ref — no changes needed to `JourneyCard`.

## Test plan

- [ ] Complete a tomb with missing hieroglyphs → click "Find missing hieroglyphs" → journey list opens and smoothly scrolls to the suggested expedition
- [ ] If the suggested journey is already visible at the top, no jarring scroll occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)