### PR TITLE
feat: add a Settings toggle to disable Fez's tutorial popups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- A "Disable tutorials" toggle in Settings, for skipping Fez's guidance popups. Explicit replays (like the tomb's "?" button) still work even with tutorials disabled.
+
 ### Changed
 - The pyramid/tomb interior map is zoomed in twice as far as the previous pass.
 

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -67,6 +67,7 @@
     "done": "Done",
     "clearGameData": "Clear game data",
     "confirmClearGameData": "This permanently deletes all progress, items, and explored pyramids. This cannot be undone.",
+    "disableTutorials": "Disable tutorials",
     "progressLevel": "In Progress",
     "treasureTomb": "Treasure Location",
     "requiresMapPieces": "Requires map pieces",

--- a/public/locales/nl/common.json
+++ b/public/locales/nl/common.json
@@ -67,6 +67,7 @@
     "done": "Klaar",
     "clearGameData": "Spelgegevens wissen",
     "confirmClearGameData": "Dit verwijdert permanent alle voortgang, items en verkende piramides. Dit kan niet ongedaan worden gemaakt.",
+    "disableTutorials": "Tutorials uitschakelen",
     "progressLevel": "Voortgang",
     "treasureTomb": "Schatlokatie",
     "requiresMapPieces": "Vereist kaartdelen",

--- a/src/app/SettingsModal.tsx
+++ b/src/app/SettingsModal.tsx
@@ -1,7 +1,7 @@
 import { type FC, useState, useEffect } from "react"
 import { useTranslation } from "react-i18next"
 import { version } from "@/../package.json"
-import { clearGameData } from "@/support/useGameStorage"
+import { clearGameData, useGameStorage } from "@/support/useGameStorage"
 import { ConfirmModal } from "@/ui/atoms/ConfirmModal"
 
 type SettingsModalProps = {
@@ -13,6 +13,7 @@ export const SettingsModal: FC<SettingsModalProps> = ({ isOpen, onClose }) => {
   const { t, i18n } = useTranslation("common")
   const [selectedLanguage, setSelectedLanguage] = useState(i18n.language)
   const [showClearConfirm, setShowClearConfirm] = useState(false)
+  const [tutorialsEnabled, setTutorialsEnabled] = useGameStorage<boolean>("tutorialsEnabled", true)
 
   const handleClearGameData = async () => {
     await clearGameData()
@@ -78,6 +79,17 @@ export const SettingsModal: FC<SettingsModalProps> = ({ isOpen, onClose }) => {
               ))}
             </select>
           </div>
+
+          {/* Disable tutorials */}
+          <label className="flex items-center justify-between gap-2">
+            <span className="text-sm font-medium text-gray-700">{t("ui.disableTutorials")}</span>
+            <input
+              type="checkbox"
+              checked={!tutorialsEnabled}
+              onChange={e => setTutorialsEnabled(!e.target.checked)}
+              className="h-5 w-5 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+            />
+          </label>
 
           {/* Clear game data */}
           <div>

--- a/src/app/fez/FezCompanion.tsx
+++ b/src/app/fez/FezCompanion.tsx
@@ -3,6 +3,7 @@ import { createPortal } from "react-dom"
 import { Fez } from "./Fez"
 import { useGameStorage } from "@/support/useGameStorage"
 import { FezContext, type FezConversationResult } from "./context"
+import { shouldSkipConversation } from "./shouldSkipConversation"
 
 export const FezCompanion: React.FC<{
   children: React.ReactNode
@@ -15,6 +16,7 @@ export const FezCompanion: React.FC<{
     }[]
   >([])
   const [conversations, setConversations, loaded] = useGameStorage<Record<string, boolean>>("conversations", {})
+  const [tutorialsEnabled] = useGameStorage<boolean>("tutorialsEnabled", true)
 
   const contextValue = useMemo(
     () => ({
@@ -26,7 +28,7 @@ export const FezCompanion: React.FC<{
         if (!loaded) {
           return onComplete?.("not-loaded")
         }
-        if (conversations[conversationId] && !options?.forceReplay) {
+        if (shouldSkipConversation(!!conversations[conversationId], tutorialsEnabled, options?.forceReplay)) {
           return onComplete?.("seen-earlier")
         }
         const entry = {
@@ -58,7 +60,7 @@ export const FezCompanion: React.FC<{
         }
       },
     }),
-    [conversations, loaded, setConversations]
+    [conversations, loaded, setConversations, tutorialsEnabled]
   )
 
   return (

--- a/src/app/fez/shouldSkipConversation.spec.ts
+++ b/src/app/fez/shouldSkipConversation.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest"
+import { shouldSkipConversation } from "./shouldSkipConversation"
+
+describe(shouldSkipConversation, () => {
+  it("shows an unseen conversation when tutorials are enabled", () => {
+    expect(shouldSkipConversation(false, true, undefined)).toBe(false)
+  })
+
+  it("skips an already-seen conversation", () => {
+    expect(shouldSkipConversation(true, true, undefined)).toBe(true)
+  })
+
+  it("skips a new conversation when tutorials are disabled", () => {
+    expect(shouldSkipConversation(false, false, undefined)).toBe(true)
+  })
+
+  it("still shows the conversation on an explicit replay, even with tutorials disabled", () => {
+    expect(shouldSkipConversation(true, false, true)).toBe(false)
+  })
+})

--- a/src/app/fez/shouldSkipConversation.ts
+++ b/src/app/fez/shouldSkipConversation.ts
@@ -1,0 +1,7 @@
+// Tutorials off still allows an explicit replay (e.g. the tomb's "?" button) — the setting
+// only stops them popping up unprompted.
+export const shouldSkipConversation = (
+  alreadySeen: boolean,
+  tutorialsEnabled: boolean,
+  forceReplay: boolean | undefined
+): boolean => (alreadySeen || !tutorialsEnabled) && !forceReplay


### PR DESCRIPTION
## Summary
- Every tutorial/onboarding popup ("welcome", "pyramidIntro", "tombTutorial", etc.) is a "Fez conversation" routed through a single `showConversation` entry point in `FezCompanion.tsx`.
- Added a persisted `"tutorialsEnabled"` setting (`useGameStorage`, default `true`) with a checkbox in the Settings modal ("Disable tutorials").
- Disabling tutorials still allows an explicit replay — the tomb's "?" button (`forceReplay: true`) keeps working, matching its existing UX intent.
- The skip decision is extracted into a small pure function, `shouldSkipConversation`, in its own file (React Fast Refresh requires component files to only export components) — also makes the gating logic trivially unit-testable.

## Test plan
- [x] `yarn tsc -b` / `yarn lint` / `yarn vitest run` — 610 tests pass (4 new for the gating logic)
- [x] Verified end-to-end via the dev server: toggling the setting on and reloading no longer shows the "Welcome to Pyramid Scheme!" popup; the setting persists across reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)