### PR TITLE
Bump GitHub Actions to node24-based major versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,11 +14,11 @@ jobs:
     outputs:
       released: ${{ steps.check.outputs.skip == 'false' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
 
@@ -63,14 +63,14 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: main
       - name: Enable Corepack
         run: corepack enable
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22.x"
           cache: "yarn"
@@ -79,11 +79,11 @@ jobs:
       - name: Build
         run: yarn build
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: "./dist"
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,13 +17,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Enable Corepack
         run: corepack enable
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
 
@@ -54,7 +54,7 @@ jobs:
             echo "CHANGELOG_EOF" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: mshick/add-pr-comment@v2
+      - uses: mshick/add-pr-comment@v3
         if: github.base_ref == 'main' && steps.check_changelog.outputs.will_release == 'true'
         with:
           message: |
@@ -68,7 +68,7 @@ jobs:
 
             </details>
 
-      - uses: mshick/add-pr-comment@v2
+      - uses: mshick/add-pr-comment@v3
         if: github.base_ref == 'main' && steps.check_changelog.outputs.will_release == 'false'
         with:
           message: |
@@ -76,7 +76,7 @@ jobs:
 
             The `[Unreleased]` section in `CHANGELOG.md` is empty.
 
-      - uses: mshick/add-pr-comment@v2
+      - uses: mshick/add-pr-comment@v3
         if: github.base_ref != 'main' && github.base_ref != ''
         with:
           message: |
@@ -86,17 +86,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Enable Corepack
         run: corepack enable
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}


### PR DESCRIPTION
## Summary
Fixes the "Node.js 20 is deprecated" warnings seen on every workflow run by bumping each affected action to its current major version, all of which target the node24 runtime:

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | v7 |
| `actions/setup-node` | v4 | v6 |
| `actions/configure-pages` | v4 | v6 |
| `actions/upload-pages-artifact` | v3 | v5 |
| `actions/deploy-pages` | v4 | v5 |
| `actions/cache` | v4 | v6 |
| `mshick/add-pr-comment` | v2 | v3 |

Checked for breaking changes relevant to this repo's actual usage (inputs, permissions, output handling) — all are safe drop-ins here:
- `upload-pages-artifact` v4+ excludes dotfiles from the uploaded artifact by default. The only dotfiles produced in `dist/` are `.DS_Store` and `.gitkeep` — neither matters to the deployed site, and there's no `.nojekyll` in use.
- `add-pr-comment` v3 requires an explicit `pull-requests: write` permission — already declared on the job that uses it (`test.yml`'s `check-version` job).
- No relevant input/output renames for any of the other bumps at this usage.

## Test plan
- [x] Validated both workflow YAML files parse correctly
- [ ] Merge and confirm a subsequent `test.yml`/`release.yml` run shows no more Node 20 deprecation warnings

https://claude.ai/code/session_014dtfjQTqmmnScZGtCnXM4e