### PR TITLE
fix: interleave side-path forks with main-path puzzles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Side paths now branch off throughout the main path instead of all bunching up after its last puzzle room.
 
 ## 0.25.1 - 2026-07-04
 ### Changed

--- a/src/app/SiteMap/useAssembledFloor.spec.ts
+++ b/src/app/SiteMap/useAssembledFloor.spec.ts
@@ -1,8 +1,49 @@
 import { renderHook } from "@testing-library/react"
 import { describe, expect, it } from "vitest"
 import { assembleFloor } from "@/game/siteAssembler"
-import type { FloorConfig } from "@/game/siteTypes"
+import type { FloorGrid, FloorConfig, CorridorCell, RoomCell } from "@/game/siteTypes"
 import { encodeEdge, useAssembledFloor } from "./useAssembledFloor"
+
+const OPPOSITE_DIR: Record<string, string> = { n: "s", s: "n", e: "w", w: "e" }
+const DIR_MOVE: Record<string, [number, number]> = { n: [-1, 0], s: [1, 0], e: [0, 1], w: [0, -1] }
+
+// The "gateway" is whichever real (non-hidden) cell sits right next to a hidden one — the
+// exact spot maskHiddenCells flags as a junction, regardless of whether it's a dedicated
+// fork room, a plain corridor corner, or an existing main-path room that a side section
+// just happens to attach onto (all of these are possible outcomes of generation, and none
+// of them is fixed for a given seed/config, so tests must find it dynamically). To
+// reproduce real play, `predecessor` — one step further back, away from the hidden branch —
+// is what gets marked "explored": completing it exercises the exact cascade that glides
+// through (or stops at, with a detector) the gateway.
+const findGatewayToHidden = (
+  grid: FloorGrid
+): {
+  gatewayPos: [number, number]
+  predecessorPos: [number, number]
+  predecessorCell: CorridorCell | RoomCell
+} => {
+  for (let r = 0; r < grid.rows; r++) {
+    for (let c = 0; c < grid.cols; c++) {
+      const cell = grid.cells[r][c]
+      if (!(cell.type === "room" || cell.type === "corridor") || !cell.hidden) continue
+      for (const dir of cell.dirs) {
+        const [dr, dc] = DIR_MOVE[dir]
+        const gatewayPos: [number, number] = [r + dr, c + dc]
+        const gateway = grid.cells[gatewayPos[0]]?.[gatewayPos[1]]
+        if (!gateway || (gateway.type !== "room" && gateway.type !== "corridor") || gateway.hidden) continue
+        const cameFrom = OPPOSITE_DIR[dir]
+        const backDir = [...gateway.dirs].find(d => d !== cameFrom)
+        if (!backDir) return { gatewayPos, predecessorPos: gatewayPos, predecessorCell: gateway }
+        const [bdr, bdc] = DIR_MOVE[backDir]
+        const predecessorPos: [number, number] = [gatewayPos[0] + bdr, gatewayPos[1] + bdc]
+        const predecessorCell = grid.cells[predecessorPos[0]]?.[predecessorPos[1]]
+        if (!predecessorCell || predecessorCell.type === "empty") continue
+        return { gatewayPos, predecessorPos, predecessorCell }
+      }
+    }
+  }
+  throw new Error("no gateway leading to a hidden cell found")
+}
 
 // Same shape as the HiddenPassage story: a hidden side section reachable only via a fork.
 const SEED = 17
