### PR TITLE
Fix pending-loot badge on wrong room type; add Clear game data setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- A "Clear game data" option in Settings, for resetting your save without needing to clear app/browser storage manually.
+
 ### Fixed
 - Fix corridor corners in pyramid interiors being hard to tap on mobile.
 - Fix a completed pyramid's interior showing different corridors explored than when you left it, after revisiting it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Fix corridor corners in pyramid interiors being hard to tap on mobile.
+- Fix a completed pyramid's interior showing different corridors explored than when you left it, after revisiting it.
 
 ## 0.24.2 - 2026-07-03
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix corridor corners in pyramid interiors being hard to tap on mobile.
 - Fix a completed pyramid's interior showing different corridors explored than when you left it, after revisiting it.
+- Fix the "pack is full" chest marker sometimes showing up on puzzle rooms instead of the chest it belonged to.
 
 ## 0.24.2 - 2026-07-03
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A "Clear game data" option in Settings, for resetting your save without needing to clear app/browser storage manually.
 
 ### Fixed
-- Fix corridor corners in pyramid interiors being hard to tap on mobile.
-- Fix a completed pyramid's interior showing different corridors explored than when you left it, after revisiting it.
 - Fix the "pack is full" chest marker sometimes showing up on puzzle rooms instead of the chest it belonged to.
 
 ## 0.24.2 - 2026-07-03

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -65,6 +65,8 @@
     "language": "Language",
     "close": "Close",
     "done": "Done",
+    "clearGameData": "Clear game data",
+    "confirmClearGameData": "This permanently deletes all progress, items, and explored pyramids. This cannot be undone.",
     "progressLevel": "In Progress",
     "treasureTomb": "Treasure Location",
     "requiresMapPieces": "Requires map pieces",

--- a/public/locales/nl/common.json
+++ b/public/locales/nl/common.json
@@ -65,6 +65,8 @@
     "language": "Taal",
     "close": "Sluiten",
     "done": "Klaar",
+    "clearGameData": "Spelgegevens wissen",
+    "confirmClearGameData": "Dit verwijdert permanent alle voortgang, items en verkende piramides. Dit kan niet ongedaan worden gemaakt.",
     "progressLevel": "Voortgang",
     "treasureTomb": "Schatlokatie",
     "requiresMapPieces": "Vereist kaartdelen",

--- a/src/app/SettingsModal.tsx
+++ b/src/app/SettingsModal.tsx
@@ -1,6 +1,8 @@
 import { type FC, useState, useEffect } from "react"
 import { useTranslation } from "react-i18next"
 import { version } from "@/../package.json"
