### PR TITLE
Journey list: drop times-completed count, fix map-piece badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- The journey list only shows a checkmark for completed expeditions now, without the "completed N times" count.
+
+### Fixed
+- The journey list's map-piece indicator now lights up again when you've found a pyramid's map piece.
 
 ## 0.26.2 - 2026-07-05
 ### Changed

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -46,8 +46,6 @@
     "backArrow": "←",
     "back": "← Back",
     "floor": "Floor {{number}}",
-    "timesSingular": "time",
-    "timesPlural": "times",
     "travel": "Travel",
     "chooseYourJourney": "Choose Your Journey",
     "backToMap": "Back to Map",

--- a/public/locales/nl/common.json
+++ b/public/locales/nl/common.json
@@ -46,8 +46,6 @@
     "backArrow": "←",
     "back": "← Terug",
     "floor": "Verdieping {{number}}",
-    "timesSingular": "keer",
-    "timesPlural": "keer",
     "travel": "Reizen",
     "chooseYourJourney": "Kies je Reis",
     "backToMap": "Terug naar Kaart",

--- a/src/app/PyramidExpedition/ExpeditionCompletionOverlay.tsx
+++ b/src/app/PyramidExpedition/ExpeditionCompletionOverlay.tsx
@@ -3,6 +3,7 @@ import { use, useEffect, type FC } from "react"
 import { useTranslation } from "react-i18next"
 import { journeys as allJourneys, type PyramidJourney } from "@/data/journeys"
 import { useJourneys, type CombinedJourneyState } from "../state/useJourneys"
