### PR TITLE
Fix corridor tap targets and interior re-exploration after revisit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Fix corridor corners in pyramid interiors being hard to tap on mobile.
+- Fix a completed pyramid's interior showing different corridors explored than when you left it, after revisiting it.
 
 ## 0.24.1 - 2026-07-03
 ### Fixed

--- a/src/app/SiteMap/SiteMapView.tsx
+++ b/src/app/SiteMap/SiteMapView.tsx
@@ -592,6 +592,10 @@ export const SiteMapView = ({
                   onClick={corridorClickable ? () => onCellClick(r, c) : undefined}
                   style={{ cursor: corridorClickable ? "pointer" : "default" }}
                 >
+                  {/* Invisible full-cell hit target — the corridor bar itself is too thin to tap reliably */}
+                  {corridorClickable && (
+                    <rect x={-CELL / 2} y={-CELL / 2} width={CELL} height={CELL} fill="transparent" />
+                  )}
                   <CorridorCellShape cell={cell} />
                   {cell.state === "reachable" && isCorner && <circle r={3} fill="#d0a840" opacity={0.85} />}
                 </g>

--- a/src/app/state/useJourneys.spec.ts
+++ b/src/app/state/useJourneys.spec.ts
@@ -163,3 +163,46 @@ describe("completeJourney", () => {
     expect(state[0].position).toBeNull()
   })
 })
+
+// ── getJourney: randomSeed stability for interior pyramids ────────────────────
+
+describe("getJourney randomSeed", () => {
+  const makeInteriorJourneyData = (id: string): TranslatedJourney =>
+    ({
+      ...makeJourneyData(id),
+      siteConfigs: [{}],
+    }) as TranslatedJourney
+
+  // createJourneysV3Api mirrors a hook that re-derives its return value from `journeys` on
+  // every render — so each read/mutation here gets a fresh api bound to the current state,
+  // the same way a component calling useJourneys() again after a state update would.
+  const makeStatefulApi = (stored: StoredJourneyStateV3, journeyData: TranslatedJourney[]) => {
+    let state = [stored]
+    return () =>
+      createJourneysV3Api({
+        journeys: state,
+        setJourneys: updater => {
+          state = typeof updater === "function" ? updater(state) : updater
+        },
+        journeyData,
+      })
+  }
+
+  it("keeps the same seed across a completion for an interior pyramid (site stays revisitable)", () => {
+    const stored = makeStoredJourney({ levelNr: REAL_LEVEL_COUNT + 1, completionCount: 0, active: true })
+    const freshApi = makeStatefulApi(stored, [makeInteriorJourneyData(REAL_ID)])
+    const seedBefore = freshApi().getJourney(REAL_ID)!.randomSeed
+    freshApi().completeJourney()
+    const seedAfter = freshApi().getJourney(REAL_ID)!.randomSeed
+    expect(seedAfter).toBe(seedBefore)
+  })
+
+  it("varies the seed across a completion for a non-interior journey (legacy repeat-run design)", () => {
+    const stored = makeStoredJourney({ levelNr: REAL_LEVEL_COUNT + 1, completionCount: 0, active: true })
+    const freshApi = makeStatefulApi(stored, [makeJourneyData(REAL_ID)])
+    const seedBefore = freshApi().getJourney(REAL_ID)!.randomSeed
+    freshApi().completeJourney()
+    const seedAfter = freshApi().getJourney(REAL_ID)!.randomSeed
+    expect(seedAfter).not.toBe(seedBefore)
+  })
+})

--- a/src/app/state/useJourneys.ts
+++ b/src/app/state/useJourneys.ts
@@ -92,17 +92,26 @@ export const createJourneysV3Api = ({
 }): JourneyAPI => {
   const activeJourneyId = journeys.find(j => j.active && knownJourneyIds.includes(j.journeyId))?.journeyId
 
+  // Pyramids with a site interior are meant to stay revisitable: the random seed must stay
+  // stable across replays so a previously explored site still matches on return.
+  const isInteriorPyramid = (journey: Journey) => journey.type === "pyramid" && !!journey.siteConfigs?.length
+
   const getJourney = (journeyId: string): CombinedJourneyState | undefined => {
     const journeyState = journeys.find(j => j.journeyId === journeyId)
     if (!journeyState) return undefined
     const journeyInfo = journeyData.find((j): j is TranslatedJourney => j.id === journeyId)
     if (!journeyInfo) return undefined
     const progressPercentage = Math.min(((journeyState.levelNr ?? 1) - 1) / journeyInfo.levelCount, 1)
+    // Interior pyramids are persistent, revisitable sites — their seed must never move, or a
+    // completed run's exploredSections stop matching the (now different) generated layout.
+    const randomSeed = isInteriorPyramid(journeyInfo)
+      ? generateNewSeed(hashString(journeyId), 1)
+      : generateNewSeed(hashString(journeyId), journeyState.completionCount + 1)
     return {
       ...journeyState,
       inProgress: journeyState.active,
       journey: journeyInfo,
-      randomSeed: generateNewSeed(hashString(journeyId), journeyState.completionCount + 1),
+      randomSeed,
       progressPercentage,
     }
   }
@@ -111,10 +120,6 @@ export const createJourneysV3Api = ({
     const info = getJourney(journeyId)
     return generateNewSeed(hashString(journeyId), (info?.completionCount ?? 0) + 1)
   }
-
-  // Pyramids with a site interior are meant to stay revisitable: the random seed must stay
-  // stable across replays so a previously explored site still matches on return.
-  const isInteriorPyramid = (journey: Journey) => journey.type === "pyramid" && !!journey.siteConfigs?.length
 
   const startJourney = (journey: Journey) => {
     const existing = journeys.find(j => j.journeyId === journey.id)


### PR DESCRIPTION
## Summary
- Enlarge the tap target for corridor corners in pyramid interiors — they were only clickable on the ~8px-wide corridor bar itself, way under any reasonable touch target size on mobile.
- Fix a completed interior pyramid's random seed changing on revisit: `randomSeed` was always derived from `completionCount + 1`, a leftover from the old repeat-run design. Completing an interior pyramid once already bumps `completionCount` from 0 to 1, which silently regenerated a *different* site layout on every subsequent visit — so previously explored corridors no longer matched, some showing explored that weren't and vice versa. Interior pyramids now use a fixed seed component, independent of `completionCount`; non-interior journeys (treasure tombs, legacy pyramids) keep their original per-completion seed variation since that's their intended design.
- Added a regression test (`getJourney randomSeed` in `useJourneys.spec.ts`) covering both the fixed (interior) and unchanged (non-interior) behavior.

## Test plan
- [x] `yarn check-types`
- [x] `yarn lint`
- [x] `yarn test run` (587 tests passing, including 2 new)
- [x] Manually verified in a browser: an offset click well outside the old corridor hit area now registers

https://claude.ai/code/session_014dtfjQTqmmnScZGtCnXM4e