@@ -24,16 +65,15 @@ describe("useAssembledFloor — hidden junctions", () => {
     if (!assembled.success) throw new Error("assembly failed")
     const grid = assembled.grid
 
-    // At this seed, the hidden treasure sits two cells past a fork: fork -> corridor -> hidden
-    // treasure. Only the endpoint is tagged `hidden`, so the corridor cell has no turn of its
-    // own on the unmasked graph — completeCell treats it as an ordinary straight passthrough
-    // and marks it "visible" while auto-revealing past it, rather than stopping there.
-    // Completing just the fork (not the corridor itself) reproduces that real play sequence.
-    const fork = grid.cells[10][14]
-    if (fork.type !== "room" || fork.roomType !== "fork") {
-      throw new Error("site generation changed — fork is no longer at (10,14) for this seed/config")
+    // The gateway sits right next to the hidden branch. Only the endpoint is tagged
+    // `hidden`, so on the unmasked graph the gateway has no turn of its own if it's a plain
+    // straight corridor — completeCell treats it as an ordinary passthrough and marks it
+    // "visible" while auto-revealing past it, rather than stopping there. Completing the
+    // predecessor (not the gateway itself) reproduces that real play sequence.
+    const { predecessorPos, predecessorCell } = findGatewayToHidden(grid)
+    const exploredSections = {
+      [predecessorCell.sectionHash ?? ""]: [encodeEdge(0, predecessorPos[0], predecessorPos[1])],
     }
-    const exploredSections = { [fork.sectionHash ?? ""]: [encodeEdge(0, 10, 14)] }
 
     const { result } = renderHook(() =>
       useAssembledFloor(JOURNEY_ID, CONFIG, SEED, 0, exploredSections, new Set(), null, 1, new Set())
@@ -52,11 +92,10 @@ describe("useAssembledFloor — hidden junctions", () => {
     const assembled = assembleFloor(JOURNEY_ID, CONFIG, SEED)
     if (!assembled.success) throw new Error("assembly failed")
     const grid = assembled.grid
-    const fork = grid.cells[10][14]
-    if (fork.type !== "room" || fork.roomType !== "fork") {
-      throw new Error("site generation changed — fork is no longer at (10,14) for this seed/config")
+    const { predecessorPos, predecessorCell } = findGatewayToHidden(grid)
+    const exploredSections = {
+      [predecessorCell.sectionHash ?? ""]: [encodeEdge(0, predecessorPos[0], predecessorPos[1])],
     }
-    const exploredSections = { [fork.sectionHash ?? ""]: [encodeEdge(0, 10, 14)] }
 
     const { result } = renderHook(() =>
       useAssembledFloor(JOURNEY_ID, CONFIG, SEED, 0, exploredSections, new Set(), null, 0, new Set())

--- a/src/game/siteAssembler.spec.ts
+++ b/src/game/siteAssembler.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 import { assembleFloor } from "./siteAssembler"
 import type { FloorConfig, FloorGrid, RoomCell } from "./siteTypes"
 import { validateSite } from "./siteValidator"
+import { findPath } from "./gridNavigation"
 
 const basicConfig = (): FloorConfig => ({
   pathPuzzles: 1,
@@ -173,6 +174,52 @@ describe(assembleFloor, () => {
       expect(puzzles.length).toBe(4)
       expect(validateSite(result.grid)).toEqual({ valid: true })
     }
+  })
+
+  it("interleaves side-section forks with main-path puzzles instead of clustering them all after the last one", () => {
+    // Before the fix, fork attachment was picked purely by which spot had the biggest open
+    // pocket — reliably the unused corridor tail past the last main-path puzzle — so every
+    // side section clustered there instead of spreading across the puzzle stretch.
+    const config: FloorConfig = {
+      pathPuzzles: 5,
+      difficulty: "starter",
+      end: "treasure",
+      exitOrStaircase: "exit",
+      sideSections: [
+        { pathPuzzles: 0, difficulty: "starter", end: "treasure" },
+        { pathPuzzles: 0, difficulty: "starter", end: "treasure" },
+        { pathPuzzles: 0, difficulty: "starter", end: "treasure" },
+      ],
+    }
+    const seeds = 40
+    let interleavedCount = 0
+    for (let seed = 0; seed < seeds; seed++) {
+      const result = assembleFloor(`site-${seed}`, config, seed)
+      expect(result.success, `seed ${seed} failed assembly`).toBe(true)
+      if (!result.success) continue
+      const { grid } = result
+      const distanceTo = (r: number, c: number) => findPath(grid, grid.entrancePos, [r, c]).length - 1
+      const puzzleDistances: number[] = []
+      const branchDistances: number[] = []
+      for (let r = 0; r < grid.rows; r++) {
+        for (let c = 0; c < grid.cols; c++) {
+          const cell = grid.cells[r][c]
+          if (cell.type === "room" && cell.roomType === "puzzle") puzzleDistances.push(distanceTo(r, c))
+          // A branch point is any node with more than 2 connections — whether that's a
+          // dedicated "fork" room, or a side section attached straight onto an existing
+          // main-path room's own cell (which keeps that room's original roomType).
+          if ((cell.type === "room" || cell.type === "corridor") && cell.dirs.size > 2) {
+            branchDistances.push(distanceTo(r, c))
+          }
+        }
+      }
+      expect(puzzleDistances.length, `seed ${seed}`).toBe(5)
+      const maxPuzzleDistance = Math.max(...puzzleDistances)
+      if (branchDistances.some(d => d < maxPuzzleDistance)) interleavedCount++
+    }
+    // A strong majority, not literally every seed — maze shape can still legitimately leave
+    // a seed with no good interleaved spot. Before the fix this was ~0/40.
+    expect(interleavedCount).toBeGreaterThan(seeds * 0.7)
   })
 
   it("property: 100 seeds × basic config all pass validation", () => {

--- a/src/game/siteAssembler.ts
+++ b/src/game/siteAssembler.ts
@@ -312,13 +312,32 @@ export const assembleFloor = (siteId: string, config: FloorConfig, seed: number)
     const sectionGroups: SectionGroup[] = []
     let failed = false
 
+    // A candidate's branch doesn't need a *pre-existing* maze passage to an unused
+    // neighbor — same as the hub-carving fallback below, a brand-new passage can be carved
+    // into any plain grid-adjacent unused cell on demand. Restricting candidates to cells
+    // that already happen to have a spare tree branch (via `neighbors`, passages only)
+    // made them vanishingly rare anywhere near the entrance: the DFS spanning tree's few
+    // side-branches are scattered roughly uniformly across the *whole* corridor, and the
+    // main-path puzzle stretch is a tiny fraction of a corridor sized to fit every side
+    // section too — so almost all of those rare branches fell in the long unused tail past
+    // the last puzzle, which is exactly the clustering this is meant to avoid.
+    const rawFreeNeighbors = (r: number, c: number): Array<[number, number]> =>
+      DIRS2.map(([dr, dc]): [number, number] => [r + dr, c + dc]).filter(
+        ([nr, nc]) => nr >= 0 && nr < N && nc >= 0 && nc < N && !usedCells.has(`${nr},${nc}`)
+      )
+
     type BranchCandidate = { pathCell: [number, number] }
     const branchCandidates: BranchCandidate[] = []
+    // Cells within the actual puzzle-bearing stretch of the main path (before the goal),
+    // in path order — kept separate so fork placement can prefer interleaving with main-path
+    // puzzles over the unused corridor tail beyond the goal (see bucketing below).
+    const mainZoneCandidates: BranchCandidate[] = []
     for (let pi = 0; pi < mainPath.length - 1; pi++) {
       const [pr, pc] = mainPath[pi]
-      const hasAdj = neighbors(pr, pc).some(([ar, ac]) => !usedCells.has(`${ar},${ac}`))
-      if (!hasAdj) continue
-      branchCandidates.push({ pathCell: [pr, pc] })
+      if (rawFreeNeighbors(pr, pc).length === 0) continue
+      const candidate: BranchCandidate = { pathCell: [pr, pc] }
+      branchCandidates.push(candidate)
+      if (pi < goalIndex) mainZoneCandidates.push(candidate)
     }
     // Prefer branch points that sit next to a genuinely large contiguous empty pocket —
     // this is where the fork ends up, and its later multi-cell footprint (the claiming
@@ -346,10 +365,12 @@ export const assembleFloor = (siteId: string, config: FloorConfig, seed: number)
       return count
     }
     const spaciousness = (pathCell: [number, number]): number => pocketSize(pathCell, 8)
-    const shuffledCandidates = branchCandidates
-      .map(bc => ({ bc, score: spaciousness(bc.pathCell) + rand() * 3 }))
-      .sort((a, b) => b.score - a.score)
-      .map(({ bc }) => bc)
+    const scoreCandidates = (list: BranchCandidate[]): BranchCandidate[] =>
+      list
+        .map(bc => ({ bc, score: spaciousness(bc.pathCell) + rand() * 3 }))
+        .sort((a, b) => b.score - a.score)
+        .map(({ bc }) => bc)
+    const shuffledCandidates = scoreCandidates(branchCandidates)
 
     // Bundle side sections onto shared branch points ("hubs") instead of every section
     // scattering to its own private fork — a floor with many side sections reads as a
@@ -363,8 +384,24 @@ export const assembleFloor = (siteId: string, config: FloorConfig, seed: number)
       hubGroups.push(sectionOrder.slice(i, i + hubGroupSize))
     }
 
-    outer: for (const group of hubGroups) {
+    // Split the main-path puzzle stretch into one contiguous slice per hub group, in path
+    // order, so each group prefers a different stretch of the corridor instead of every
+    // group competing for whichever single spot has the biggest open pocket (which is
+    // reliably the unused tail past the last main-path puzzle — the exact clustering this
+    // is meant to avoid). Slices are handed out in a shuffled order so hub 0 doesn't always
+    // land nearest the entrance. Falls back to the full main zone, then the whole corridor
+    // (today's behavior), so this can never make an otherwise-placeable section fail.
+    const mainZoneSlices: BranchCandidate[][] = hubGroups.map((_, bi) => {
+      const start = Math.floor((bi * mainZoneCandidates.length) / hubGroups.length)
+      const end = Math.floor(((bi + 1) * mainZoneCandidates.length) / hubGroups.length)
+      return scoreCandidates(mainZoneCandidates.slice(start, end))
+    })
+    const sliceOrder = hubGroups.map((_, i) => i).sort(() => rand() - 0.5)
+    const shuffledMainZoneCandidates = scoreCandidates(mainZoneCandidates)
+
+    outer: for (const [groupIdx, group] of hubGroups.entries()) {
       let hubCell: [number, number] | null = null
+      const ownSlice = mainZoneSlices[sliceOrder[groupIdx]]
 
       for (const si of group) {
         const section = sideSections[si]
@@ -372,11 +409,12 @@ export const assembleFloor = (siteId: string, config: FloorConfig, seed: number)
         const needed = secIntermediate.length + 1 + (section.gate ? 1 : 0)
         let placed = false
 
-        // Try the shared hub first (if this group already has one); fall through to a
-        // fresh candidate search if it's run out of free adjacent directions.
+        // Try the shared hub first (if this group already has one), then this group's own
+        // stretch of the puzzle zone, then any other main-zone spot, then the full corridor
+        // (including the tail) as a last resort.
         const candidateSources: BranchCandidate[] = hubCell
-          ? [{ pathCell: hubCell }, ...shuffledCandidates]
-          : shuffledCandidates
+          ? [{ pathCell: hubCell }, ...ownSlice, ...shuffledMainZoneCandidates, ...shuffledCandidates]
+          : [...ownSlice, ...shuffledMainZoneCandidates, ...shuffledCandidates]
 
         for (const {
           pathCell: [pcr, pcc],
@@ -385,13 +423,14 @@ export const assembleFloor = (siteId: string, config: FloorConfig, seed: number)
             .filter(([ar, ac]) => !usedCells.has(`${ar},${ac}`))
             .sort(() => rand() - 0.5)
 
-          // The hub is out of natural passages to branch into — carve a brand-new one
-          // into a plain grid-adjacent unused cell instead of giving up on it. This is a
-          // deliberate departure from "perfect maze" (a real cycle) at hub spots only:
-          // two junctions ending up next to each other is fine, players can explore
-          // either order — it just makes that visible as one genuine multi-exit room
-          // instead of two separate ones.
-          if (freeAdj.length === 0 && hubCell && pcr === hubCell[0] && pcc === hubCell[1]) {
+          // No natural passage to branch into — carve a brand-new one into a plain
+          // grid-adjacent unused cell instead of giving up on this candidate. A deliberate
+          // departure from "perfect maze" (a real cycle) at branch spots: two junctions
+          // ending up next to each other is fine, players can explore either order — it
+          // just makes that visible as one genuine multi-exit room instead of two separate
+          // ones. Not just for repeat-hub cells (see rawFreeNeighbors above for why this
+          // needs to work for the first branch off a spot too, not only subsequent ones).
+          if (freeAdj.length === 0) {
             const carveCandidates = DIRS2.map(([dr, dc]): [number, number] => [pcr + dr, pcc + dc])
               .filter(
                 ([nr, nc]) =>


### PR DESCRIPTION
## Summary
- Side-section forks previously all clustered in the corridor tail past the last main-path puzzle, instead of spreading across the puzzle stretch.
- Root cause: branch eligibility required a pre-existing maze passage to a spare cell, and the DFS tree's few side-branches are scattered close to uniformly across the *whole* corridor — but the puzzle-bearing stretch is a tiny fraction of a corridor sized to fit every side section's own content too, so nearly all eligible branch points fell in the (much longer) unused tail by sheer proportion.
- Fix: branch eligibility no longer requires an existing passage (a new one can be carved on demand, same as the existing hub-repeat fallback); side-section hub groups are each assigned a distinct slice of the puzzle-bearing stretch (shuffled order), falling back to other main-zone slices, then the full corridor, only if nothing usable is found there.

## Test plan
- [x] `yarn tsc -b` passes
- [x] `yarn vitest run` — 605 tests pass, including a new property test asserting a strong majority of seeds show a branch point interleaved before the last main-path puzzle (fails on the old code, ~0/40)
- [x] Updated two `useAssembledFloor` tests that hardcoded a fork's coordinates for a specific seed, since attachment points are no longer stable at that spot — now locate the gateway into the hidden section dynamically
- [x] Visually verified in Storybook: gates/puzzles/treasures now mix together right off the main path near the entrance instead of clustering at the end

🤖 Generated with [Claude Code](https://claude.com/claude-code)