### PR TITLE
fix: keep the explorer dot's path on already-explored ground

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Fix the explorer dot cutting through unexplored corridors when a floor has a genuine loop and you tap a destination reachable by more than one route.
+
 ### Changed
 - The pyramid/tomb interior map is more zoomed in — corridors, rooms, and icons are all noticeably bigger.
 

--- a/src/game/gridNavigation.spec.ts
+++ b/src/game/gridNavigation.spec.ts
@@ -180,11 +180,56 @@ describe(findPath, () => {
   })
 
   it("returns path through corridor cells between two rooms", () => {
-    const grid = makeLinearGrid() // entrance(0,0) -e- corridor(0,1) -e- exit(0,2)
+    // Same shape as makeLinearGrid, but with states representing already-explored ground —
+    // the corridor and destination need to be seen (not "fogged") to be a valid route at all.
+    const grid: FloorGrid = {
+      ...makeLinearGrid(),
+      cells: [
+        [
+          { type: "room", roomType: "puzzle", dirs: new Set<Direction>(["e"]), state: "reachable" },
+          { type: "corridor", dirs: new Set<Direction>(["w", "e"]), state: "visible" },
+          { type: "room", roomType: "exit", dirs: new Set<Direction>(["w"]), state: "reachable" },
+        ],
+      ],
+    }
     const path = findPath(grid, [0, 0], [0, 2])
     expect(path).toEqual([
       [0, 0],
       [0, 1],
+      [0, 2],
+    ])
+  })
+
+  it("never routes through a fogged (unexplored) cell, even when it's the only shortest route", () => {
+    // A diamond: (0,1) is a direct, unexplored shortcut between the two rooms; (1,0)-(1,1)-(1,2)
+    // is a longer detour the player has actually seen. Real loops mean the graph-shortest path
+    // and the "route the player has walked" can now genuinely differ.
+    const grid: FloorGrid = {
+      siteId: "test",
+      rows: 2,
+      cols: 3,
+      entrancePos: [0, 0],
+      exitPos: [0, 2],
+      staircases: {},
+      cells: [
+        [
+          { type: "room", roomType: "puzzle", dirs: new Set<Direction>(["e", "s"]), state: "reachable" },
+          { type: "corridor", dirs: new Set<Direction>(["w", "e"]), state: "fogged" },
+          { type: "room", roomType: "exit", dirs: new Set<Direction>(["w", "s"]), state: "reachable" },
+        ],
+        [
+          { type: "corridor", dirs: new Set<Direction>(["n", "e"]), state: "visible" },
+          { type: "corridor", dirs: new Set<Direction>(["w", "e"]), state: "visible" },
+          { type: "corridor", dirs: new Set<Direction>(["w", "n"]), state: "visible" },
+        ],
+      ],
+    }
+    const path = findPath(grid, [0, 0], [0, 2])
+    expect(path).toEqual([
+      [0, 0],
+      [1, 0],
+      [1, 1],
+      [1, 2],
       [0, 2],
     ])
   })

--- a/src/game/gridNavigation.ts
+++ b/src/game/gridNavigation.ts
@@ -125,6 +125,12 @@ export const findPath = (
         nc = c + dc
       const nk = key(nr, nc)
       if (parent.has(nk)) continue
+      const neighbor = grid.cells[nr]?.[nc]
+      // Now that real loops exist, the graph-shortest route isn't always the one the
+      // player has actually walked — it can cut through a corridor never revealed yet.
+      // Restricting to non-fogged cells keeps the animated path on ground the player has
+      // genuinely seen, even if that means a longer route than the absolute shortest one.
+      if (!neighbor || neighbor.type === "empty" || neighbor.state === "fogged") continue
       parent.set(nk, key(r, c))
       if (nr === tr && nc === tc) break outer
       queue.push([nr, nc])

--- a/src/game/siteAssembler.spec.ts
+++ b/src/game/siteAssembler.spec.ts
@@ -1,8 +1,33 @@
 import { describe, expect, it } from "vitest"
 import { assembleFloor } from "./siteAssembler"
-import type { FloorConfig, FloorGrid, RoomCell } from "./siteTypes"
+import type { Direction, FloorConfig, FloorGrid, RoomCell } from "./siteTypes"
 import { validateSite } from "./siteValidator"
-import { findPath } from "./gridNavigation"
+
+const DIR_MOVE: Record<Direction, [number, number]> = { n: [-1, 0], s: [1, 0], e: [0, 1], w: [0, -1] }
+
+// Pure structural BFS distance, ignoring exploration state — assembleFloor's output is a
+// freshly-generated, unexplored grid, so findPath's real (state-aware) pathing has nothing
+// to work with here; this measures the maze's actual graph shape instead.
+const graphDistance = (grid: FloorGrid, from: readonly [number, number], to: readonly [number, number]): number => {
+  const key = (r: number, c: number) => `${r},${c}`
+  const visited = new Set([key(...from)])
+  const queue: Array<[number, number, number]> = [[from[0], from[1], 0]]
+  while (queue.length > 0) {
+    const [r, c, d] = queue.shift()!
+    if (r === to[0] && c === to[1]) return d
+    const cell = grid.cells[r]?.[c]
+    if (!cell || cell.type === "empty") continue
+    for (const dir of cell.dirs) {
+      const [dr, dc] = DIR_MOVE[dir]
+      const nr = r + dr,
+        nc = c + dc
+      if (visited.has(key(nr, nc))) continue
+      visited.add(key(nr, nc))
+      queue.push([nr, nc, d + 1])
+    }
+  }
+  throw new Error(`no path from ${from} to ${to}`)
+}
 
 const basicConfig = (): FloorConfig => ({
   pathPuzzles: 1,
@@ -198,7 +223,7 @@ describe(assembleFloor, () => {
       expect(result.success, `seed ${seed} failed assembly`).toBe(true)
       if (!result.success) continue
       const { grid } = result
-      const distanceTo = (r: number, c: number) => findPath(grid, grid.entrancePos, [r, c]).length - 1
+      const distanceTo = (r: number, c: number) => graphDistance(grid, grid.entrancePos, [r, c])
       const puzzleDistances: number[] = []
       const branchDistances: number[] = []
       for (let r = 0; r < grid.rows; r++) {


### PR DESCRIPTION
## Summary
- `findPath` did a plain graph BFS with no notion of exploration state, so it always returned the absolute graph-shortest route between two points regardless of `cell.state`.
- That was invisible while floors were effectively trees (one route between any two nodes). Now that real loops/alternate routes exist between rooms, the graph-shortest path and the route the player has actually walked can genuinely differ — tapping a destination could animate the explorer dot cutting straight through a corridor never revealed yet.
- Fix: neighbors with `state === "fogged"` are excluded from the BFS, so it only routes through ground the player has actually seen, even if that's a longer detour.

## Test plan
- [x] `yarn tsc -b` passes
- [x] `yarn lint` passes
- [x] `yarn vitest run` — 606 tests pass, including a new `gridNavigation.spec.ts` test with a diamond graph where the shortest route is unexplored and the longer one isn't (fails on the old code, confirmed via stash)
- [x] Updated two tests that were using `findPath` as a pure structural distance calculator on grids where cells default to `"fogged"` — unrelated to the state-aware pathing this fixes — to use realistic states / a local state-agnostic BFS helper instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)