### PR TITLE
feat: zoom in the site map, driven by one shared base unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- The pyramid/tomb interior map is more zoomed in — corridors, rooms, and icons are all noticeably bigger.
 
 ## 0.25.2 - 2026-07-05
 ### Changed

--- a/src/app/SiteMap/ExplorerDot.tsx
+++ b/src/app/SiteMap/ExplorerDot.tsx
@@ -1,9 +1,7 @@
 import { useEffect, useRef, useState } from "react"
 import type { FloorGrid } from "../../game/siteTypes"
 import { findPath } from "../../game/gridNavigation"
-
-export const SITE_MAP_CELL = 44
-export const SITE_MAP_PAD = 44
+import { CELL, EXPLORER_DOT_RADIUS } from "./mapScale"
 
 type Point = { x: number; y: number }
 
@@ -22,8 +20,8 @@ type Props = {
 export const ExplorerDot = ({
   grid,
   pos,
-  cellSize = SITE_MAP_CELL,
-  padding = SITE_MAP_PAD,
+  cellSize = CELL,
+  padding = CELL,
   segmentDuration = 120,
   color = "#ffd060",
   onArrive,
@@ -120,7 +118,7 @@ export const ExplorerDot = ({
     <circle
       cx={svgPos.x}
       cy={svgPos.y}
-      r={9}
+      r={EXPLORER_DOT_RADIUS}
       fill={color}
       stroke="#110d08"
       strokeWidth={2}

--- a/src/app/SiteMap/SiteMapView.spec.tsx
+++ b/src/app/SiteMap/SiteMapView.spec.tsx
@@ -1,7 +1,16 @@
 import { render, fireEvent } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
 import { SiteMapView } from "./SiteMapView"
+import { CELL, WALL_THICKNESS } from "./mapScale"
 import type { CellState, Direction, FloorGrid, GridCell } from "@/game/siteTypes"
+
+// PAD === CELL in SiteMapView, so a cell at (row, col) always centers at this pixel —
+// derived from the shared scale constant rather than hardcoded, so a future EM change
+// doesn't silently break every position assumption in this file.
+const cellCenter = (row: number, col: number) => ({
+  cx: CELL + col * CELL + CELL / 2,
+  cy: CELL + row * CELL + CELL / 2,
+})
 
 // ── Grid factory ──────────────────────────────────────────────────────────────
 
@@ -128,19 +137,20 @@ describe("SiteMapView — room clickability", () => {
 })
 
 // Finds the cell group by its exact translate transform, then checks whether it has a
-// wall rect on the given relative edge (CELL = 44, so half = 22). North and west walls
-// (and south and east) share an x,y origin — only width/height tell them apart — so all
-// four dimensions are matched, not just position.
+// wall rect on the given relative edge. North and west walls (and south and east) share
+// an x,y origin — only width/height tell them apart — so all four dimensions are matched,
+// not just position.
 const hasWallRect = (container: HTMLElement, cx: number, cy: number, edge: "n" | "s" | "e" | "w") => {
   const g = Array.from(container.querySelectorAll("g")).find(
     el => el.getAttribute("transform") === `translate(${cx}, ${cy})`
   )
   if (!g) throw new Error(`no cell group at (${cx}, ${cy})`)
+  const half = CELL / 2
   const rect = {
-    n: { x: -22, y: -22, w: 44, h: 4 },
-    s: { x: -22, y: 18, w: 44, h: 4 },
-    w: { x: -22, y: -22, w: 4, h: 44 },
-    e: { x: 18, y: -22, w: 4, h: 44 },
+    n: { x: -half, y: -half, w: CELL, h: WALL_THICKNESS },
+    s: { x: -half, y: half - WALL_THICKNESS, w: CELL, h: WALL_THICKNESS },
+    w: { x: -half, y: -half, w: WALL_THICKNESS, h: CELL },
+    e: { x: half - WALL_THICKNESS, y: -half, w: WALL_THICKNESS, h: CELL },
   }[edge]
   return Array.from(g.querySelectorAll('rect[fill="#080502"]')).some(
     r =>
@@ -152,22 +162,21 @@ const hasWallRect = (container: HTMLElement, cx: number, cy: number, edge: "n" |
 }
 
 describe("SiteMapView — junction merging", () => {
-  // Grid layout: fork | void | fork, 1 row. PAD = CELL = 44, so cell centers land at
-  // x = 44 + col*44 + 22: col 0 -> 66, col 1 (the shared void) -> 110, col 2 -> 154.
+  // Grid layout: fork | void | fork, 1 row.
   it("opens the wall between two forks that each claim a side of the void between them", () => {
     // Neither fork has a real graph edge to the other; each claims its own adjacent void
     // cell, and the shared boundary should render with no wall on either side.
     const { container } = render(<SiteMapView grid={makeGrid([[fork("visible"), empty, fork("visible")]])} />)
-    expect(hasWallRect(container, 110, 66, "e")).toBe(false)
-    expect(hasWallRect(container, 154, 66, "w")).toBe(false)
+    expect(hasWallRect(container, cellCenter(0, 1).cx, cellCenter(0, 1).cy, "e")).toBe(false)
+    expect(hasWallRect(container, cellCenter(0, 2).cx, cellCenter(0, 2).cy, "w")).toBe(false)
   })
 
   it("does not merge non-junction rooms sharing a claimed void the same way", () => {
     // puzzle rooms don't claim void at all, so the shared cell renders as nothing and
     // each room keeps its own wall facing the gap.
     const { container } = render(<SiteMapView grid={makeGrid([[room("visible"), empty, room("visible")]])} />)
-    expect(hasWallRect(container, 66, 66, "e")).toBe(true)
-    expect(hasWallRect(container, 154, 66, "w")).toBe(true)
+    expect(hasWallRect(container, cellCenter(0, 0).cx, cellCenter(0, 0).cy, "e")).toBe(true)
+    expect(hasWallRect(container, cellCenter(0, 2).cx, cellCenter(0, 2).cy, "w")).toBe(true)
   })
 })
 
@@ -186,7 +195,6 @@ describe("SiteMapView — diagonal claim stability across a hidden-passage revea
       [empty, straightCorridor("reachable", ["e"]), fork("reachable", ["n", "w"])],
     ])
 
-  // PAD = CELL = 44: col1 -> x=110, row1 -> y=110, row2 -> y=154
   const floorFillAt = (container: HTMLElement, cx: number, cy: number) => {
     const g = Array.from(container.querySelectorAll("g")).find(
       el => el.getAttribute("transform") === `translate(${cx}, ${cy})`
@@ -201,9 +209,9 @@ describe("SiteMapView — diagonal claim stability across a hidden-passage revea
     const hidden = render(<SiteMapView grid={buildGrid(empty)} />)
     const revealed = render(<SiteMapView grid={buildGrid(leafTreasure("visible", ["s"]))} />)
 
-    const forkFill = floorFillAt(hidden.container, 154, 154)
-    expect(floorFillAt(hidden.container, 110, 110)).toBe(forkFill)
-    expect(floorFillAt(revealed.container, 110, 110)).toBe(forkFill)
+    const forkFill = floorFillAt(hidden.container, cellCenter(2, 2).cx, cellCenter(2, 2).cy)
+    expect(floorFillAt(hidden.container, cellCenter(1, 1).cx, cellCenter(1, 1).cy)).toBe(forkFill)
+    expect(floorFillAt(revealed.container, cellCenter(1, 1).cx, cellCenter(1, 1).cy)).toBe(forkFill)
   })
 
   it("breaks an exact flank-strength tie in favor of the fork, regardless of either room's state", () => {
@@ -232,8 +240,8 @@ describe("SiteMapView — diagonal claim stability across a hidden-passage revea
       ["completed", "completed"],
     ] as const) {
       const { container } = render(<SiteMapView grid={buildGrid(treasureState, forkState)} />)
-      expect(hasWallRect(container, 110, 110, "n")).toBe(true)
-      expect(hasWallRect(container, 110, 110, "w")).toBe(false)
+      expect(hasWallRect(container, cellCenter(1, 1).cx, cellCenter(1, 1).cy, "n")).toBe(true)
+      expect(hasWallRect(container, cellCenter(1, 1).cx, cellCenter(1, 1).cy, "w")).toBe(false)
     }
   })
 })
@@ -270,7 +278,7 @@ describe("SiteMapView — long corridor click target", () => {
       ],
     ])
     const { container } = render(<SiteMapView grid={grid} onCellClick={onClick} explorerPos={[0, 0]} />)
-    const nearCell = findCell(container, 110, 66)
+    const nearCell = findCell(container, cellCenter(0, 1).cx, cellCenter(0, 1).cy)
     expect(nearCell?.style.cursor).toBe("pointer")
     fireEvent.click(nearCell!)
     expect(onClick).toHaveBeenCalledWith(0, 3)
@@ -280,7 +288,7 @@ describe("SiteMapView — long corridor click target", () => {
     const onClick = vi.fn()
     const grid = makeGrid([[fork("completed", ["e"]), corridor("reachable", true)]])
     const { container } = render(<SiteMapView grid={grid} onCellClick={onClick} explorerPos={[0, 0]} />)
-    fireEvent.click(findCell(container, 110, 66)!)
+    fireEvent.click(findCell(container, cellCenter(0, 1).cx, cellCenter(0, 1).cy)!)
     expect(onClick).toHaveBeenCalledWith(0, 1)
   })
 
@@ -289,7 +297,7 @@ describe("SiteMapView — long corridor click target", () => {
       [fork("completed", ["e"]), straightCorridor("visible", ["e", "w"]), straightCorridor("reachable", ["n", "e"])],
     ])
     const { container } = render(<SiteMapView grid={grid} explorerPos={[0, 0]} />)
-    const nearCell = findCell(container, 110, 66)
+    const nearCell = findCell(container, cellCenter(0, 1).cx, cellCenter(0, 1).cy)
     expect(nearCell?.querySelector("polygon")).toBeTruthy()
     expect(nearCell?.querySelector("circle")).toBeNull()
   })
@@ -302,9 +310,9 @@ describe("SiteMapView — long corridor click target", () => {
       [fork("completed", ["e"]), straightCorridor("visible", ["e", "w"]), straightCorridor("reachable", ["n", "e"])],
     ])
     const { container, rerender } = render(<SiteMapView grid={grid} explorerPos={[0, 0]} />)
-    expect(findCell(container, 110, 66)?.querySelector("polygon")).toBeTruthy()
+    expect(findCell(container, cellCenter(0, 1).cx, cellCenter(0, 1).cy)?.querySelector("polygon")).toBeTruthy()
 
     rerender(<SiteMapView grid={grid} explorerPos={[0, 2]} />)
-    expect(findCell(container, 110, 66)?.querySelector("polygon")).toBeNull()
+    expect(findCell(container, cellCenter(0, 1).cx, cellCenter(0, 1).cy)?.querySelector("polygon")).toBeNull()
   })
 })

