### PR TITLE
Fix site map rendering squished on narrow screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Fix the pyramid/tomb interior map rendering squished on narrow screens — the map now always renders at full size and scrolls in both directions instead of shrinking to fit the width while staying full height.
 
 ## 0.26.0 - 2026-07-05
 ### Added

--- a/src/app/SiteMap/SiteMapView.tsx
+++ b/src/app/SiteMap/SiteMapView.tsx
@@ -949,7 +949,7 @@ export const SiteMapView = ({
         viewBox={`0 0 ${svgWidth} ${svgHeight}`}
         role="img"
         aria-label="site map"
-        className="m-auto"
+        className="m-auto shrink-0"
         style={{ background: "#110d08" }}
       >
         <defs>


### PR DESCRIPTION
## Summary
- Root cause of the "scroll area is big but tiles are small" report: the site map `<svg>` is a flex child of an `overflow-auto` container. As a replaced element it defaults to `flex-shrink: 1`, so on any viewport narrower than the map's native pixel width, flexbox shrank the svg's *width* to fit while its *height* stayed at full intrinsic size — squishing the whole map horizontally instead of scrolling.
- This existed before, but rarely triggered because grids at half the size (pre-zoom-2x) usually fit within typical viewport widths. Doubling the map made it much easier to exceed the viewport width and hit the bug.
- Fix: add `shrink-0` to the svg so it always renders at its native size and the container scrolls in both axes instead of distorting.

Verified by reproducing the squish in a narrow-viewport Storybook harness (svg boundingBox width collapsed to the container's width while height stayed at full intrinsic size) and confirming `shrink-0` makes both axes match the native 1904×1904 size with proper overflow scrolling.

Also confirmed via `curl` that the live v0.26.0 deploy's JS bundle is byte-identical to a fresh local build of `main`, ruling out a stale deploy/cache as the cause.

## Test plan
- [x] `yarn tsc -b`
- [x] `yarn lint`
- [x] `yarn vitest run src/app/SiteMap`
- [x] Reproduced and verified the fix visually via Storybook + Playwright

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013L2NVyxvE7rSBew4yRj7ZM