### PR TITLE
fix: journey card layout and tomb tablet multiplication guard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pyramid-scheme",
   "private": true,
-  "version": "0.23.3",
+  "version": "0.23.4",
   "type": "module",
   "scripts": {
     "dev": "vite --port 9164",

--- a/src/app/TombExpedition.tsx
+++ b/src/app/TombExpedition.tsx
@@ -72,6 +72,7 @@ export const TombExpedition: FC<{
       hieroglyphIds: tableau.inventoryIds,
       numberRange: journey.levelSettings.numberRange,
       operations: journey.levelSettings.operators,
+      maxMultiplyOperandResult: journey.levelSettings.maxMultiplyOperandResult,
     }
     const calc = generateRewardCalculation(settings, random)
     return calc

--- a/src/game/generateRewardCalculation.ts
+++ b/src/game/generateRewardCalculation.ts
@@ -17,6 +17,7 @@ export type RewardCalculationSettings = {
   hieroglyphIds: string[]
   numberRange: [min: number, max: number]
   operations: Operation[]
+  maxMultiplyOperandResult?: number
 }
 
 export type RewardCalculation = {
@@ -59,7 +60,11 @@ export const generateRewardCalculation = (
   // Step 2: Generate a formula where all symbols occur (maybe multiple times)
   const mainFormulaNumbers = generateCalculationNumbers(pickedNumbers.concat(bonus), pickedNumbers, [], random)
   const mainFormula = createSmallestVerifiedFormula(
-    { pickedNumbers: mainFormulaNumbers, operations: settings.operations },
+    {
+      pickedNumbers: mainFormulaNumbers,
+      operations: settings.operations,
+      maxMultiplyOperandResult: settings.maxMultiplyOperandResult,
+    },
     undefined, // no main formula yet
     random
   )
@@ -94,6 +99,7 @@ export const generateRewardCalculation = (
           pickedNumbers: calcNumbers,
           operations: operators,
           useResult: "allow",
+          maxMultiplyOperandResult: settings.maxMultiplyOperandResult,
         },
         mainFormula,
         random

--- a/src/ui/JourneyCard.tsx
+++ b/src/ui/JourneyCard.tsx
@@ -45,15 +45,18 @@ export const JourneyCard: FC<PropsWithChildren<JourneyCardProps>> = ({
     <button
       onClick={() => !disabled && onClick(journey)}
       disabled={disabled}
-      className={clsx("group flex flex-row rounded-lg border-l-0 text-left transition-all duration-300 contain-paint", {
-        "cursor-not-allowed border-gray-300 bg-gray-100 opacity-30 contrast-75 grayscale": disabled,
-        "border-gray-400 bg-gray-100 shadow-lg hover:scale-105 hover:border-gray-500 hover:shadow-xl":
-          !disabled && isTreasureTomb,
-        "border-amber-300 bg-amber-50 shadow-lg hover:scale-105 hover:border-amber-400 hover:shadow-xl":
-          !disabled && !isTreasureTomb,
-        "animate-slide-in-up": showAnimation,
-        "ring-2 ring-blue-400 ring-offset-2": suggested,
-      })}
+      className={clsx(
+        "group flex w-full flex-row rounded-lg border-l-0 text-left transition-all duration-300 contain-paint",
+        {
+          "cursor-not-allowed border-gray-300 bg-gray-100 opacity-30 contrast-75 grayscale": disabled,
+          "border-gray-400 bg-gray-100 shadow-lg hover:scale-105 hover:border-gray-500 hover:shadow-xl":
+            !disabled && isTreasureTomb,
+          "border-amber-300 bg-amber-50 shadow-lg hover:scale-105 hover:border-amber-400 hover:shadow-xl":
+            !disabled && !isTreasureTomb,
+          "animate-slide-in-up": showAnimation,
+          "ring-2 ring-blue-400 ring-offset-2": suggested,
+        }
+      )}
       style={{
         animationDelay: showAnimation ? `${index * 100}ms` : "0ms",
       }}

--- a/src/ui/JourneyCard.tsx
+++ b/src/ui/JourneyCard.tsx
@@ -60,7 +60,7 @@ export const JourneyCard: FC<PropsWithChildren<JourneyCardProps>> = ({
     >
       <div
         className={clsx(
-          "h-full w-4 flex-shrink-0",
+          "w-4 flex-shrink-0 self-stretch",
           journey.difficulty === "starter" && "bg-stone-500",
           journey.difficulty === "junior" && "bg-gradient-to-b from-orange-300 to-orange-400",
           journey.difficulty === "expert" && "bg-gradient-to-b from-slate-200 to-slate-400",
@@ -69,10 +69,15 @@ export const JourneyCard: FC<PropsWithChildren<JourneyCardProps>> = ({
         )}
       ></div>
       <div
-        className={clsx("flex-1 flex-col rounded-r-lg border-2 border-l-0 py-3 pr-3 pl-1", {
+        className={clsx("flex-1 flex-col rounded-r-lg py-3 pr-3 pl-1", {
+          "border-2 border-l-0": !suggested,
           "cursor-not-allowed border-gray-300 bg-gray-100 opacity-30 contrast-75 grayscale": disabled,
-          "border-gray-400 bg-gray-100 shadow-lg hover:border-gray-500 hover:shadow-xl": !disabled && isTreasureTomb,
-          "border-amber-300 bg-amber-50 shadow-lg hover:border-amber-400 hover:shadow-xl": !disabled && !isTreasureTomb,
+          "border-gray-400 bg-gray-100 shadow-lg hover:border-gray-500 hover:shadow-xl":
+            !disabled && isTreasureTomb && !suggested,
+          "border-amber-300 bg-amber-50 shadow-lg hover:border-amber-400 hover:shadow-xl":
+            !disabled && !isTreasureTomb && !suggested,
+          "bg-gray-100 shadow-lg": !disabled && isTreasureTomb && suggested,
+          "bg-amber-50 shadow-lg": !disabled && !isTreasureTomb && suggested,
         })}
       >
         {suggested && (


### PR DESCRIPTION
## Summary

- Fix difficulty-colored sidebar not rendering in `JourneyCard` — `h-full` resolved to 0 on an empty div in a flex container; replaced with `self-stretch`
- Fix inconsistent card widths in the journey list grid — added `w-full` to the button so it fills its grid cell
- Fix tomb tablet formulas allowing large multiplication operands (e.g. 29 × 8) — `maxMultiplyOperandResult` was only wired up to the crocodile/compare puzzle, not to `generateRewardCalculation` used by tablet puzzles

## Test plan

- [ ] Open journey list and verify cards all have the correct difficulty-colored left sidebar (stone/orange/slate/yellow/emerald)
- [ ] On a wide screen (xl breakpoint), verify all cards in the 2-column grid are the same width
- [ ] Play a wizard or master treasure tomb and verify no multiplication shows an operand larger than the configured limit (10 for master, 12 for wizard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)