--- a/src/app/SiteMap/SiteMapView.tsx
+++ b/src/app/SiteMap/SiteMapView.tsx
@@ -11,6 +11,14 @@ import type {
 } from "../../game/siteTypes"
 import { revealAll } from "../../game/gridNavigation"
 import { ExplorerDot } from "./ExplorerDot"
+import {
+  CELL,
+  WALL_THICKNESS,
+  NODE_RADIUS_LARGE,
+  NODE_RADIUS_PUZZLE,
+  NODE_RADIUS_FORK,
+  MARKER_RADIUS,
+} from "./mapScale"
 
 // Cells one step outside the grid are still real void for claiming purposes — a fork or
 // endpoint sitting on the map's edge shouldn't look artificially clipped next to one
@@ -27,8 +35,6 @@ type Props = {
   className?: string
 }
 
-const CELL = 44
-
 const entranceFill: Record<CellState, string> = {
   fogged: "#1a1208",
   visible: "#281c08",
@@ -43,7 +49,7 @@ const entranceStroke: Record<CellState, string> = {
 }
 
 const EntranceShape = ({ state }: ShapeProps) => {
-  const r = 15
+  const r = NODE_RADIUS_LARGE
   const fill = entranceFill[state]
   const stroke = entranceStroke[state]
   // arch: flat bottom, semicircle top
@@ -92,7 +98,7 @@ const KEY_COLOR_HEX: Record<KeyColor, { visible: string; reachable: string }> = 
 }
 
 const PuzzleShape = ({ state }: ShapeProps) => {
-  const r = 16
+  const r = NODE_RADIUS_PUZZLE
   const fill = puzzleFill[state]
   const stroke = puzzleStroke[state]
   return (
@@ -138,7 +144,7 @@ const trapStroke: Record<CellState, string> = {
 }
 
 const TrapShape = ({ state }: ShapeProps) => {
-  const r = 16
+  const r = NODE_RADIUS_PUZZLE
   const fill = trapFill[state]
   const stroke = trapStroke[state]
   return (
@@ -163,13 +169,13 @@ const TrapShape = ({ state }: ShapeProps) => {
 }
 
 const ForkShape = ({ state }: ShapeProps) => {
-  const r = 7
+  const r = NODE_RADIUS_FORK
   const stroke = state === "fogged" ? "#2e2018" : "#5a4a30"
   return <polygon points={`0,${-r} ${r},0 0,${r} ${-r},0`} fill="#1e160e" stroke={stroke} strokeWidth={1.5} />
 }
 
 const GateNodeShape = ({ state, gateVariant, keyColor }: ShapeProps) => {
-  const r = 15
+  const r = NODE_RADIUS_LARGE
   const isTomb = gateVariant === "tomb-key"
   const colorKey = state === "visible" ? "visible" : "reachable"
   const fill = isTomb ? tombGateFill[state] : gateFill[state]
@@ -230,7 +236,7 @@ const GateNodeShape = ({ state, gateVariant, keyColor }: ShapeProps) => {
 }
 
 const TreasureShape = ({ state, keyColor, keyColors }: ShapeProps) => {
-  const r = 15
+  const r = NODE_RADIUS_LARGE
   const colorKey = state === "visible" ? "visible" : "reachable"
   const badges = keyColors && keyColors.length > 0 ? keyColors : keyColor ? [keyColor] : []
   const primaryColor = badges[0]
@@ -275,8 +281,8 @@ const TreasureShape = ({ state, keyColor, keyColors }: ShapeProps) => {
 }
 
 const StairheadShape = ({ state }: ShapeProps) => {
-  const r = 15
-  const cut = 5
+  const r = NODE_RADIUS_LARGE
+  const cut = 6
   const fill = stairFill[state]
   const stroke = stairStroke[state]
   const pts = [
@@ -300,7 +306,7 @@ const StairheadShape = ({ state }: ShapeProps) => {
 }
 
 const ExitShape = ({ state }: ShapeProps) => {
-  const r = 15
+  const r = NODE_RADIUS_LARGE
   const fill = exitFill[state]
   const stroke = exitStroke[state]
   return (
@@ -313,14 +319,14 @@ const ExitShape = ({ state }: ShapeProps) => {
 }
 
 const nodeRadius: Record<RoomType, number> = {
-  entrance: 15,
-  puzzle: 16,
-  trap: 16,
-  fork: 7,
-  gate: 15,
-  treasure: 15,
-  stairhead: 15,
-  exit: 15,
+  entrance: NODE_RADIUS_LARGE,
+  puzzle: NODE_RADIUS_PUZZLE,
+  trap: NODE_RADIUS_PUZZLE,
+  fork: NODE_RADIUS_FORK,
+  gate: NODE_RADIUS_LARGE,
+  treasure: NODE_RADIUS_LARGE,
+  stairhead: NODE_RADIUS_LARGE,
+  exit: NODE_RADIUS_LARGE,
 }
 
 const NodeShape = ({ type, state, gateVariant, keyColor, keyColors }: ShapeProps & { type: RoomType }) => {
@@ -791,7 +797,6 @@ const roomFloorFill: Record<CellState, string> = {
   completed: "#332210",
 }
 const WALL_COLOR = "#080502"
-const WALL_THICKNESS = 4
 
 const FloorTile = ({
   state,
@@ -870,11 +875,19 @@ const DecorationGlyph = ({ kind }: { kind: DecorationKind }) => {
 // as an arrow instead of a dot to hint which way it leads.
 const DIR_ROTATION: Record<Direction, number> = { n: 0, e: 90, s: 180, w: 270 }
 
-const ReachableDot = () => <circle r={3} fill="#d0a840" opacity={0.85} />
+const ReachableDot = () => <circle r={MARKER_RADIUS} fill="#d0a840" opacity={0.85} />
 
-const RunTargetArrow = ({ dir }: { dir: Direction }) => (
-  <polygon points="0,-5 4,4 -4,4" fill="#d0a840" opacity={0.85} transform={`rotate(${DIR_ROTATION[dir]})`} />
-)
+const RunTargetArrow = ({ dir }: { dir: Direction }) => {
+  const r = MARKER_RADIUS
+  return (
+    <polygon
+      points={`0,${-r} ${r},${r} ${-r},${r}`}
+      fill="#d0a840"
+      opacity={0.85}
+      transform={`rotate(${DIR_ROTATION[dir]})`}
+    />
+  )
+}
 
 // ─── Component ────────────────────────────────────────────────────────────────
 

--- a/src/app/SiteMap/mapScale.ts
+++ b/src/app/SiteMap/mapScale.ts
@@ -1,0 +1,16 @@
+// Every size on the site map derives from this one base unit. Bump EM to zoom the whole
+// map in or out — cell size, wall thickness, and every room icon's radius scale with it,
+// instead of needing a dozen hand-tuned constants kept in sync by hand.
+export const EM = 14
+
+export const CELL = EM * 4 // 56 — width/height of one grid cell, in SVG units
+export const WALL_THICKNESS = CELL / 11 // ~5
+
+// Room icon radii. Puzzle/trap rooms read slightly larger since their square shape has
+// more visual weight at the same radius than the circular/diamond ones.
+export const NODE_RADIUS_LARGE = CELL * 0.34 // entrance, gate, treasure, stairhead, exit — ~19
+export const NODE_RADIUS_PUZZLE = CELL * 0.36 // puzzle, trap — ~20
+export const NODE_RADIUS_FORK = CELL * 0.16 // junctions stay small — connective tissue, not a destination — ~9
+
+export const EXPLORER_DOT_RADIUS = CELL * 0.2 // ~11
+export const MARKER_RADIUS = CELL * 0.07 // reachable-corner dot / corridor-run arrow — ~4


### PR DESCRIPTION
## Summary
- Corridors and rooms rendered small on mobile ("more zoomed in" requested).
- New `src/app/SiteMap/mapScale.ts` is the single source of truth for every size on the map — cell size, wall thickness, and each room icon's radius are all derived from one base unit (`EM`), instead of a dozen independently hand-tuned pixel constants scattered across `SiteMapView.tsx` and `ExplorerDot.tsx` (the same duplication that caused an earlier off-center-dot bug). Bumping `EM` now zooms the whole map with a single change.
- Cell size: 44 → 56 (`EM=14`, `CELL=EM*4`), with wall thickness and every icon radius scaled to match.
- Updated `SiteMapView.spec.tsx`'s hardcoded pixel-position assumptions to derive from the same `CELL`/`WALL_THICKNESS` constants instead of magic numbers.

## Test plan
- [x] `yarn tsc -b` passes
- [x] `yarn lint` passes
- [x] `yarn vitest run` — 605 tests pass
- [x] Visually verified in Storybook: corridors/rooms/icons all scale together proportionally, nothing clips into walls

🤖 Generated with [Claude Code](https://claude.com/claude-code)