### PR TITLE
refactor: extract buildTombCalculationSettings to keep formula inputs in sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pyramid-scheme",
   "private": true,
-  "version": "0.23.5",
+  "version": "0.23.6",
   "type": "module",
   "scripts": {
     "dev": "vite --port 9164",

--- a/src/app/PyramidLevel/inventoryLootLogic.ts
+++ b/src/app/PyramidLevel/inventoryLootLogic.ts
@@ -1,7 +1,7 @@
 import { type CombinedJourneyState } from "@/app/state/useJourneys"
 import { journeys, type TreasureTombJourney } from "@/data/journeys"
 import { tableauLevels, TOMB_SYMBOLS } from "@/data/tableaus"
-import { generateRewardCalculation } from "@/game/generateRewardCalculation"
+import { buildTombCalculationSettings, generateRewardCalculation } from "@/game/generateRewardCalculation"
 import { generateNewSeed, mulberry32, shuffle } from "@/game/random"
 import { getItemFirstLevel } from "@/data/itemLevelLookup"
 import { type Difficulty, difficultyCompare } from "@/data/difficultyLevels"
@@ -114,13 +114,10 @@ export const determineInventoryLootForCurrentRuns = (
 
     const seed = journeySeedGenerator(tombId)
     const tableauRandom = mulberry32(generateNewSeed(seed, currentLevel))
-    const settings = {
-      amountSymbols: tableau.symbolCount,
-      hieroglyphIds: tableau.inventoryIds,
-      numberRange: tombInfo.levelSettings.numberRange,
-      operations: tombInfo.levelSettings.operators,
-    }
-    const calculation = generateRewardCalculation(settings, tableauRandom)
+    const calculation = generateRewardCalculation(
+      buildTombCalculationSettings(tombInfo.levelSettings, tableau),
+      tableauRandom
+    )
 
     // add all symbols to itemsRequired
     Object.entries(calculation.symbolCounts).forEach(([symbol, count]) => {

--- a/src/app/TombExpedition.tsx
+++ b/src/app/TombExpedition.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "react-i18next"
 import { TombPuzzle } from "./TombLevel/TombPuzzle"
 import { useTableauTranslations } from "@/data/useTableauTranslations"
 import { generateNewSeed, mulberry32 } from "@/game/random"
-import { generateRewardCalculation } from "@/game/generateRewardCalculation"
+import { buildTombCalculationSettings, generateRewardCalculation } from "@/game/generateRewardCalculation"
 import type { TreasureTombJourney } from "@/data/journeys"
 import { ComparePuzzle } from "./TombLevel/ComparePuzzle"
 import { TombBackdrop } from "@/ui/TombBackdrop"
@@ -67,14 +67,7 @@ export const TombExpedition: FC<{
   const calculation = useMemo(() => {
     const random = mulberry32(seed)
     if (!tableau) return null
-    const settings = {
-      amountSymbols: tableau.symbolCount,
-      hieroglyphIds: tableau.inventoryIds,
-      numberRange: journey.levelSettings.numberRange,
-      operations: journey.levelSettings.operators,
-      maxMultiplyOperandResult: journey.levelSettings.maxMultiplyOperandResult,
-    }
-    const calc = generateRewardCalculation(settings, random)
+    const calc = generateRewardCalculation(buildTombCalculationSettings(journey.levelSettings, tableau), random)
     return calc
   }, [seed, tableau, journey.levelSettings])
 

--- a/src/app/pages/TableauInventory.tsx
+++ b/src/app/pages/TableauInventory.tsx
@@ -3,7 +3,7 @@ import { useJourneys, type CombinedJourneyState } from "../state/useJourneys"
 import { journeys, type TreasureTombJourney } from "@/data/journeys"
 import { useTableauTranslations } from "@/data/useTableauTranslations"
 import { generateNewSeed, mulberry32 } from "@/game/random"
-import { generateRewardCalculation } from "@/game/generateRewardCalculation"
+import { buildTombCalculationSettings, generateRewardCalculation } from "@/game/generateRewardCalculation"
 import { useInventory } from "../Inventory/useInventory"
 import { getInventoryItemById } from "@/data/inventory"
 import { getItemFirstLevel } from "@/data/itemLevelLookup"
@@ -27,16 +27,7 @@ export const TableauInventory: FC<{ journeyInfo: CombinedJourneyState }> = ({ jo
   const calculation = useMemo(() => {
     const random = mulberry32(seed)
     if (!journey || !tableau) return null
-    return generateRewardCalculation(
-      {
-        amountSymbols: tableau.symbolCount,
-        hieroglyphIds: tableau.inventoryIds,
-        numberRange: journey.levelSettings.numberRange,
-        operations: journey.levelSettings.operators,
-        maxMultiplyOperandResult: journey.levelSettings.maxMultiplyOperandResult,
-      },
-      random
-    )
+    return generateRewardCalculation(buildTombCalculationSettings(journey.levelSettings, tableau), random)
   }, [journey, seed, tableau])
 
   if (!journey || !calculation) {

--- a/src/game/generateRewardCalculation.spec.ts
+++ b/src/game/generateRewardCalculation.spec.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest"
-import { generateRewardCalculation, type RewardCalculationSettings } from "./generateRewardCalculation"
+import {
+  buildTombCalculationSettings,
+  generateRewardCalculation,
+  type RewardCalculationSettings,
+} from "./generateRewardCalculation"
 import { mulberry32 } from "./random"
 import { formulaToString } from "../app/Formulas/formulas"
 
@@ -278,6 +282,34 @@ describe(generateRewardCalculation, () => {
       const withConstraint = generateRewardCalculation({ ...base, maxMultiplyOperandResult: 5 }, mulberry32(12345))
       const withoutConstraint = generateRewardCalculation(base, mulberry32(12345))
       expect(withConstraint.symbolCounts).not.toEqual(withoutConstraint.symbolCounts)
+    })
+  })
+
+  describe("buildTombCalculationSettings", () => {
+    it("maps journey levelSettings and tableau to RewardCalculationSettings", () => {
+      const levelSettings = {
+        numberRange: [1, 10] as [number, number],
+        operators: ["+", "*"] as RewardCalculationSettings["operations"],
+        maxMultiplyOperandResult: 5,
+      }
+      const tableau = { symbolCount: 3, inventoryIds: ["𓁧", "𓃯", "𓁝"] }
+      expect(buildTombCalculationSettings(levelSettings, tableau)).toEqual({
+        amountSymbols: 3,
+        hieroglyphIds: ["𓁧", "𓃯", "𓁝"],
+        numberRange: [1, 10],
+        operations: ["+", "*"],
+        maxMultiplyOperandResult: 5,
+      })
+    })
+
+    it("forwards undefined maxMultiplyOperandResult", () => {
+      const levelSettings = {
+        numberRange: [1, 10] as [number, number],
+        operators: ["+"] as RewardCalculationSettings["operations"],
+      }
+      const tableau = { symbolCount: 2, inventoryIds: ["𓁧", "𓃯"] }
+      const settings = buildTombCalculationSettings(levelSettings, tableau)
+      expect(settings.maxMultiplyOperandResult).toBeUndefined()
     })
   })
 

--- a/src/game/generateRewardCalculation.ts
+++ b/src/game/generateRewardCalculation.ts
@@ -20,6 +20,28 @@ export type RewardCalculationSettings = {
   maxMultiplyOperandResult?: number
 }
 
+export type TombLevelSettings = {
+  numberRange: [min: number, max: number]
+  operators: Operation[]
+  maxMultiplyOperandResult?: number
+}
+
+export type TombTableauSettings = {
+  symbolCount: number
+  inventoryIds: string[]
+}
+
+export const buildTombCalculationSettings = (
+  levelSettings: TombLevelSettings,
+  tableau: TombTableauSettings
+): RewardCalculationSettings => ({
+  amountSymbols: tableau.symbolCount,
+  hieroglyphIds: tableau.inventoryIds,
+  numberRange: levelSettings.numberRange,
+  operations: levelSettings.operators,
+  maxMultiplyOperandResult: levelSettings.maxMultiplyOperandResult,
+})
+
 export type RewardCalculation = {
   pickedNumbers: number[]
   symbolMapping: Record<number, string>


### PR DESCRIPTION
## Summary
- All three callers of `generateRewardCalculation` that build settings from a journey (`TombExpedition`, `TableauInventory`, `inventoryLootLogic`) now use a shared `buildTombCalculationSettings(levelSettings, tableau)` helper
- Also fixes `inventoryLootLogic` which had the same missing `maxMultiplyOperandResult` bug as the previous PR (#70)
- Two new tests guard the helper: one verifies all fields are mapped correctly (including `maxMultiplyOperandResult`), one verifies `undefined` passes through

## Why
A future field added to `levelSettings` only needs to be wired up in one place instead of three — the bug fixed in #70 can't recur.

## Test plan
- [ ] All 15 tests in `generateRewardCalculation.spec.ts` pass
- [ ] `yarn check-types` clean
- [ ] `yarn lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)