### PR TITLE
feat: double the site map zoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- The pyramid/tomb interior map is zoomed in twice as far as the previous pass.
 
 ## 0.25.3 - 2026-07-05
 ### Changed

--- a/src/app/SiteMap/mapScale.ts
+++ b/src/app/SiteMap/mapScale.ts
@@ -1,16 +1,16 @@
 // Every size on the site map derives from this one base unit. Bump EM to zoom the whole
 // map in or out — cell size, wall thickness, and every room icon's radius scale with it,
 // instead of needing a dozen hand-tuned constants kept in sync by hand.
-export const EM = 14
+export const EM = 28
 
-export const CELL = EM * 4 // 56 — width/height of one grid cell, in SVG units
-export const WALL_THICKNESS = CELL / 11 // ~5
+export const CELL = EM * 4 // 112 — width/height of one grid cell, in SVG units
+export const WALL_THICKNESS = CELL / 11 // ~10
 
 // Room icon radii. Puzzle/trap rooms read slightly larger since their square shape has
 // more visual weight at the same radius than the circular/diamond ones.
-export const NODE_RADIUS_LARGE = CELL * 0.34 // entrance, gate, treasure, stairhead, exit — ~19
-export const NODE_RADIUS_PUZZLE = CELL * 0.36 // puzzle, trap — ~20
-export const NODE_RADIUS_FORK = CELL * 0.16 // junctions stay small — connective tissue, not a destination — ~9
+export const NODE_RADIUS_LARGE = CELL * 0.34 // entrance, gate, treasure, stairhead, exit — ~38
+export const NODE_RADIUS_PUZZLE = CELL * 0.36 // puzzle, trap — ~40
+export const NODE_RADIUS_FORK = CELL * 0.16 // junctions stay small — connective tissue, not a destination — ~18
 
-export const EXPLORER_DOT_RADIUS = CELL * 0.2 // ~11
-export const MARKER_RADIUS = CELL * 0.07 // reachable-corner dot / corridor-run arrow — ~4
+export const EXPLORER_DOT_RADIUS = CELL * 0.2 // ~22
+export const MARKER_RADIUS = CELL * 0.07 // reachable-corner dot / corridor-run arrow — ~8


### PR DESCRIPTION
## Summary
- Bumped `EM` 14 → 28 in `mapScale.ts`. Every other size (cell, wall thickness, icon radii, explorer dot, markers) derives from it, so the whole map scales with this one change.

## Test plan
- [x] `yarn tsc -b` / `yarn lint` / `yarn vitest run` — 606 tests pass
- [x] Visually verified in Storybook — corridors, rooms, and icons are all twice as big

🤖 Generated with [Claude Code](https://claude.com/claude-code)