### PR TITLE
Always deploy on manual release run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,9 @@ jobs:
 
   deploy:
     needs: release
-    if: needs.release.outputs.released == 'true'
+    # Always deploy on a successful manual run, even if there was nothing new to release —
+    # this is also the "just deploy current main" button.
+    if: needs.release.result == 'success'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary
- Removing `deploy.yml` (#75) also removed the only "just redeploy current main" trigger — `release.yml`'s `deploy` job only ran when the `release` job actually bumped the version.
- Since `release.yml` is `workflow_dispatch`-only (always a deliberate manual trigger), running it with nothing new to release is a reasonable way to ask for a plain redeploy. Changed `deploy`'s condition from `needs.release.outputs.released == 'true'` to `needs.release.result == 'success'`.

## Test plan
- [x] Validated the YAML parses correctly and the `if` condition is syntactically sound
- [ ] Merge, then manually trigger `release.yml` to confirm it deploys the current `main` (which has had no successful deploy yet due to the `deploy.yml` race)

https://claude.ai/code/session_014dtfjQTqmmnScZGtCnXM4e