### PR TITLE
Give pyramid/tomb interiors organic, multi-cell rooms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+- Junctions, treasure rooms, staircases, and exits inside pyramid and tomb interiors now appear as larger, uniquely shaped rooms instead of uniform single tiles.
+- The corridor leading up to a locked gate now blends into the neighboring room instead of showing as a separate passage tile.
+- Interior corridors wind more naturally, with occasional wider junctions where several paths meet.
+
+### Added
+- Some interior rooms now display decorative dungeon details, such as statues or sarcophagi.
+
 ## 0.24.2 - 2026-07-03
 ### Fixed
 - Fix corridor corners in pyramid interiors being hard to tap on mobile.

--- a/docs/game-design/spritesheet-renderer-prep.md
+++ b/docs/game-design/spritesheet-renderer-prep.md
@@ -50,3 +50,34 @@ No stored state needed. `ExplorerDot` already has access to `from` and `to` posi
 outside those two files cares about the rendering primitive.
 
 **Spritesheet manifest** — a simple `Record<theme, { url: string; tileW: number; tileH: number; map: Record<tileName, [sx, sy]> }>` passed as a prop or loaded via a hook. No game-data coupling needed.
+
+**Room-space claiming (`buildRoomClaims` in `SiteMapView.tsx`)** — forks and dead-end
+treasure/stairhead/exit rooms already claim extra grid cells as real footprint (box-first
+3x3 including diagonals, falling back to an orthogonal flood-fill), purely derived at
+render time from the finished `FloorGrid` — see the function and its comments for the
+current rules, including the exception that absorbs a gate's one-cell approach corridor
+into the junction's own footprint. This is exactly the shape a sprite-tile pass needs, and
+the two per-cell values it needs are already computed today, just not carried as data yet:
+
+- **Autotile role** — the `open: Record<Direction, boolean>` bitmask computed per cell
+  (walls vs. openings) is already the Wang-tile/autotile index (e.g. "room top-left
+  corner", "corridor straight", "room center"). Nothing new to derive, just needs to be
+  exposed as a lookup key instead of directly driving rect/wall geometry.
+- **`kind: "room" | "corridor"`** — already computed per cell for floor tinting. Doubles
+  as the signal for where ambient overlays (dust puffs, light beams) and decorations are
+  allowed to scatter — corridors should stay bare, rooms (including claimed cells) can
+  carry them.
+
+Still missing, needed before sprite selection can be theme-aware:
+
+- **Area/ward styling** ("junior ward" reads as a noble wing, etc.) — cells already carry
+  a `sectionHash` from generation tracing back to their DSL section, but that hash is
+  currently just an opaque dedup key with no semantic meaning attached. Needs a lookup
+  built once from `FloorConfig`, e.g. `sectionHash → { difficulty, theme }`, threaded down
+  to the renderer alongside the `theme` prop from item 1 above.
+
+Proposed shape when this is picked up: one more pure, unit-testable function alongside
+`buildRoomClaims`, e.g. `selectTile(grid, claims, areaByHash, r, c) → { area, role, kind,
+decoration }`, called once per cell and consumed by the sprite renderer instead of the
+current inline rect/wall drawing. Rendering-layer only — no changes to `siteAssembler.ts`
+or the `FloorGrid` data model.

--- a/src/app/SiteMap/SiteMapView.tsx
+++ b/src/app/SiteMap/SiteMapView.tsx
@@ -1,7 +1,21 @@
-import { useEffect, useRef } from "react"
-import type { CellState, CorridorCell, FloorGrid, GateVariant, KeyColor, RoomType } from "../../game/siteTypes"
+import { useEffect, useMemo, useRef } from "react"
+import type {
+  CellState,
+  DecorationKind,
+  Direction,
+  FloorGrid,
+  GateVariant,
+  GridCell,
+  KeyColor,
+  RoomType,
+} from "../../game/siteTypes"
 import { revealAll } from "../../game/gridNavigation"
 import { ExplorerDot } from "./ExplorerDot"
+
+// Cells one step outside the grid are still real void for claiming purposes — a fork or
+// endpoint sitting on the map's edge shouldn't look artificially clipped next to one
+// that happens to have interior void around it. Anything beyond the grid is `empty`.
+const cellAt = (grid: FloorGrid, r: number, c: number): GridCell => grid.cells[r]?.[c] ?? { type: "empty" }
 
 type Props = {
   grid: FloorGrid
@@ -14,8 +28,6 @@ type Props = {
 }
 
 const CELL = 44
-const CORRIDOR_W = 8
-const CORRIDOR_INNER = 3
 
 const entranceFill: Record<CellState, string> = {
   fogged: "#1a1208",
@@ -311,41 +323,6 @@ const nodeRadius: Record<RoomType, number> = {
   exit: 12,
 }
 
-const NodeBackground = ({ type }: { type: RoomType }) => {
-  const bg = "#110d08"
-  const r = nodeRadius[type]
-  switch (type) {
-    case "entrance": {
-      const archPath = `M ${-r},${r} L ${-r},0 A ${r},${r} 0 0,1 ${r},0 L ${r},${r} Z`
-      return <path d={archPath} fill={bg} />
-    }
-    case "puzzle":
-    case "trap":
-    case "gate":
-      return <rect x={-r} y={-r} width={r * 2} height={r * 2} fill={bg} />
-    case "fork":
-      return <polygon points={`0,${-r} ${r},0 0,${r} ${-r},0`} fill={bg} />
-    case "treasure":
-      return <polygon points={`0,${-r} ${r},0 0,${r} ${-r},0`} fill={bg} />
-    case "stairhead": {
-      const cut = 5
-      const pts = [
-        `-${r - cut},-${r}`,
-        `${r - cut},-${r}`,
-        `${r},-${r - cut}`,
-        `${r},${r - cut}`,
-        `${r - cut},${r}`,
-        `-${r - cut},${r}`,
-        `-${r},${r - cut}`,
-        `-${r},-${r - cut}`,
-      ].join(" ")
-      return <polygon points={pts} fill={bg} />
-    }
-    case "exit":
-      return <circle r={r} fill={bg} />
-  }
-}
-
 const NodeShape = ({ type, state, gateVariant, keyColor, keyColors }: ShapeProps & { type: RoomType }) => {
   const p = { state, gateVariant, keyColor, keyColors }
   switch (type) {
@@ -472,48 +449,277 @@ const exitIcon: Record<CellState, string> = {
   completed: "#d0d850",
 }
 
-// ─── Corridor arms (shared by corridor cells and room cells) ──────────────────
+// ─── Floor tiles ────────────────────────────────────────────────────────────────
+// Every occupied cell (room or corridor) is a floor tile composited from a full-cell
+// fill plus 0-4 wall strips, chosen per side from the same `dirs` bitmask the future
+// sprite-tile renderer will use (see docs/game-design/spritesheet-renderer-prep.md).
 
-type ArmSet = ReadonlySet<"n" | "s" | "e" | "w">
+const ALL_DIRS: readonly Direction[] = ["n", "s", "e", "w"]
+const DIR_MOVES: Record<Direction, readonly [number, number]> = {
+  n: [-1, 0],
+  s: [1, 0],
+  e: [0, 1],
+  w: [0, -1],
+}
 
-const ConnectionStubs = ({ dirs, state }: { dirs: ArmSet; state: CellState }) => {
-  if (state === "fogged") return null
-  const HALF = CELL / 2
-  const HW = CORRIDOR_W / 2
-  const HI = CORRIDOR_INNER / 2
-  const armDefs = {
-    n: { ox: -HW, oy: -HALF, ow: CORRIDOR_W, oh: HALF + HW, ix: -HI, iy: -HALF, iw: CORRIDOR_INNER, ih: HALF + HI },
-    s: { ox: -HW, oy: -HW, ow: CORRIDOR_W, oh: HALF + HW, ix: -HI, iy: -HI, iw: CORRIDOR_INNER, ih: HALF + HI },
-    e: { ox: -HW, oy: -HW, ow: HALF + HW, oh: CORRIDOR_W, ix: -HI, iy: -HI, iw: HALF + HI, ih: CORRIDOR_INNER },
-    w: {
-      ox: -HALF - HW,
-      oy: -HW,
-      ow: HALF + HW,
-      oh: CORRIDOR_W,
-      ix: -HALF - HI,
-      iy: -HI,
-      iw: HALF + HI,
-      ih: CORRIDOR_INNER,
-    },
+// Forks and dead-end (leaf) treasure/stairhead/exit rooms claim adjacent grid cells as
+// part of their own footprint — real extra tiles, grid-aligned, rather than a rendering
+// stretch. That keeps every room shape made of whole cells, which is what the eventual
+// sprite-tile renderer needs to tile cleanly (see
+// docs/game-design/spritesheet-renderer-prep.md). Purely derived at render time from
+// the existing grid — no generation-side bookkeeping.
+const canClaimVoid = (roomType: RoomType, dirsSize: number): boolean =>
+  roomType === "fork" ||
+  ((roomType === "treasure" || roomType === "stairhead" || roomType === "exit") && dirsSize === 1)
+
+const ORTHO_OFFSETS: ReadonlyArray<readonly [number, number]> = [
+  [-1, 0],
+  [1, 0],
+  [0, -1],
+  [0, 1],
+]
+// Each diagonal offset paired with the two orthogonal offsets flanking it — a diagonal
+// only joins the claim if at least one flank "belongs" to the owner too (either also
+// claimed void, or the owner's own real corridor arm), otherwise it'd be a tile touching
+// the room by a single corner point with walls on all 4 sides (nothing to open toward),
+// which reads as a floating box rather than part of the room.
+const DIAGONAL_OFFSETS: ReadonlyArray<{
+  offset: readonly [number, number]
+  flanks: readonly [readonly [number, number], readonly [number, number]]
+}> = [
+  {
+    offset: [-1, -1],
+    flanks: [
+      [-1, 0],
+      [0, -1],
+    ],
+  },
+  {
+    offset: [-1, 1],
+    flanks: [
+      [-1, 0],
+      [0, 1],
+    ],
+  },
+  {
+    offset: [1, -1],
+    flanks: [
+      [1, 0],
+      [0, -1],
+    ],
+  },
+  {
+    offset: [1, 1],
+    flanks: [
+      [1, 0],
+      [0, 1],
+    ],
+  },
+]
+
+// A neighbor is claimable if it's genuine void (`empty`), or — the one exception — a
+// single corridor tile that only exists to *approach* a gate: either a real gate room
+// two steps away (revealed), or a corridor stub whose far side got masked to `empty`
+// because it leads into an undetected hidden section. Either way that corridor tile
+// reads better as the junction's own doorway than as a separate hallway segment.
+// Diagonal neighbors can only ever be void — a real edge is never diagonal.
+const isClaimableNeighbor = (grid: FloorGrid, ownerR: number, ownerC: number, nr: number, nc: number): boolean => {
+  const cell = cellAt(grid, nr, nc)
+  if (cell.type === "empty") return true
+  if (cell.type !== "corridor") return false
+  const dr = nr - ownerR,
+    dc = nc - ownerC
+  if (Math.abs(dr) + Math.abs(dc) !== 1) return false
+  const beyond = grid.cells[ownerR + dr * 2]?.[ownerC + dc * 2]
+  const leadsToGate = beyond?.type === "room" && beyond.roomType === "gate"
+  return leadsToGate || cell.dirs.size === 1
+}
+
+const OFFSET_TO_DIR: Record<string, Direction> = { "-1,0": "n", "1,0": "s", "0,-1": "w", "0,1": "e" }
+const edgeKey = (r1: number, c1: number, r2: number, c2: number): string => {
+  const a = `${r1},${c1}`,
+    b = `${r2},${c2}`
+  return a < b ? `${a}|${b}` : `${b}|${a}`
+}
+
+type RoomClaims = {
+  /** claimed-cell key ("r,c") -> owning room's key ("r,c") */
+  claimedBy: ReadonlyMap<string, string>
+  /** the one claimed cell (per owner) that carries the owner's decoration, if any */
+  decorationAt: ReadonlyMap<string, DecorationKind>
+  /** unordered cell-pair keys with no wall between them (owner<->claim, or diagonal<->flank) */
+  openEdges: ReadonlySet<string>
+}
+
+// Row-major scan so two nearby claimable rooms never fight over the same cell —
+// whichever comes first in reading order claims it. Each owner independently claims
+// whichever of its 8 immediate neighbors (sides + diagonals) are free — no flood-fill
+// beyond that ring, so the shape stays a direct "3x3 minus whatever's occupied" instead
+// of wandering off into open floor further away. A diagonal's flank can be either
+// claimed void or the owner's own real corridor arm — either way the diagonal ends up
+// visually flush with a wall the owner already has open, not floating by itself.
+const buildRoomClaims = (grid: FloorGrid): RoomClaims => {
+  const claimedBy = new Map<string, string>()
+  const decorationAt = new Map<string, DecorationKind>()
+  const openEdges = new Set<string>()
+  for (let r = 0; r < grid.rows; r++) {
+    for (let c = 0; c < grid.cols; c++) {
+      const cell = grid.cells[r][c]
+      if (cell.type !== "room" || !canClaimVoid(cell.roomType, cell.dirs.size)) continue
+      const ownerKey = `${r},${c}`
+      // decoration only ever lands on a genuine claim (void or diagonal), never on a
+      // flank corridor that's just being re-tinted below
+      const claims: Array<[number, number]> = []
+      // a real corridor arm used as a diagonal's flank keeps functioning as a normal
+      // passage (own state, own click behavior) but renders with the room's floor tint
+      // since it's now flush with the claimed diagonal beside it
+      const flankClaims: Array<[number, number]> = []
+      const claimedThisOwner = new Set<string>()
+      for (const [dr, dc] of ORTHO_OFFSETS) {
+        const nr = r + dr,
+          nc = c + dc
+        const key = `${nr},${nc}`
+        if (claimedBy.has(key) || !isClaimableNeighbor(grid, r, c, nr, nc)) continue
+        claims.push([nr, nc])
+        claimedThisOwner.add(key)
+        openEdges.add(edgeKey(r, c, nr, nc))
+      }
+      for (const {
+        offset: [dr, dc],
+        flanks,
+      } of DIAGONAL_OFFSETS) {
+        const nr = r + dr,
+          nc = c + dc
+        const key = `${nr},${nc}`
+        if (claimedBy.has(key) || !isClaimableNeighbor(grid, r, c, nr, nc)) continue
+        const attachedFlanks = flanks.filter(([fr, fc]) => {
+          if (claimedThisOwner.has(`${r + fr},${c + fc}`)) return true
+          return cell.dirs.has(OFFSET_TO_DIR[`${fr},${fc}`])
+        })
+        if (attachedFlanks.length === 0) continue
+        claims.push([nr, nc])
+        claimedThisOwner.add(key)
+        for (const [fr, fc] of attachedFlanks) {
+          const flankR = r + fr,
+            flankC = c + fc
+          const flankKey = `${flankR},${flankC}`
+          openEdges.add(edgeKey(nr, nc, flankR, flankC))
+          if (!claimedThisOwner.has(flankKey) && !claimedBy.has(flankKey)) {
+            flankClaims.push([flankR, flankC])
+            claimedThisOwner.add(flankKey)
+          }
+        }
+      }
+      if (cell.decoration && claims.length > 0) {
+        decorationAt.set(`${claims[0][0]},${claims[0][1]}`, cell.decoration)
+      }
+      for (const [nr, nc] of [...claims, ...flankClaims]) claimedBy.set(`${nr},${nc}`, ownerKey)
+    }
   }
+  return { claimedBy, decorationAt, openEdges }
+}
+
+const isOpenSide = (grid: FloorGrid, claims: RoomClaims, r: number, c: number, dir: Direction): boolean => {
+  const cell = cellAt(grid, r, c)
+  const [dr, dc] = DIR_MOVES[dir]
+  const nr = r + dr,
+    nc = c + dc
+  // a real graph edge is always open
+  if ((cell.type === "room" || cell.type === "corridor") && cell.dirs.has(dir)) return true
+  return claims.openEdges.has(edgeKey(r, c, nr, nc))
+}
+
+// A corridor is a "corner" (and thus a valid click target for corner-reveal/hidden-
+// passage interaction) whenever it isn't a plain straight-through segment.
+const isCorridorCorner = (dirs: ReadonlySet<Direction>): boolean =>
+  dirs.size !== 2 || !((dirs.has("n") && dirs.has("s")) || (dirs.has("e") && dirs.has("w")))
+
+// Corridors and rooms share the same wall/opening logic, but get different floor tints
+// so a room's footprint (fork/endpoint chambers included) reads as a distinct place —
+// not just "a wide stretch of hallway". Room floor is warmer/lighter than corridor floor.
+const corridorFloorFill: Record<CellState, string> = {
+  fogged: "#130c07",
+  visible: "#1e130a",
+  reachable: "#22160b",
+  completed: "#1c130a",
+}
+const roomFloorFill: Record<CellState, string> = {
+  fogged: "#1c130a",
+  visible: "#382412",
+  reachable: "#3f2a15",
+  completed: "#332210",
+}
+const WALL_COLOR = "#080502"
+const WALL_THICKNESS = 4
+
+const FloorTile = ({
+  state,
+  open,
+  kind,
+}: {
+  state: CellState
+  open: Record<Direction, boolean>
+  kind: "room" | "corridor"
+}) => {
+  const half = CELL / 2
+  const fill = kind === "room" ? roomFloorFill[state] : corridorFloorFill[state]
   return (
     <>
-      {(["n", "s", "e", "w"] as const)
-        .filter(d => dirs.has(d))
-        .map(dir => {
-          const a = armDefs[dir]
-          return (
-            <g key={dir}>
-              <rect x={a.ox} y={a.oy} width={a.ow} height={a.oh} fill="#2a1e12" />
-              <rect x={a.ix} y={a.iy} width={a.iw} height={a.ih} fill="#3a2a18" />
-            </g>
-          )
-        })}
+      <rect x={-half} y={-half} width={CELL} height={CELL} fill={fill} />
+      {!open.n && <rect x={-half} y={-half} width={CELL} height={WALL_THICKNESS} fill={WALL_COLOR} />}
+      {!open.s && <rect x={-half} y={half - WALL_THICKNESS} width={CELL} height={WALL_THICKNESS} fill={WALL_COLOR} />}
+      {!open.w && <rect x={-half} y={-half} width={WALL_THICKNESS} height={CELL} fill={WALL_COLOR} />}
+      {!open.e && <rect x={half - WALL_THICKNESS} y={-half} width={WALL_THICKNESS} height={CELL} fill={WALL_COLOR} />}
     </>
   )
 }
 
-const CorridorCellShape = ({ cell }: { cell: CorridorCell }) => <ConnectionStubs dirs={cell.dirs} state={cell.state} />
+// ─── Decorations ────────────────────────────────────────────────────────────────
+// Placeholder glyphs only — real sprite art arrives with the sprite-tile renderer
+// migration (see docs/game-design/spritesheet-renderer-prep.md). Rendered centered in
+// the room's first genuine claim (void or diagonal — never a flank corridor, see
+// buildRoomClaims above).
+
+const DECORATION_COLOR = "#5a4a30"
+
+const DecorationGlyph = ({ kind }: { kind: DecorationKind }) => {
+  switch (kind) {
+    case "sarcophagus":
+      return (
+        <rect x={-6} y={-10} width={12} height={20} rx={4} fill="none" stroke={DECORATION_COLOR} strokeWidth={1.5} />
+      )
+    case "statue":
+      return (
+        <>
+          <circle cy={-8} r={4} fill="none" stroke={DECORATION_COLOR} strokeWidth={1.5} />
+          <rect x={-4} y={-4} width={8} height={14} fill="none" stroke={DECORATION_COLOR} strokeWidth={1.5} />
+        </>
+      )
+    case "fountain":
+      return (
+        <>
+          <circle r={9} fill="none" stroke={DECORATION_COLOR} strokeWidth={1.5} />
+          <circle r={3} fill={DECORATION_COLOR} />
+        </>
+      )
+    case "pit":
+      return <ellipse rx={9} ry={7} fill="#0a0604" stroke={DECORATION_COLOR} strokeWidth={1.5} />
+    case "rubble":
+      return (
+        <>
+          <circle cx={-4} cy={2} r={3} fill={DECORATION_COLOR} opacity={0.7} />
+          <circle cx={3} cy={-2} r={4} fill={DECORATION_COLOR} opacity={0.7} />
+          <circle cx={2} cy={5} r={2.5} fill={DECORATION_COLOR} opacity={0.7} />
+        </>
+      )
+    case "pillar":
+      return <rect x={-4} y={-10} width={8} height={20} fill="none" stroke={DECORATION_COLOR} strokeWidth={1.5} />
+    case "chestProp":
+      return (
+        <rect x={-6} y={-5} width={12} height={10} rx={1} fill="none" stroke={DECORATION_COLOR} strokeWidth={1.5} />
+      )
+  }
+}
 
 // ─── Component ────────────────────────────────────────────────────────────────
 
@@ -528,8 +734,12 @@ export const SiteMapView = ({
   const grid = revealAllCells ? revealAll(gridProp) : gridProp
   const scrollRef = useRef<HTMLDivElement>(null)
   const svgRef = useRef<SVGSVGElement>(null)
+  const claims = useMemo(() => buildRoomClaims(grid), [grid])
 
-  const PAD = 30
+  // Must be >= CELL: a fork/endpoint on the map's edge can claim one cell of "outside
+  // the grid" void (see cellAt above), and that extra ring needs to physically fit
+  // within the padding margin without clipping.
+  const PAD = CELL
   const svgWidth = grid.cols * CELL + PAD * 2
   const svgHeight = grid.rows * CELL + PAD * 2
 
@@ -571,18 +781,68 @@ export const SiteMapView = ({
         </defs>
         <rect width={svgWidth} height={svgHeight} fill="url(#stone)" />
 
-        {Array.from({ length: grid.rows }, (_, r) =>
-          Array.from({ length: grid.cols }, (_, c) => {
-            const cell = grid.cells[r][c]
-            if (cell.type === "empty") return null
-
+        {Array.from({ length: grid.rows + 2 }, (_, ri) => {
+          const r = ri - 1
+          return Array.from({ length: grid.cols + 2 }, (_, ci) => {
+            const c = ci - 1
+            const cell = cellAt(grid, r, c)
             const cx = PAD + c * CELL + CELL / 2
             const cy = PAD + r * CELL + CELL / 2
+            const cellKey = `${r},${c}`
+            const claimOwnerKey = claims.claimedBy.get(cellKey)
+
+            // A cell claimed by a neighboring room — genuine void (including one step
+            // outside the grid), or a corridor absorbed as a gate's approach or a
+            // diagonal's flank anchor (see buildRoomClaims) — renders as part of that
+            // room, always, using the OWNER's state for the floor tint. The claim shape
+            // is a static function of the finished grid (independent of exploration
+            // progress), so the whole blob must render as a single visual unit — hiding
+            // a claimed corridor while its own fog state lags behind the owner's is what
+            // punched the "spotty" holes in an otherwise-explored room. Click/interaction
+            // still uses the corridor's own state, since it's a real, independently
+            // progressed passage for gameplay purposes even though it looks unified.
+            if (claimOwnerKey && (cell.type === "empty" || cell.type === "corridor")) {
+              const [ownerRow, ownerCol] = claimOwnerKey.split(",").map(Number)
+              const owner = grid.cells[ownerRow]?.[ownerCol]
+              if (!owner || owner.type !== "room") return null
+              const state = owner.state
+              const open = Object.fromEntries(ALL_DIRS.map(d => [d, isOpenSide(grid, claims, r, c, d)])) as Record<
+                Direction,
+                boolean
+              >
+              const decoration = claims.decorationAt.get(cellKey)
+              const isCorner = cell.type === "corridor" && isCorridorCorner(cell.dirs)
+              const corridorClickable =
+                cell.type === "corridor" &&
+                onCellClick &&
+                (cell.state === "reachable" || cell.state === "completed") &&
+                isCorner
+              return (
+                <g
+                  key={cellKey}
+                  transform={`translate(${cx}, ${cy})`}
+                  onClick={corridorClickable ? () => onCellClick(r, c) : undefined}
+                  style={{ cursor: corridorClickable ? "pointer" : "default" }}
+                >
+                  <FloorTile state={state} open={open} kind="room" />
+                  {cell.type === "corridor" && cell.state === "reachable" && isCorner && (
+                    <circle r={3} fill="#d0a840" opacity={0.85} />
+                  )}
+                  {decoration && state !== "fogged" && <DecorationGlyph kind={decoration} />}
+                </g>
+              )
+            }
+
+            if (cell.type === "empty") return null
+
+            const open = Object.fromEntries(ALL_DIRS.map(d => [d, isOpenSide(grid, claims, r, c, d)])) as Record<
+              Direction,
+              boolean
+            >
 
             if (cell.type === "corridor") {
-              const isCorner =
-                cell.dirs.size !== 2 ||
-                !((cell.dirs.has("n") && cell.dirs.has("s")) || (cell.dirs.has("e") && cell.dirs.has("w")))
+              if (cell.state === "fogged") return null
+              const isCorner = isCorridorCorner(cell.dirs)
               const corridorClickable =
                 onCellClick && (cell.state === "reachable" || cell.state === "completed") && isCorner
               return (
@@ -592,11 +852,7 @@ export const SiteMapView = ({
                   onClick={corridorClickable ? () => onCellClick(r, c) : undefined}
                   style={{ cursor: corridorClickable ? "pointer" : "default" }}
                 >
-                  {/* Invisible full-cell hit target — the corridor bar itself is too thin to tap reliably */}
-                  {corridorClickable && (
-                    <rect x={-CELL / 2} y={-CELL / 2} width={CELL} height={CELL} fill="transparent" />
-                  )}
-                  <CorridorCellShape cell={cell} />
+                  <FloorTile state={cell.state} open={open} kind="corridor" />
                   {cell.state === "reachable" && isCorner && <circle r={3} fill="#d0a840" opacity={0.85} />}
                 </g>
               )
@@ -616,8 +872,7 @@ export const SiteMapView = ({
                 onClick={clickable ? () => onCellClick(r, c) : undefined}
                 style={{ cursor: clickable ? "pointer" : "default" }}
               >
-                <ConnectionStubs dirs={cell.dirs} state={state} />
-                <NodeBackground type={cell.roomType} />
+                <FloorTile state={state} open={open} kind="room" />
                 <g opacity={isCompleted && !isPending ? 0.45 : 1}>
                   <NodeShape
                     type={cell.roomType}
@@ -634,7 +889,7 @@ export const SiteMapView = ({
               </g>
             )
           })
-        )}
+        })}
 
         {explorerPos && <ExplorerDot grid={grid} pos={explorerPos} />}
       </svg>

--- a/src/game/siteAssembler.spec.ts
+++ b/src/game/siteAssembler.spec.ts
@@ -197,6 +197,68 @@ describe(assembleFloor, () => {
     }
   })
 
+  describe("multi-cell footprints", () => {
+    it("assigns decorations from the section's authored pool, on the fork/endpoint's own room cell", () => {
+      const config: FloorConfig = {
+        pathPuzzles: 0,
+        difficulty: "starter",
+        end: "treasure",
+        exitOrStaircase: "exit",
+        sideSections: [
+          { pathPuzzles: 0, difficulty: "starter", end: "treasure", decorations: ["sarcophagus"] },
+          {
+            pathPuzzles: 1,
+            difficulty: "junior",
+            end: "staircase",
+            gate: { type: "floor-key" },
+            decorations: ["statue"],
+          },
+        ],
+      }
+      let sawDecoration = false
+      for (let seed = 0; seed < 30; seed++) {
+        const result = assembleFloor(`site-${seed}`, config, seed)
+        if (!result.success) continue
+        const decorations = result.grid.cells
+          .flat()
+          .flatMap(cell => (cell.type === "room" ? [cell.decoration] : []))
+          .filter(Boolean)
+        if (decorations.length > 0) {
+          sawDecoration = true
+          for (const d of decorations) expect(["sarcophagus", "statue"]).toContain(d)
+        }
+      }
+      expect(sawDecoration).toBe(true)
+    })
+
+    it("bundles some side sections onto a shared hub fork with a carved 4-way junction", () => {
+      const config: FloorConfig = {
+        pathPuzzles: 2,
+        difficulty: "starter",
+        end: "treasure",
+        exitOrStaircase: "exit",
+        sideSections: [
+          { pathPuzzles: 1, difficulty: "starter", end: "treasure" },
+          { pathPuzzles: 1, difficulty: "starter", end: "treasure" },
+          { pathPuzzles: 0, difficulty: "starter", end: "treasure" },
+          { pathPuzzles: 0, difficulty: "starter", end: "treasure" },
+          { pathPuzzles: 1, difficulty: "junior", end: "staircase", gate: { type: "floor-key" } },
+        ],
+      }
+      let sawHub = false
+      for (let seed = 0; seed < 60; seed++) {
+        const result = assembleFloor(`site-${seed}`, config, seed)
+        if (!result.success) continue
+        const v = validateSite(result.grid)
+        expect(v.valid, `seed ${seed} failed validation: ${JSON.stringify(v)}`).toBe(true)
+        if (result.grid.cells.flat().some(c => c.type === "room" && c.roomType === "fork" && c.dirs.size === 4)) {
+          sawHub = true
+        }
+      }
+      expect(sawHub).toBe(true)
+    })
+  })
+
   describe("trap rooms", () => {
     it("places trap rooms for a trapped section", () => {
       const config: FloorConfig = {

--- a/src/game/siteAssembler.ts
+++ b/src/game/siteAssembler.ts
@@ -11,6 +11,7 @@ import type {
   KeyColor,
   SubSection,
   SideSection,
+  DecorationKind,
 } from "./siteTypes"
 import { validateSite } from "./siteValidator"
 
@@ -53,12 +54,26 @@ const DIRS: Array<[number, number]> = [
   [0, -1],
 ]
 
-const DIRMAP: Array<[number, number, Direction]> = [
-  [-1, 0, "n"],
-  [0, 1, "e"],
-  [1, 0, "s"],
-  [0, -1, "w"],
+// Real path nodes live only on even/even grid coordinates, two cells apart in any
+// direction — the cell directly between two connected nodes is a plain corridor
+// connector. This guarantees a genuine empty gap wherever the maze winds back near
+// itself (a switchback's two strands are never directly adjacent, only ever
+// diagonally so), instead of a dense maze where every single cell is real path and
+// parallel strands can end up touching with nothing but a thin wall between them.
+const NODE_STEP = 2
+const DIRS2: Array<[number, number]> = [
+  [-NODE_STEP, 0],
+  [0, NODE_STEP],
+  [NODE_STEP, 0],
+  [0, -NODE_STEP],
 ]
+const CONNECTOR_DIRS: Array<[number, number, Direction]> = [
+  [-NODE_STEP, 0, "n"],
+  [0, NODE_STEP, "e"],
+  [NODE_STEP, 0, "s"],
+  [0, -NODE_STEP, "w"],
+]
+const OPPOSITE: Record<Direction, Direction> = { n: "s", s: "n", e: "w", w: "e" }
 
 const makePkey = (N: number) => (r1: number, c1: number, r2: number, c2: number) => {
   const a = r1 * N + c1,
@@ -66,33 +81,45 @@ const makePkey = (N: number) => (r1: number, c1: number, r2: number, c2: number)
   return a < b ? `${a}-${b}` : `${b}-${a}`
 }
 
+// How often the DFS continues in the same direction instead of turning, when it can.
+// A plain random-direction DFS maze is very serpentine (every step is a coin flip);
+// biasing toward straight runs gives longer corridors and fewer forced turns, which
+// reads as "a real place" and needs fewer click-to-reveal stops on first traversal.
+const STRAIGHT_BIAS = 0.65
+
 // Generate a perfect DFS maze on an N×N grid starting from (entR, entC).
 // Returns adjacency function, BFS path from entrance to farthest cell, and passages set.
 const buildMaze = (N: number, entR: number, entC: number, rand: () => number) => {
   const passages = new Set<string>()
   const visited = new Set<string>()
   const pkey = makePkey(N)
+  // Direction of travel used to reach each visited cell, for the straightness bias.
+  const arrivedVia = new Map<string, [number, number]>()
 
   // ponytail: iterative DFS avoids stack overflow for large N
   const stack: Array<[number, number]> = [[entR, entC]]
   visited.add(`${entR},${entC}`)
   while (stack.length > 0) {
     const [r, c] = stack[stack.length - 1]
-    const unvisited = DIRS.map(([dr, dc]) => [r + dr, c + dc] as [number, number]).filter(
+    const unvisited = DIRS2.map(([dr, dc]) => [r + dr, c + dc] as [number, number]).filter(
       ([nr, nc]) => nr >= 0 && nr < N && nc >= 0 && nc < N && !visited.has(`${nr},${nc}`)
     )
     if (unvisited.length === 0) {
       stack.pop()
     } else {
-      const [nr, nc] = unvisited[Math.floor(rand() * unvisited.length)]
+      const incoming = arrivedVia.get(`${r},${c}`)
+      const straightAhead = incoming && unvisited.find(([nr, nc]) => nr - r === incoming[0] && nc - c === incoming[1])
+      const [nr, nc] =
+        straightAhead && rand() < STRAIGHT_BIAS ? straightAhead : unvisited[Math.floor(rand() * unvisited.length)]
       passages.add(pkey(r, c, nr, nc))
       visited.add(`${nr},${nc}`)
+      arrivedVia.set(`${nr},${nc}`, [nr - r, nc - c])
       stack.push([nr, nc])
     }
   }
 
   const neighbors = (r: number, c: number): Array<[number, number]> =>
-    DIRS.map(([dr, dc]) => [r + dr, c + dc] as [number, number]).filter(
+    DIRS2.map(([dr, dc]) => [r + dr, c + dc] as [number, number]).filter(
       ([nr, nc]) => nr >= 0 && nr < N && nc >= 0 && nc < N && passages.has(pkey(r, c, nr, nc))
     )
 
@@ -127,14 +154,19 @@ const buildMaze = (N: number, entR: number, entC: number, rand: () => number) =>
 }
 
 // Find a chain of `count` cells starting from (startR, startC),
-// extending through available maze neighbors not in usedCells.
+// extending through available maze neighbors not in usedCells. The final cell in the
+// chain becomes a section/sub-section endpoint, which later wants a multi-cell footprint
+// (see the claiming pass in assembleFloor) — so when a `scorer` is given, the last step
+// is biased toward a neighbor with more surrounding open space, same idea as fork
+// placement above. Every other step stays a plain random shuffle.
 const extendPath = (
   startR: number,
   startC: number,
   count: number,
   neighbors: (r: number, c: number) => Array<[number, number]>,
   usedCells: Set<string>,
-  rand: () => number
+  rand: () => number,
+  scorer?: (r: number, c: number) => number
 ): Array<[number, number]> | null => {
   if (count === 0) return []
   const result: Array<[number, number]> = []
@@ -142,9 +174,14 @@ const extendPath = (
 
   const dfs = (r: number, c: number, remaining: number): boolean => {
     if (remaining === 0) return true
-    const nbrs = neighbors(r, c)
-      .filter(([nr, nc]) => !tempUsed.has(`${nr},${nc}`))
-      .sort(() => rand() - 0.5)
+    const free = neighbors(r, c).filter(([nr, nc]) => !tempUsed.has(`${nr},${nc}`))
+    const nbrs =
+      remaining === 1 && scorer
+        ? free
+            .map(n => ({ n, score: scorer(n[0], n[1]) + rand() * 3 }))
+            .sort((a, b) => b.score - a.score)
+            .map(({ n }) => n)
+        : free.sort(() => rand() - 0.5)
     for (const [nr, nc] of nbrs) {
       tempUsed.add(`${nr},${nc}`)
       result.push([nr, nc])
@@ -188,7 +225,8 @@ export const assembleFloor = (siteId: string, config: FloorConfig, seed: number)
   // Build the ordered sequence of intermediate main-path node types
   const intermediateTypes = buildIntermediateTypes(config.pathPuzzles, config.chestEvery ?? 0)
 
-  // Minimum cells needed (nodes only, sections may need extra for branching)
+  // Minimum node count needed (real path nodes only — the connector cell between two
+  // adjacent nodes lives at a separate, non-node grid position, see NODE_STEP above).
   const minCells =
     1 + // entrance
     intermediateTypes.length +
@@ -196,19 +234,36 @@ export const assembleFloor = (siteId: string, config: FloorConfig, seed: number)
     1 + // exit/stairhead
     sideSections.reduce((sum, sec) => {
       const si = buildIntermediateTypes(sec.pathPuzzles, sec.chestEvery ?? 0)
-      const rc = si.length + 1 + (sec.gate ? 1 : 0)
-      const secCells = rc <= 1 ? rc : (rc - 1) * 2 + 1
+      const secCells = si.length + 1 + (sec.gate ? 1 : 0)
       const subCells = (sec.sideSections ?? []).reduce((s2, sub) => {
         const subI = buildIntermediateTypes(sub.pathPuzzles, sub.chestEvery ?? 0)
-        const subRc = subI.length + 1 + (sub.gate ? 1 : 0)
-        return s2 + (subRc <= 1 ? subRc : (subRc - 1) * 2 + 1)
+        return s2 + subI.length + 1 + (sub.gate ? 1 : 0)
       }, 0)
       return sum + secCells + subCells
     }, 0)
 
-  // Derive odd grid size: enough cells + padding for layout freedom
+  // Rough count of fork/endpoint rooms that will want a decorative multi-cell footprint
+  // later (see footprint-claiming pass below) — a one-pass estimate is fine since that
+  // pass is best-effort (claims whatever's free, never fails).
+  const subSectionCount = sideSections.reduce((s, sec) => s + (sec.sideSections?.length ?? 0), 0)
+  const expectedFootprintRooms =
+    sideSections.length /* forks */ +
+    2 /* main end + exit */ +
+    sideSections.length /* section ends */ +
+    subSectionCount /* sub-section ends */
+  const FOOTPRINT_SLACK_PER_ROOM = 2
+
+  // Derive odd grid size. Only even/even positions can hold a real node (see NODE_STEP
+  // above), so usable node capacity is ((N+1)/2)^2, not N^2 — the grid needs to be
+  // noticeably bigger than the old dense model for the same amount of content, which
+  // is exactly the point: the odd-position lattice between nodes is what guarantees a
+  // genuine gap wherever the path winds back near itself.
   let N = 3
-  while (N * N < minCells + N + sideSections.length) N += 2
+  while (
+    Math.pow((N + 1) / 2, 2) <
+    minCells * 4 + (N + 1) / 2 + sideSections.length + expectedFootprintRooms * FOOTPRINT_SLACK_PER_ROOM
+  )
+    N += 2
 
   const nid = (r: number, c: number) => `${siteId}-${r}-${c}`
 
@@ -218,13 +273,14 @@ export const assembleFloor = (siteId: string, config: FloorConfig, seed: number)
     const rand = mulberry32(seed + attempt * 7919)
     const pkey = makePkey(N)
 
-    // Pick entrance from edge cells (non-corner preferred for more connections)
+    // Pick entrance from edge cells (non-corner preferred for more connections).
+    // Must be an even/even position — the only kind of cell that can be a real node.
     const edgeCells: Array<[number, number]> = []
-    for (let r = 0; r < N; r++) {
+    for (let r = 0; r < N; r += 2) {
       edgeCells.push([r, 0])
       edgeCells.push([r, N - 1])
     }
-    for (let c = 1; c < N - 1; c++) {
+    for (let c = 2; c < N - 1; c += 2) {
       edgeCells.push([0, c])
       edgeCells.push([N - 1, c])
     }
@@ -232,15 +288,15 @@ export const assembleFloor = (siteId: string, config: FloorConfig, seed: number)
 
     const { neighbors, mainPath, passages } = buildMaze(N, entR, entC, rand)
 
-    // Stride-2 spacing: 1 corridor between each room.
     // Exit placed at the farthest dead-end (degree-1) so no corridor passes through it.
+    // mainPath is already a sequence of directly-connected nodes (see buildMaze), so
+    // the main-path content nodes are just its first interLen+2 entries, taken directly
+    // — no stride multiplication needed like the old dense model required.
     const interLen = intermediateTypes.length
-    const minPathLen = interLen * 2 + 3
-    if (mainPath.length < minPathLen + 1) continue
+    const goalIndex = interLen + 1 // 0 = entrance, 1..interLen = intermediates, interLen+1 = goal
+    if (mainPath.length < goalIndex + 2) continue // need >=1 more node past the goal, for a distinct exit
 
-    const mainNodeCells: Array<[number, number]> = [mainPath[0]]
-    for (let i = 0; i < interLen; i++) mainNodeCells.push(mainPath[(i + 1) * 2])
-    mainNodeCells.push(mainPath[minPathLen - 1])
+    const mainNodeCells: Array<[number, number]> = mainPath.slice(0, goalIndex + 1)
 
     // Full mainPath as corridor so sections can branch from anywhere along it
     const usedCells = new Set<string>(mainPath.map(([r, c]) => `${r},${c}`))
@@ -264,42 +320,119 @@ export const assembleFloor = (siteId: string, config: FloorConfig, seed: number)
       if (!hasAdj) continue
       branchCandidates.push({ pathCell: [pr, pc] })
     }
-    const shuffledCandidates = [...branchCandidates].sort(() => rand() - 0.5)
-
-    for (let si = 0; si < sideSections.length; si++) {
-      const section = sideSections[si]
-      const secIntermediate = buildIntermediateTypes(section.pathPuzzles, section.chestEvery ?? 0)
-      const roomCount = secIntermediate.length + 1 + (section.gate ? 1 : 0)
-      const needed = roomCount <= 1 ? roomCount : (roomCount - 1) * 2 + 1
-      let placed = false
-
-      for (const {
-        pathCell: [pcr, pcc],
-      } of shuffledCandidates) {
-        const freeAdj = neighbors(pcr, pcc)
-          .filter(([ar, ac]) => !usedCells.has(`${ar},${ac}`))
-          .sort(() => rand() - 0.5)
-        if (freeAdj.length === 0) continue
-
-        for (const [startR, startC] of freeAdj) {
-          usedCells.add(`${startR},${startC}`)
-          const rest = extendPath(startR, startC, needed - 1, neighbors, usedCells, rand)
-          if (rest === null) {
-            usedCells.delete(`${startR},${startC}`)
-            continue
-          }
-          const cells: Array<[number, number]> = [[startR, startC], ...rest]
-          cells.slice(1).forEach(([r, c]) => usedCells.add(`${r},${c}`))
-          sectionGroups.push({ sectionIdx: si, cells, intermediate: secIntermediate, attachedAt: [pcr, pcc] })
-          placed = true
-          break
+    // Prefer branch points that sit next to a genuinely large contiguous empty pocket —
+    // this is where the fork ends up, and its later multi-cell footprint (the claiming
+    // pass below) floods outward through exactly this kind of pocket. A handful of
+    // scattered free cells scores far lower than one solid open patch of the same size.
+    // Jittered rather than a hard sort so mazes stay varied, not just "biggest room wins".
+    const pocketSize = ([pr, pc]: [number, number], cap: number): number => {
+      const visited = new Set<string>([`${pr},${pc}`])
+      const queue: Array<[number, number]> = [[pr, pc]]
+      let count = 0
+      while (queue.length > 0 && count < cap) {
+        const [r, c] = queue.shift()!
+        for (const [dr, dc] of DIRS) {
+          const nr = r + dr,
+            nc = c + dc
+          const key = `${nr},${nc}`
+          if (visited.has(key)) continue
+          visited.add(key)
+          if (nr < 0 || nr >= N || nc < 0 || nc >= N || usedCells.has(key)) continue
+          count++
+          if (count >= cap) break
+          queue.push([nr, nc])
         }
-        if (placed) break
       }
+      return count
+    }
+    const spaciousness = (pathCell: [number, number]): number => pocketSize(pathCell, 8)
+    const shuffledCandidates = branchCandidates
+      .map(bc => ({ bc, score: spaciousness(bc.pathCell) + rand() * 3 }))
+      .sort((a, b) => b.score - a.score)
+      .map(({ bc }) => bc)
 
-      if (!placed) {
-        failed = true
-        break
+    // Bundle side sections onto shared branch points ("hubs") instead of every section
+    // scattering to its own private fork — a floor with many side sections reads as a
+    // few significant crossroads rooms rather than many forgettable single junctions.
+    // Group size scales with how many sections there are; low counts stay ungrouped
+    // (today's behavior, one fork per section).
+    const hubGroupSize = sideSections.length >= 5 ? 3 : sideSections.length >= 2 ? 2 : 1
+    const sectionOrder = sideSections.map((_, i) => i).sort(() => rand() - 0.5)
+    const hubGroups: number[][] = []
+    for (let i = 0; i < sectionOrder.length; i += hubGroupSize) {
+      hubGroups.push(sectionOrder.slice(i, i + hubGroupSize))
+    }
+
+    outer: for (const group of hubGroups) {
+      let hubCell: [number, number] | null = null
+
+      for (const si of group) {
+        const section = sideSections[si]
+        const secIntermediate = buildIntermediateTypes(section.pathPuzzles, section.chestEvery ?? 0)
+        const needed = secIntermediate.length + 1 + (section.gate ? 1 : 0)
+        let placed = false
+
+        // Try the shared hub first (if this group already has one); fall through to a
+        // fresh candidate search if it's run out of free adjacent directions.
+        const candidateSources: BranchCandidate[] = hubCell
+          ? [{ pathCell: hubCell }, ...shuffledCandidates]
+          : shuffledCandidates
+
+        for (const {
+          pathCell: [pcr, pcc],
+        } of candidateSources) {
+          let freeAdj = neighbors(pcr, pcc)
+            .filter(([ar, ac]) => !usedCells.has(`${ar},${ac}`))
+            .sort(() => rand() - 0.5)
+
+          // The hub is out of natural passages to branch into — carve a brand-new one
+          // into a plain grid-adjacent unused cell instead of giving up on it. This is a
+          // deliberate departure from "perfect maze" (a real cycle) at hub spots only:
+          // two junctions ending up next to each other is fine, players can explore
+          // either order — it just makes that visible as one genuine multi-exit room
+          // instead of two separate ones.
+          if (freeAdj.length === 0 && hubCell && pcr === hubCell[0] && pcc === hubCell[1]) {
+            const carveCandidates = DIRS2.map(([dr, dc]): [number, number] => [pcr + dr, pcc + dc])
+              .filter(
+                ([nr, nc]) =>
+                  nr >= 0 &&
+                  nr < N &&
+                  nc >= 0 &&
+                  nc < N &&
+                  !usedCells.has(`${nr},${nc}`) &&
+                  !passages.has(pkey(pcr, pcc, nr, nc))
+              )
+              .sort(() => rand() - 0.5)
+            if (carveCandidates.length > 0) {
+              passages.add(pkey(pcr, pcc, carveCandidates[0][0], carveCandidates[0][1]))
+              freeAdj = [carveCandidates[0]]
+            }
+          }
+          if (freeAdj.length === 0) continue
+
+          for (const [startR, startC] of freeAdj) {
+            usedCells.add(`${startR},${startC}`)
+            const rest = extendPath(startR, startC, needed - 1, neighbors, usedCells, rand, (r, c) =>
+              pocketSize([r, c], 8)
+            )
+            if (rest === null) {
+              usedCells.delete(`${startR},${startC}`)
+              continue
+            }
+            const cells: Array<[number, number]> = [[startR, startC], ...rest]
+            cells.slice(1).forEach(([r, c]) => usedCells.add(`${r},${c}`))
+            sectionGroups.push({ sectionIdx: si, cells, intermediate: secIntermediate, attachedAt: [pcr, pcc] })
+            if (!hubCell) hubCell = [pcr, pcc]
+            placed = true
+            break
+          }
+          if (placed) break
+        }
+
+        if (!placed) {
+          failed = true
+          break outer
+        }
       }
     }
 
@@ -347,8 +480,7 @@ export const assembleFloor = (siteId: string, config: FloorConfig, seed: number)
       for (let si = 0; si < subSects.length; si++) {
         const sub = subSects[si]
         const subIntermediate = buildIntermediateTypes(sub.pathPuzzles, sub.chestEvery ?? 0)
-        const subRoomCount = subIntermediate.length + 1 + (sub.gate ? 1 : 0)
-        const subNeeded = subRoomCount <= 1 ? subRoomCount : (subRoomCount - 1) * 2 + 1
+        const subNeeded = subIntermediate.length + 1 + (sub.gate ? 1 : 0)
         let placed = false
 
         for (const [pcr, pcc] of subBranchCandidates) {
@@ -358,7 +490,9 @@ export const assembleFloor = (siteId: string, config: FloorConfig, seed: number)
           if (freeAdj.length === 0) continue
           for (const [startR, startC] of freeAdj) {
             usedCells.add(`${startR},${startC}`)
-            const rest = extendPath(startR, startC, subNeeded - 1, neighbors, usedCells, rand)
+            const rest = extendPath(startR, startC, subNeeded - 1, neighbors, usedCells, rand, (r, c) =>
+              pocketSize([r, c], 8)
+            )
             if (rest === null) {
               usedCells.delete(`${startR},${startC}`)
               continue
@@ -460,22 +594,32 @@ export const assembleFloor = (siteId: string, config: FloorConfig, seed: number)
     const roomSpecs = new Map<string, RoomSpec>()
     const cellSectionHash = new Map<string, string>()
     const hiddenCellPositions = new Set<string>()
+    // Which section's authored decoration pool a footprint room should draw from.
+    const cellDecorationPool = new Map<string, DecorationKind[] | undefined>()
 
     const posKey = (r: number, c: number) => `${r},${c}`
 
     const mainSectionHash = computeMainSectionHash(config)
-    for (const [r, c] of mainPath) cellSectionHash.set(posKey(r, c), mainSectionHash)
+    for (const [r, c] of mainPath) {
+      cellSectionHash.set(posKey(r, c), mainSectionHash)
+      cellDecorationPool.set(posKey(r, c), config.decorations)
+    }
     for (const group of sectionGroups) {
       const sHash = computeSideSectionHash(sideSections[group.sectionIdx], group.sectionIdx)
       const isHidden = hiddenSectionIdxs.has(group.sectionIdx)
+      const pool = sideSections[group.sectionIdx].decorations
       for (const [r, c] of group.cells) {
         cellSectionHash.set(posKey(r, c), sHash)
+        cellDecorationPool.set(posKey(r, c), pool)
         if (isHidden) hiddenCellPositions.add(posKey(r, c))
       }
     }
     for (const { subSection, cells, parentSectionIdx, subSectionIdx } of subSectionGroups) {
       const sHash = computeSideSectionHash(subSection, subSectionIdx, parentSectionIdx)
-      for (const [r, c] of cells) cellSectionHash.set(posKey(r, c), sHash)
+      for (const [r, c] of cells) {
+        cellSectionHash.set(posKey(r, c), sHash)
+        cellDecorationPool.set(posKey(r, c), subSection.decorations)
+      }
     }
 
     // Collect branch junction cells (become fork nodes)
@@ -565,9 +709,10 @@ export const assembleFloor = (siteId: string, config: FloorConfig, seed: number)
         contentStart = 1
       }
 
-      // Intermediate nodes within section (puzzles/traps + chests), stride-2 to leave corridors
+      // Intermediate nodes within section (puzzles/traps + chests) — consecutive nodes,
+      // the connector cell between each pair lives at a separate grid position.
       for (let pi = 0; pi < intermediate.length; pi++) {
-        const [r, c] = cells[(contentStart + pi) * 2]
+        const [r, c] = cells[contentStart + pi]
         if (intermediate[pi] === "chest") {
           roomSpecs.set(posKey(r, c), { roomType: "treasure", reward: { type: "hieroglyphs" } })
         } else if (section.trapped) {
@@ -670,9 +815,9 @@ export const assembleFloor = (siteId: string, config: FloorConfig, seed: number)
     // Fill used cells with corridor or room
     for (const cellKey of usedCells) {
       const [r, c] = cellKey.split(",").map(Number)
-      // Compute dirs from passages
+      // Compute dirs from passages — nodes are two cells apart (see NODE_STEP above)
       const dirs = new Set<Direction>()
-      for (const [dr, dc, d] of DIRMAP) {
+      for (const [dr, dc, d] of CONNECTOR_DIRS) {
         const nr = r + dr,
           nc = c + dc
         if (
@@ -718,11 +863,67 @@ export const assembleFloor = (siteId: string, config: FloorConfig, seed: number)
       }
     }
 
+    // Materialize the connector cell for every real edge between two used nodes — this
+    // is the plain 1-wide corridor cell physically between them (see NODE_STEP above).
+    // Each edge is only processed once (from its lower-keyed endpoint) since it's
+    // symmetric. A connector inherits `hidden` only when both endpoints do, so a hidden
+    // section's own internal corridors stay hidden together with it, while the single
+    // corridor linking a hidden section to its (visible) attachment point stays visible
+    // — same as a normal doorway would.
+    for (const cellKey of usedCells) {
+      const [r, c] = cellKey.split(",").map(Number)
+      for (const [dr, dc, d] of CONNECTOR_DIRS) {
+        const nr = r + dr,
+          nc = c + dc
+        const neighborKey = `${nr},${nc}`
+        if (nr < 0 || nr >= N || nc < 0 || nc >= N) continue
+        if (!passages.has(pkey(r, c, nr, nc)) || !usedCells.has(neighborKey)) continue
+        if (r * N + c > nr * N + nc) continue // process each edge once
+        const mr = (r + nr) / 2,
+          mc = (c + nc) / 2
+        const hidden = hiddenCellPositions.has(cellKey) && hiddenCellPositions.has(neighborKey) ? true : undefined
+        const sectionHash = cellSectionHash.get(cellKey) ?? mainSectionHash
+        cells2D[mr][mc] = {
+          type: "corridor",
+          dirs: new Set([d, OPPOSITE[d]]),
+          state: "fogged",
+          sectionHash,
+          ...(hidden ? { hidden } : {}),
+        }
+      }
+    }
+
     // Set entrance cell state to "reachable"
     const [entRr, entCc] = [entR, entC]
     const entranceCell = cells2D[entRr][entCc]
     if (entranceCell.type === "room") {
       cells2D[entRr][entCc] = { ...entranceCell, state: "reachable" }
+    }
+
+    // Decorations: fork rooms and leaf-degree endpoint rooms (dead ends — treasure,
+    // stairhead, exit) may show a decoration drawn from their section's authored pool.
+    // Purely cosmetic, placed directly on the room's own cell — the renderer draws it
+    // offset into whichever side has open void next to it (see SiteMapView.tsx).
+    const endpointPositions = new Set<string>()
+    for (const [pk, spec] of roomSpecs) {
+      if (spec.roomType !== "treasure" && spec.roomType !== "stairhead" && spec.roomType !== "exit") continue
+      const [r, c] = pk.split(",").map(Number)
+      const cell = cells2D[r][c]
+      if (cell.type === "room" && cell.dirs.size === 1) endpointPositions.add(pk)
+    }
+    const decorationPoolIdx = new Map<DecorationKind[], number>()
+    const nextDecoration = (pool?: DecorationKind[]): DecorationKind | undefined => {
+      if (!pool) return undefined
+      const idx = decorationPoolIdx.get(pool) ?? 0
+      decorationPoolIdx.set(pool, idx + 1)
+      return pool[idx]
+    }
+    for (const pk of new Set([...forkPositions, ...endpointPositions])) {
+      const decoration = nextDecoration(cellDecorationPool.get(pk))
+      if (!decoration) continue
+      const [r, c] = pk.split(",").map(Number)
+      const owner = cells2D[r][c]
+      if (owner.type === "room") cells2D[r][c] = { ...owner, decoration }
     }
 
     const staircases: Record<string, readonly [number, number]> = {}

--- a/src/game/siteTypes.ts
+++ b/src/game/siteTypes.ts
@@ -23,6 +23,7 @@ export type CorridorCell = {
 }
 export type GateVariant = "floor-key" | "tomb-key"
 export type KeyColor = "blue" | "red" | "green" | "yellow" | "purple"
+export type DecorationKind = "sarcophagus" | "statue" | "fountain" | "pit" | "rubble" | "pillar" | "chestProp"
 export type RoomCell = {
   type: "room"
   roomType: RoomType
@@ -37,6 +38,7 @@ export type RoomCell = {
   keyColors?: KeyColor[]
   family?: PuzzleFamily
   stairId?: string
+  decoration?: DecorationKind
 }
 export type GridCell = EmptyCell | CorridorCell | RoomCell
 
@@ -62,6 +64,8 @@ export type SubSection = {
   endReward?: TreasureReward
   hidden?: boolean
   trapped?: boolean
+  /** Pool of decoration kinds available to this section's fork/endpoint rooms. */
+  decorations?: DecorationKind[]
 }
 export type SideSection = SubSection & {
   sideSections?: SubSection[]
@@ -75,6 +79,8 @@ export type FloorConfig = {
   /** If set, the entrance room becomes an up-stairhead with this stairId. */
   entrance?: "stairhead" | { stairId: string }
   sideSections: SideSection[]
+  /** Pool of decoration kinds available to the main path's fork/endpoint rooms. */
+  decorations?: DecorationKind[]
   mainEndReward?: TreasureReward
   chestRewards?: TreasureReward[]
   puzzleFamily?: PuzzleFamily

--- a/src/ui/NumberChest.stories.tsx
+++ b/src/ui/NumberChest.stories.tsx
@@ -3,7 +3,7 @@ import { NumberChest } from "./NumberChest"
 import { useState } from "react"
 
 const meta = {
-  title: "UI/NumberLock",
+  title: "UI/NumberChest",
   component: NumberChest,
   parameters: {
     layout: "centered",

--- a/src/worldGen/configBuilder.ts
+++ b/src/worldGen/configBuilder.ts
@@ -259,6 +259,7 @@ const buildSideSections = (
         end: "treasure" as const,
         ...(subGate ? { gate: subGate } : {}),
         ...(subEndReward ? { endReward: subEndReward } : {}),
+        ...(sub.decorations?.length ? { decorations: sub.decorations } : {}),
       }
     })
     sections.push({
@@ -268,6 +269,7 @@ const buildSideSections = (
       ...(gate ? { gate } : {}),
       ...(endReward ? { endReward } : {}),
       ...(subSections?.length ? { sideSections: subSections } : {}),
+      ...(cs.decorations?.length ? { decorations: cs.decorations } : {}),
     })
   }
 
@@ -453,6 +455,7 @@ const buildSiteConfigs = (plan: PyramidPlan[]): Record<string, SiteConfig[]> => 
             sideSections: floorSideSections,
             ...(isLast ? { mainEndReward } : {}),
             ...(floorChests.length > 0 ? { chestRewards: floorChests } : {}),
+            ...(fc.decorations?.length ? { decorations: fc.decorations } : {}),
           } satisfies FloorConfig)
         }
         pyramidConfigs.push(floorConfigs)
@@ -585,6 +588,7 @@ const buildTombConfigs = (): Record<string, SiteConfig[]> => {
         ...(Array.isArray(s.sideSections) && s.sideSections.length > 0
           ? { sideSections: buildSideSections(s.sideSections as SideSectionConstraint<"tombTreasure">[]) }
           : {}),
+        ...(s.decorations?.length ? { decorations: s.decorations } : {}),
       }))
 
     const floors: SiteConfig = Array.from({ length: levelCount }, (_, i) => {
@@ -614,6 +618,7 @@ const buildTombConfigs = (): Record<string, SiteConfig[]> => {
         puzzleFamily,
         ...(isLast && hasCroc ? { lastMainPuzzleFamily: "crocodile" as const } : {}),
         ...(mainEndReward ? { mainEndReward } : {}),
+        ...(authored?.decorations?.length ? { decorations: authored.decorations } : {}),
       }
     })
 

--- a/src/worldGen/dsl.ts
+++ b/src/worldGen/dsl.ts
@@ -1,4 +1,5 @@
 import type { Tier, Difficulty } from "./types"
+import type { DecorationKind } from "../game/siteTypes"
 
 // ── Constraint vocabulary ─────────────────────────────────────────────────────
 
@@ -30,6 +31,8 @@ export type SideSectionConstraint<TExtra extends string = never> = {
   puzzleFamily?: PuzzleFamily | PuzzleFamily[]
   endReward?: RewardSpec | TExtra
   sideSections?: SideSectionConstraint<TExtra>[]
+  /** Pool of decoration kinds this section's fork/endpoint rooms may draw from. */
+  decorations?: DecorationKind[]
 }
 
 export type FloorConstraint<TExtra extends string = never> = {
@@ -38,6 +41,8 @@ export type FloorConstraint<TExtra extends string = never> = {
   puzzleFamily?: PuzzleFamily | PuzzleFamily[]
   mainEndReward?: RewardHint | TExtra
   chestReward?: RewardHint | TExtra
+  /** Pool of decoration kinds the main path's fork/endpoint rooms may draw from. */
+  decorations?: DecorationKind[]
   /**
    * Side paths for this pyramid.
    * - SideIntensity | number: that many auto mosaic-piece paths, no explicit sections.


### PR DESCRIPTION
## Summary
- Reworks maze generation to a coarse even/odd grid with a straightness bias and hub-bundled side branches, guaranteeing genuine void pockets next to corridors and forks instead of a dense maze where parallel strands touch.
- `SiteMapView` derives room shapes purely at render time: forks and dead-end treasure/staircase/exit rooms claim their immediate ring of empty/diagonal neighbors (including one step past the grid edge), absorb a gate's one-cell approach corridor into their own footprint, and always render as a single, correctly-fogged blob regardless of exploration progress — no data-model or generation-side bookkeeping.
- DSL-authored decoration pools let sections place cosmetic props (sarcophagus, statue, fountain, etc.) in their fork/endpoint rooms.
- Updated `CHANGELOG.md` and `docs/game-design/spritesheet-renderer-prep.md` (documents the room-claim design for the future sprite-tile renderer).

## Test plan
- [x] `yarn tsc --noEmit`
- [x] `yarn lint`
- [x] `yarn test run` (589 tests)
- [x] `yarn build`
- [x] Visual spot-check via direct SVG render across multiple seeds/configs (forks, dead ends, gates, hidden sections, map-edge rooms, fully-fogged state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014dtfjQTqmmnScZGtCnXM4e