### PR TITLE
fix: travel list hieroglyph counts now match tablet formula

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pyramid-scheme",
   "private": true,
-  "version": "0.23.4",
+  "version": "0.23.5",
   "type": "module",
   "scripts": {
     "dev": "vite --port 9164",

--- a/src/app/pages/TableauInventory.tsx
+++ b/src/app/pages/TableauInventory.tsx
@@ -33,6 +33,7 @@ export const TableauInventory: FC<{ journeyInfo: CombinedJourneyState }> = ({ jo
         hieroglyphIds: tableau.inventoryIds,
         numberRange: journey.levelSettings.numberRange,
         operations: journey.levelSettings.operators,
+        maxMultiplyOperandResult: journey.levelSettings.maxMultiplyOperandResult,
       },
       random
     )

--- a/src/game/generateRewardCalculation.spec.ts
+++ b/src/game/generateRewardCalculation.spec.ts
@@ -226,6 +226,53 @@ describe(generateRewardCalculation, () => {
     `)
   })
 
+  describe("maxMultiplyOperandResult", () => {
+    const collectMultiplyOperands = (formula: import("../app/Formulas/formulas").Formula): number[] => {
+      const results: number[] = []
+      const visit = (node: number | import("../app/Formulas/formulas").Formula | { symbol: number }) => {
+        if (typeof node === "number" || "symbol" in node) return
+        if (node.operation === "*") {
+          results.push(
+            typeof node.left === "number" ? node.left : "symbol" in node.left ? node.left.symbol : (visit(node.left), 0),
+            typeof node.right === "number" ? node.right : "symbol" in node.right ? node.right.symbol : (visit(node.right), 0)
+          )
+        }
+        visit(node.left)
+        visit(node.right)
+      }
+      visit(formula)
+      return results
+    }
+
+    it("constrains multiply operands across all formulas", () => {
+      const max = 5
+      const settings: RewardCalculationSettings = {
+        amountSymbols: 3,
+        numberRange: [1, 10],
+        hieroglyphIds: ["𓁧", "𓃯", "𓁝"],
+        operations: ["+", "*"],
+        maxMultiplyOperandResult: max,
+      }
+      const random = mulberry32(12345)
+      const result = generateRewardCalculation(settings, random)
+      const allFormulas = [result.mainFormula, ...result.hintFormulas]
+      const operands = allFormulas.flatMap(collectMultiplyOperands)
+      expect(operands.every(v => v <= max)).toBe(true)
+    })
+
+    it("produces different symbolCounts without the constraint", () => {
+      const base: RewardCalculationSettings = {
+        amountSymbols: 3,
+        numberRange: [1, 10],
+        hieroglyphIds: ["𓁧", "𓃯", "𓁝"],
+        operations: ["+", "*"],
+      }
+      const withConstraint = generateRewardCalculation({ ...base, maxMultiplyOperandResult: 5 }, mulberry32(12345))
+      const withoutConstraint = generateRewardCalculation(base, mulberry32(12345))
+      expect(withConstraint.symbolCounts).not.toEqual(withoutConstraint.symbolCounts)
+    })
+  })
+
   it("can generate a puzzle with low difficulty", () => {
     const settings: RewardCalculationSettings = {
       amountSymbols: 2,

--- a/src/game/generateRewardCalculation.spec.ts
+++ b/src/game/generateRewardCalculation.spec.ts
@@ -233,8 +233,16 @@ describe(generateRewardCalculation, () => {
         if (typeof node === "number" || "symbol" in node) return
         if (node.operation === "*") {
           results.push(
-            typeof node.left === "number" ? node.left : "symbol" in node.left ? node.left.symbol : (visit(node.left), 0),
-            typeof node.right === "number" ? node.right : "symbol" in node.right ? node.right.symbol : (visit(node.right), 0)
+            typeof node.left === "number"
+              ? node.left
+              : "symbol" in node.left
+                ? node.left.symbol
+                : (visit(node.left), 0),
+            typeof node.right === "number"
+              ? node.right
+              : "symbol" in node.right
+                ? node.right.symbol
+                : (visit(node.right), 0)
           )
         }
         visit(node.left)


### PR DESCRIPTION
## Summary
- `TableauInventory` was missing `maxMultiplyOperandResult` when calling `generateRewardCalculation`, while `TombExpedition` (the actual puzzle) passes it from `journey.levelSettings`
- When that setting is defined it causes formula candidates to be rejected during generation, advancing the RNG differently — so the two calls ended up with different formulas and different `symbolCounts`
- One-line fix: pass `maxMultiplyOperandResult` in `TableauInventory.tsx` to match `TombExpedition.tsx`

## Test plan
- [ ] Start a treasure tomb journey where `maxMultiplyOperandResult` is set in level settings
- [ ] Verify the travel list hieroglyph counts match the counts shown in the actual tomb puzzle
- [ ] Bump: 0.23.4 → 0.23.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)