+import { clearGameData } from "@/support/useGameStorage"
+import { ConfirmModal } from "@/ui/ConfirmModal"
 
 type SettingsModalProps = {
   isOpen: boolean
@@ -10,6 +12,12 @@ type SettingsModalProps = {
 export const SettingsModal: FC<SettingsModalProps> = ({ isOpen, onClose }) => {
   const { t, i18n } = useTranslation("common")
   const [selectedLanguage, setSelectedLanguage] = useState(i18n.language)
+  const [showClearConfirm, setShowClearConfirm] = useState(false)
+
+  const handleClearGameData = async () => {
+    await clearGameData()
+    window.location.reload()
+  }
 
   // Update local state when i18n language changes
   useEffect(() => {
@@ -70,6 +78,16 @@ export const SettingsModal: FC<SettingsModalProps> = ({ isOpen, onClose }) => {
               ))}
             </select>
           </div>
+
+          {/* Clear game data */}
+          <div>
+            <button
+              onClick={() => setShowClearConfirm(true)}
+              className="w-full rounded-lg border border-red-300 px-4 py-2 font-medium text-red-600 transition-colors hover:bg-red-50"
+            >
+              {t("ui.clearGameData")}
+            </button>
+          </div>
         </div>
 
         <div className="mt-6 flex items-center justify-end gap-4">
@@ -82,6 +100,16 @@ export const SettingsModal: FC<SettingsModalProps> = ({ isOpen, onClose }) => {
           </button>
         </div>
       </div>
+
+      <ConfirmModal
+        isOpen={showClearConfirm}
+        title={t("ui.clearGameData")}
+        message={t("ui.confirmClearGameData")}
+        confirmText={t("ui.clearGameData")}
+        cancelText={t("ui.cancel")}
+        onConfirm={handleClearGameData}
+        onCancel={() => setShowClearConfirm(false)}
+      />
     </div>
   )
 }

--- a/src/app/SiteMap/SiteMapView.tsx
+++ b/src/app/SiteMap/SiteMapView.tsx
@@ -605,7 +605,14 @@ export const SiteMapView = ({
             // room cell
             const state = cell.state
             const isCompleted = state === "completed"
-            const isPending = isCompleted && (pendingCells?.has(`${r},${c}`) ?? false)
+            // Only ever a pending-loot marker for a treasure room with a consumable reward — this
+            // guards against stale coordinates in pendingCells (e.g. left over from before a site
+            // was regenerated) painting the badge onto whatever room now occupies that cell.
+            const isPending =
+              isCompleted &&
+              cell.roomType === "treasure" &&
+              cell.reward?.type === "consumable" &&
+              (pendingCells?.has(`${r},${c}`) ?? false)
             const clickable = onCellClick && (state === "reachable" || state === "completed")
             const roomR = nodeRadius[cell.roomType]
 

--- a/src/support/useGameStorage.ts
+++ b/src/support/useGameStorage.ts
@@ -1,6 +1,8 @@
-import { useOfflineStorage } from "@/support/useOfflineStorage"
+import { useOfflineStorage, clearOfflineStore } from "@/support/useOfflineStorage"
 
 const GAME_STORE = "pyramid-scheme-store"
 
 export const useGameStorage = <T>(key: string, initialValue: T | (() => T)) =>
   useOfflineStorage<T>(key, initialValue, GAME_STORE)
+
+export const clearGameData = (): Promise<void> => clearOfflineStore(GAME_STORE)

--- a/src/support/useOfflineStorage.ts
+++ b/src/support/useOfflineStorage.ts
@@ -8,6 +8,7 @@ type Store = {
   getItem: <T>(key: string) => Promise<T | null>
   setItem: <T>(key: string, value: T) => Promise<T | null>
   removeItem: (key: string) => Promise<void>
+  clear: () => Promise<void>
   subscribe: <T>(key: string, callback: (value: T) => void) => VoidFunction
 }
 
@@ -35,6 +36,9 @@ const getStore = (storeName: string): Store => {
       },
       removeItem: async key => {
         await forage.removeItem(key)
+      },
+      clear: async () => {
+        await forage.clear()
       },
       subscribe: <T>(key: string, callback: (value: T) => void) => {
         subscribers.push({ key, callback } as {
@@ -66,6 +70,11 @@ export const setOfflineValue = <T>(key: string, value: T, storeName = "defaultSt
 export const deleteOfflineValue = (key: string, storeName = "defaultStore"): Promise<void> => {
   const store = getStore(storeName)
   return store.removeItem(key)
+}
+
+export const clearOfflineStore = (storeName = "defaultStore"): Promise<void> => {
+  const store = getStore(storeName)
+  return store.clear()
 }
 
 export const useOfflineStorage = <T>(


### PR DESCRIPTION
## Summary
These commits were originally pushed to the `fixes` branch after PR #78 had already been squash-merged (and released as v0.24.2), so they never made it into `main`. Opening a fresh PR with just the remaining work, rebased cleanly onto current `main`.

- Fix the "pack is full" chest marker showing up on puzzle rooms instead of the treasure it belonged to — `pendingCells` only carried coordinates with no check that the room there is still a treasure room with a consumable reward, so any mismatched coordinate could paint the badge on whatever room occupies that cell.
- Add a "Clear game data" option to Settings (with confirmation) — useful on mobile where there's no easy way to clear a single site's storage, e.g. to recover from any leftover bad save state.

## Test plan
- [x] `yarn check-types`
- [x] `yarn lint`
- [x] `yarn test run` (587 tests passing)
- [x] Manually verified the Clear game data flow in a browser: confirm dialog, cancel path, and a real clear+reload producing a genuinely fresh app state

https://claude.ai/code/session_014dtfjQTqmmnScZGtCnXM4e