+import { useProgression } from "../state/useProgression"
 import { FezContext } from "../fez/context"
 
 export const ExpeditionCompletionOverlay: FC<{
@@ -13,6 +14,7 @@ export const ExpeditionCompletionOverlay: FC<{
 }> = ({ onJourneyComplete, onStartJourney, newPyramidJourneyId, activeJourney }) => {
   const { t } = useTranslation("common")
   const { getJourney } = useJourneys()
+  const { hasMapPiece } = useProgression()
   const journey = activeJourney.journey as PyramidJourney
   const { showConversation } = use(FezContext)
 
@@ -26,7 +28,7 @@ export const ExpeditionCompletionOverlay: FC<{
   const pyramidJourneysForDifficulty = allJourneys.filter(
     j => j.type === "pyramid" && j.difficulty === journey.difficulty
   )
-  const allMapPiecesFound = pyramidJourneysForDifficulty.every(j => getJourney(j.id)?.foundMapPiece === true)
+  const allMapPiecesFound = pyramidJourneysForDifficulty.every(j => hasMapPiece(j.id))
   const tombState = tombJourney ? getJourney(tombJourney.id) : undefined
   const newTombJourneyId =
     allMapPiecesFound && tombJourney && (tombState?.completionCount ?? 0) === 0 ? tombJourney.id : undefined

--- a/src/app/PyramidLevel/lootEffects.spec.ts
+++ b/src/app/PyramidLevel/lootEffects.spec.ts
@@ -8,7 +8,6 @@ const makeJourney = (levelNr = 1, seed = 12345): CombinedJourneyState =>
     journeyId: "starter_pyramid_1",
     levelNr,
     completionCount: 0,
-    foundMapPiece: false,
     inProgress: true,
     active: true,
     randomSeed: seed,

--- a/src/app/PyramidLevel/mapPieceLogic.spec.ts
+++ b/src/app/PyramidLevel/mapPieceLogic.spec.ts
@@ -15,7 +15,6 @@ const makeState = (overrides: Partial<CombinedJourneyState> & { journey?: Transl
     randomSeed: 12345,
     levelNr: 1,
     completionCount: 0,
-    foundMapPiece: false,
     journey: makeJourney("pyramid"),
     ...overrides,
   }) as unknown as CombinedJourneyState
@@ -23,54 +22,54 @@ const makeState = (overrides: Partial<CombinedJourneyState> & { journey?: Transl
 const noJourneyInfo = () => undefined
 
 describe("determineMapPieceLoot", () => {
-  it("mapPieceChance is 0 when foundMapPiece is true", () => {
-    const state = makeState({ foundMapPiece: true })
+  it("mapPieceChance is 0 when hasMapPiece is true", () => {
+    const state = makeState({})
     const getJourney = () => state
-    const result = determineMapPieceLoot(state, getJourney)
+    const result = determineMapPieceLoot(state, getJourney, true)
     expect(result.mapPieceChance).toBe(0)
     expect(result.shouldAwardMapPiece).toBe(false)
   })
 
   it("mapPieceChance is 0 for non-pyramid journeys", () => {
     const state = makeState({ journey: makeJourney("treasure_tomb") })
-    const result = determineMapPieceLoot(state, noJourneyInfo)
+    const result = determineMapPieceLoot(state, noJourneyInfo, false)
     expect(result.mapPieceChance).toBe(0)
   })
 
   it("mapPieceChance = startChance when completionCount is 0", () => {
     const state = makeState({ journey: makeJourney("pyramid", 0.4, 0.2) })
-    const getJourney = () => ({ ...state, completionCount: 0, foundMapPiece: false })
-    const result = determineMapPieceLoot(state, getJourney)
+    const getJourney = () => ({ ...state, completionCount: 0 })
+    const result = determineMapPieceLoot(state, getJourney, false)
     expect(result.mapPieceChance).toBeCloseTo(0.4)
   })
 
   it("mapPieceChance increases with completionCount", () => {
     const state = makeState({ journey: makeJourney("pyramid", 0.4, 0.2) })
-    const getJourney = (n: number) => () => ({ ...state, completionCount: n, foundMapPiece: false })
-    const r0 = determineMapPieceLoot(state, getJourney(0))
-    const r2 = determineMapPieceLoot(state, getJourney(2))
+    const getJourney = (n: number) => () => ({ ...state, completionCount: n })
+    const r0 = determineMapPieceLoot(state, getJourney(0), false)
+    const r2 = determineMapPieceLoot(state, getJourney(2), false)
     expect(r2.mapPieceChance).toBeCloseTo(r0.mapPieceChance + 2 * 0.2)
   })
 
   it("bonusMapFragmentChance is added to base chance", () => {
     const state = makeState({ journey: makeJourney("pyramid", 0.4, 0.0) })
-    const getJourney = () => ({ ...state, completionCount: 0, foundMapPiece: false })
-    const base = determineMapPieceLoot(state, getJourney)
-    const bonus = determineMapPieceLoot(state, getJourney, 0.15)
+    const getJourney = () => ({ ...state, completionCount: 0 })
+    const base = determineMapPieceLoot(state, getJourney, false)
+    const bonus = determineMapPieceLoot(state, getJourney, false, 0.15)
     expect(bonus.mapPieceChance).toBeCloseTo(base.mapPieceChance + 0.15)
   })
 
   it("result is deterministic for the same seed", () => {
     const state = makeState({ journey: makeJourney("pyramid", 0.5, 0.1) })
-    const getJourney = () => ({ ...state, completionCount: 1, foundMapPiece: false })
-    const r1 = determineMapPieceLoot(state, getJourney)
-    const r2 = determineMapPieceLoot(state, getJourney)
+    const getJourney = () => ({ ...state, completionCount: 1 })
+    const r1 = determineMapPieceLoot(state, getJourney, false)
+    const r2 = determineMapPieceLoot(state, getJourney, false)
     expect(r1.shouldAwardMapPiece).toBe(r2.shouldAwardMapPiece)
   })
 
   it("falls back to completionCount=0 when getJourney returns undefined", () => {
     const state = makeState({ journey: makeJourney("pyramid", 0.4, 0.2) })
-    const result = determineMapPieceLoot(state, noJourneyInfo)
+    const result = determineMapPieceLoot(state, noJourneyInfo, false)
     expect(result.mapPieceChance).toBeCloseTo(0.4)
   })
 })

--- a/src/app/PyramidLevel/mapPieceLogic.ts
+++ b/src/app/PyramidLevel/mapPieceLogic.ts
@@ -17,6 +17,7 @@ const getMapPieceChance = (journey: Journey, journeyCount: number): number => {
 export const determineMapPieceLoot = (
   activeJourney: CombinedJourneyState,
   getJourney: (journeyId: string) => CombinedJourneyState | undefined,
+  hasMapPiece: boolean,
   bonusMapFragmentChance: number = 0
 ): MapPieceResult => {
   const journeyInfo = getJourney(activeJourney.journeyId)
@@ -24,11 +25,10 @@ export const determineMapPieceLoot = (
 
   const lootSeed = generateNewSeed(activeJourney.randomSeed, activeJourney.levelNr)
   const random = mulberry32(lootSeed)
-  const foundMapPiece = journeyInfo?.foundMapPiece || false
 
   const journey = activeJourney.journey
 
-  const mapPieceChance = foundMapPiece ? 0 : getMapPieceChance(journey, journeyCount) + bonusMapFragmentChance
+  const mapPieceChance = hasMapPiece ? 0 : getMapPieceChance(journey, journeyCount) + bonusMapFragmentChance
 
   const shouldAwardMapPiece = random() < mapPieceChance
 

--- a/src/app/PyramidLevel/useLootDetermination.tsx
+++ b/src/app/PyramidLevel/useLootDetermination.tsx
@@ -1,4 +1,5 @@
 import { useJourneys, type CombinedJourneyState } from "@/app/state/useJourneys"
+import { useProgression } from "@/app/state/useProgression"
 import { useMemo } from "react"
 import { useTranslation } from "react-i18next"
 import { determineMapPieceLoot } from "./mapPieceLogic"
@@ -50,11 +51,12 @@ const makeInventoryLoot = (
 export const useLootDetermination = (
   activeJourney: CombinedJourneyState
 ): { loot: Loot | null; collectLoot: () => void } => {
-  const { findMapPiece, getJourney, nextJourneySeed, maxDifficulty } = useJourneys()
+  const { getJourney, nextJourneySeed, maxDifficulty } = useJourneys()
+  const { hasMapPiece, markMapPieceFound } = useProgression()
   const { inventory, addItems } = useInventory()
   const { t } = useTranslation("treasures")
 
-  const mapPieceResult = determineMapPieceLoot(activeJourney, getJourney, 0)
+  const mapPieceResult = determineMapPieceLoot(activeJourney, getJourney, hasMapPiece(activeJourney.journeyId), 0)
   const inventoryResult = determineInventoryLootForCurrentRuns(
     activeJourney,
     maxDifficulty,
@@ -79,7 +81,7 @@ export const useLootDetermination = (
           itemComponent: "📜",
           rarity: "rare",
         },
-        collectLoot: findMapPiece,
+        collectLoot: () => markMapPieceFound(activeJourney.journeyId),
       }
     }
 
@@ -100,8 +102,9 @@ export const useLootDetermination = (
     expeditionItemIds,
     inventoryItemHook,
     activeJourney.journey,
+    activeJourney.journeyId,
     t,
-    findMapPiece,
+    markMapPieceFound,
     addItems,
   ])
 }

--- a/src/app/SiteMap/SiteMapScreen.tsx
+++ b/src/app/SiteMap/SiteMapScreen.tsx
@@ -237,7 +237,10 @@ export const SiteMapScreen = ({ journeyId, siteConfig, seed, onSiteComplete, onC
                 onCollect: () => {
                   if (reward.type === "hieroglyphFragment")
                     progression.addFragment(reward.hieroglyphId, reward.pieceIndex)
-                  else if (reward.type === "mapPiece") progression.collectMapPiece(reward.tombId)
+                  else if (reward.type === "mapPiece") {
+                    progression.collectMapPiece(reward.tombId)
+                    journeys.findMapPiece()
+                  }
                   else if (reward.type === "tombKey") {
                     progression.addTombKey(reward.keyId)
                     progression.applyTreasurePerk(reward.keyId)

--- a/src/app/SiteMap/SiteMapScreen.tsx
+++ b/src/app/SiteMap/SiteMapScreen.tsx
@@ -239,7 +239,7 @@ export const SiteMapScreen = ({ journeyId, siteConfig, seed, onSiteComplete, onC
                     progression.addFragment(reward.hieroglyphId, reward.pieceIndex)
                   else if (reward.type === "mapPiece") {
                     progression.collectMapPiece(reward.tombId)
-                    journeys.findMapPiece()
+                    progression.markMapPieceFound(journeyId)
                   }
                   else if (reward.type === "tombKey") {
                     progression.addTombKey(reward.keyId)

--- a/src/app/SiteMap/SiteMapScreen.tsx
+++ b/src/app/SiteMap/SiteMapScreen.tsx
@@ -240,8 +240,7 @@ export const SiteMapScreen = ({ journeyId, siteConfig, seed, onSiteComplete, onC
                   else if (reward.type === "mapPiece") {
                     progression.collectMapPiece(reward.tombId)
                     progression.markMapPieceFound(journeyId)
-                  }
-                  else if (reward.type === "tombKey") {
+                  } else if (reward.type === "tombKey") {
                     progression.addTombKey(reward.keyId)
                     progression.applyTreasurePerk(reward.keyId)
                   } else if (reward.type === "mosaicPiece") progression.collectMosaicPiece()

--- a/src/app/pages/Travel.tsx
+++ b/src/app/pages/Travel.tsx
@@ -283,8 +283,6 @@ export const TravelPage: FC<{
                         length: t("ui.length"),
                         chambers: t("ui.chambers"),
                         progressLevel: t("ui.progressLevel"),
-                        timesPlural: t("ui.timesPlural"),
-                        timesSingular: t("ui.timesSingular"),
                       }}
                       onClick={handleJourneySelect}
                     >

--- a/src/app/pages/Travel.tsx
+++ b/src/app/pages/Travel.tsx
@@ -22,7 +22,7 @@ export const TravelPage: FC<{
   const journeys = useJourneyTranslations()
 
   const { activeJourneyId, startJourney, visitLevel, cancelJourney, getJourney } = useJourneys()
-  const { isTombDiscovered, mapPieceCount } = useProgression()
+  const { isTombDiscovered, mapPieceCount, hasMapPiece: hasFoundMapPiece } = useProgression()
   const [showJourneySelection, setShowJourneySelection] = useState(false)
   const [selectedJourney, setSelectedJourney] = useState<TranslatedJourney | null>(null)
   const [showInterruptModal, setShowInterruptModal] = useState(false)
@@ -237,7 +237,7 @@ export const TravelPage: FC<{
                 }
                 const journeyInfo = getJourney(journey.id)
                 const completionCount = journeyInfo?.completionCount ?? 0
-                const hasMapPiece = journeyInfo?.foundMapPiece ?? false
+                const hasMapPiece = hasFoundMapPiece(journey.id)
                 const progressLevelNr = journeyInfo?.levelNr ?? 0
 
                 if (journey.type === "treasure_tomb") {

--- a/src/app/state/useJourneys.spec.ts
+++ b/src/app/state/useJourneys.spec.ts
@@ -24,7 +24,6 @@ const makeStoredJourney = (overrides: Partial<StoredJourneyStateV3> = {}): Store
   journeyId: REAL_ID,
   levelNr: 1,
   completionCount: 0,
-  foundMapPiece: false,
   active: true,
   exploredSections: {},
   position: null,

--- a/src/app/state/useJourneys.ts
+++ b/src/app/state/useJourneys.ts
@@ -12,7 +12,6 @@ export type StoredJourneyStateV3 = {
   levelNr: number
 
   completionCount: number
-  foundMapPiece: boolean
   active: boolean
   // keyed by sectionHash; cells explored in the site interior — persists across revisits
   // stale entries (section hash no longer in world) are silently ignored on apply
@@ -40,7 +39,6 @@ export type JourneyAPI = {
   completeJourney: () => void
   cancelJourney: () => void
   completeLevel: () => void
-  findMapPiece: () => void
   markCellExplored: (sectionHash: string, cellId: string) => void
   getExploredSections: (journeyId: string) => Record<string, string[]>
   updatePosition: (journeyId: string, nodeId: string) => void
@@ -140,7 +138,6 @@ export const createJourneysV3Api = ({
       journeyId: journey.id,
       levelNr: 1,
       completionCount: 0,
-      foundMapPiece: false,
       active: true,
       exploredSections: {},
       position: null,
@@ -194,11 +191,6 @@ export const createJourneysV3Api = ({
         j.journeyId === activeJourneyId ? { ...j, levelNr: j.levelNr + 1, position: null, interiorLevelNr: null } : j
       )
     )
-  }
-
-  const findMapPiece = () => {
-    if (!activeJourneyId) return
-    setJourneys(prev => prev.map(j => (j.journeyId === activeJourneyId ? { ...j, foundMapPiece: true } : j)))
   }
 
   const markCellExplored = (sectionHash: string, cellId: string) => {
@@ -292,7 +284,6 @@ export const createJourneysV3Api = ({
     maxDifficulty,
     getJourney,
     nextJourneySeed,
-    findMapPiece,
     startJourney,
     visitLevel,
     completeJourney,

--- a/src/app/state/useProgression.ts
+++ b/src/app/state/useProgression.ts
@@ -34,6 +34,8 @@ type ProgressionState = {
   mosaicSeenCount: number
   mosaicPieceCount: number
   collectedMapPieces: Record<string, number>
+  // journeyIds whose map-piece chest has been opened — inventory-as-truth for the journey list badge
+  mapPieceJourneys: string[]
   currentHealth: number // half-hearts
   maxHealth: number // half-hearts
   consumables: ConsumableInventory
@@ -58,6 +60,7 @@ const initialState: ProgressionState = {
   mosaicSeenCount: 0,
   mosaicPieceCount: 0,
   collectedMapPieces: {},
+  mapPieceJourneys: [],
   currentHealth: 6,
   maxHealth: 6,
   consumables: { bandage: 0, oil: 0, trapTool: 0 },
@@ -85,6 +88,8 @@ export type ProgressionAPI = {
   markMosaicViewed: (count: number) => void
   collectMapPiece: (tombId: string) => void
   mapPieceCount: (tombId: string) => number
+  hasMapPiece: (journeyId: string) => boolean
+  markMapPieceFound: (journeyId: string) => void
   currentHealth: number
   maxHealth: number
   canAttemptTrap: () => boolean
@@ -185,6 +190,13 @@ export const useProgression = (): ProgressionAPI => {
           }
         }),
       mapPieceCount: tombId => state.collectedMapPieces[tombId] ?? 0,
+      hasMapPiece: journeyId => (state.mapPieceJourneys ?? []).includes(journeyId),
+      markMapPieceFound: journeyId =>
+        setState(prev =>
+          (prev.mapPieceJourneys ?? []).includes(journeyId)
+            ? prev
+            : { ...prev, mapPieceJourneys: [...(prev.mapPieceJourneys ?? []), journeyId] }
+        ),
       currentHealth: state.currentHealth ?? 6,
       maxHealth: state.maxHealth ?? 6,
       canAttemptTrap: () => canAttemptTrap(state.currentHealth ?? 6),

--- a/src/ui/organisms/JourneyCard.stories.tsx
+++ b/src/ui/organisms/JourneyCard.stories.tsx
@@ -91,8 +91,6 @@ const meta = {
       length: "Length",
       chambers: "chambers",
       progressLevel: "Progress: Level",
-      timesPlural: "times",
-      timesSingular: "time",
     },
   },
 } satisfies Meta<typeof JourneyCard>

--- a/src/ui/organisms/JourneyCard.tsx
+++ b/src/ui/organisms/JourneyCard.tsx
@@ -8,8 +8,6 @@ type JourneyCardLabels = {
   length: string
   chambers: string
   progressLevel: string
-  timesPlural: string
-  timesSingular: string
 }
 
 type JourneyCardProps = {
@@ -140,12 +138,9 @@ export const JourneyCard: FC<PropsWithChildren<JourneyCardProps>> = ({
                 <span className="ml-1 inline-flex items-center bg-green-800 bg-clip-text text-transparent">📜</span>
               )}{" "}
               {completionCount > 0 && (
-                <>
-                  <span className="inline-flex size-5 scale-75 items-center justify-center rounded-full bg-green-800 p-0.5 text-xs text-white">
-                    ✔︎
-                  </span>
-                  : {completionCount} {completionCount > 1 ? labels.timesPlural : labels.timesSingular}
-                </>
+                <span className="inline-flex size-5 scale-75 items-center justify-center rounded-full bg-green-800 p-0.5 text-xs text-white">
+                  ✔︎
+                </span>
               )}
             </span>
           )}


### PR DESCRIPTION
## Summary
- The journey list checkmark no longer shows the "completed N times" count next to it — just the checkmark.
- The 📜 map-piece badge on a pyramid's journey card lights up again: it relied on `useJourneys().findMapPiece()`, which stopped being called once map pieces moved into site-interior chests (collected via `progression.collectMapPiece()` in `SiteMapScreen` instead).
- Follow-up refactor: replaced the standalone `foundMapPiece` boolean on journey state with `progression.mapPieceJourneys` (same inventory-as-truth pattern as `collectedFragments`), so the badge, the legacy RNG loot path, and `ExpeditionCompletionOverlay`'s "all pieces found" check all read from one source instead of a flag that had to be kept in sync by hand — this should hold up better across world regenerations while authoring continues.

## Test plan
- [ ] Complete a pyramid, find its map piece via a chest, confirm the journey list shows the 📜 badge afterward
- [ ] Confirm the journey list checkmark still shows for completed journeys, without a "times completed" count
- [ ] `yarn test` / `yarn check-types` / `yarn lint` all pass (verified locally)

Note: existing local save data collected before this change won't retroactively show the badge (no migration, matching this project's existing "hard reset over migration" convention for schema changes) — clear game data if you want a clean state.