### PR TITLE
Spread main-path content, expose corridor straightness knob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Puzzles, chests, and a floor's main treasure room are now spread out along the whole path from entrance to exit, instead of being packed near the entrance with a long empty corridor afterward.
 
 ## 0.26.3 - 2026-07-05
 ### Changed

--- a/src/game/siteAssembler.ts
+++ b/src/game/siteAssembler.ts
@@ -85,11 +85,12 @@ const makePkey = (N: number) => (r1: number, c1: number, r2: number, c2: number)
 // A plain random-direction DFS maze is very serpentine (every step is a coin flip);
 // biasing toward straight runs gives longer corridors and fewer forced turns, which
 // reads as "a real place" and needs fewer click-to-reveal stops on first traversal.
-const STRAIGHT_BIAS = 0.65
+// Overridable per floor via FloorConfig.corridorStraightness (see assembleFloor).
+const DEFAULT_STRAIGHT_BIAS = 0.65
 
 // Generate a perfect DFS maze on an N×N grid starting from (entR, entC).
 // Returns adjacency function, BFS path from entrance to farthest cell, and passages set.
-const buildMaze = (N: number, entR: number, entC: number, rand: () => number) => {
+const buildMaze = (N: number, entR: number, entC: number, rand: () => number, straightBias: number) => {
   const passages = new Set<string>()
   const visited = new Set<string>()
   const pkey = makePkey(N)
@@ -110,7 +111,7 @@ const buildMaze = (N: number, entR: number, entC: number, rand: () => number) =>
       const incoming = arrivedVia.get(`${r},${c}`)
       const straightAhead = incoming && unvisited.find(([nr, nc]) => nr - r === incoming[0] && nc - c === incoming[1])
       const [nr, nc] =
-        straightAhead && rand() < STRAIGHT_BIAS ? straightAhead : unvisited[Math.floor(rand() * unvisited.length)]
+        straightAhead && rand() < straightBias ? straightAhead : unvisited[Math.floor(rand() * unvisited.length)]
       passages.add(pkey(r, c, nr, nc))
       visited.add(`${nr},${nc}`)
       arrivedVia.set(`${nr},${nc}`, [nr - r, nc - c])
@@ -286,17 +287,39 @@ export const assembleFloor = (siteId: string, config: FloorConfig, seed: number)
     }
     const [entR, entC] = edgeCells[Math.floor(rand() * edgeCells.length)]
 
-    const { neighbors, mainPath, passages } = buildMaze(N, entR, entC, rand)
+    const straightBias = config.corridorStraightness ?? DEFAULT_STRAIGHT_BIAS
+    const { neighbors, mainPath, passages } = buildMaze(N, entR, entC, rand, straightBias)
 
     // Exit placed at the farthest dead-end (degree-1) so no corridor passes through it.
-    // mainPath is already a sequence of directly-connected nodes (see buildMaze), so
-    // the main-path content nodes are just its first interLen+2 entries, taken directly
-    // — no stride multiplication needed like the old dense model required.
+    // Content nodes (puzzles/chests + the goal) are spread evenly across the whole main
+    // path instead of packed against the entrance — packing them up front left a long
+    // bare corridor behind the goal with nothing to do and nowhere to branch. Spreading
+    // keeps something to find along the whole walk, and puts the goal last (closest to
+    // the exit) so there's no unused tail behind it either.
     const interLen = intermediateTypes.length
-    const goalIndex = interLen + 1 // 0 = entrance, 1..interLen = intermediates, interLen+1 = goal
-    if (mainPath.length < goalIndex + 2) continue // need >=1 more node past the goal, for a distinct exit
+    const contentCount = interLen + 1 // + goal
+    if (mainPath.length < contentCount + 2) continue // need entrance + content + a distinct exit
 
-    const mainNodeCells: Array<[number, number]> = mainPath.slice(0, goalIndex + 1)
+    const contentIndices: number[] = []
+    {
+      const used = new Set<number>()
+      const lastIdx = mainPath.length - 2 // reserve the final index for the exit
+      for (let i = 0; i < contentCount; i++) {
+        const t = (i + 1) / (contentCount + 1)
+        let idx = Math.round(1 + t * (lastIdx - 1))
+        idx = Math.max(1, Math.min(lastIdx, idx))
+        while (used.has(idx) && idx < lastIdx) idx++
+        while (used.has(idx) && idx > 1) idx--
+        used.add(idx)
+        contentIndices.push(idx)
+      }
+      contentIndices.sort((a, b) => a - b)
+    }
+    const goalIndex = contentIndices[contentIndices.length - 1]
+    // Aligned with intermediateTypes order — puzzleChestIndices[k] is where intermediateTypes[k] lands.
+    const puzzleChestIndices = contentIndices.slice(0, -1)
+    const puzzleChestRole = new Map<number, number>()
+    puzzleChestIndices.forEach((idx, k) => puzzleChestRole.set(idx, k))
 
     // Full mainPath as corridor so sections can branch from anywhere along it
     const usedCells = new Set<string>(mainPath.map(([r, c]) => `${r},${c}`))
@@ -664,11 +687,12 @@ export const assembleFloor = (siteId: string, config: FloorConfig, seed: number)
     // Collect branch junction cells (become fork nodes)
     const forkPositions = new Set(sectionGroups.map(g => posKey(g.attachedAt[0], g.attachedAt[1])))
 
-    // Main path nodes
+    // Main path nodes — spread across the full path per contentIndices/goalIndex above;
+    // everything else along mainPath is left unassigned and falls through to plain corridor.
     const lastPuzzleIntermediateIdx = config.lastMainPuzzleFamily ? intermediateTypes.lastIndexOf("puzzle") : -1
     let mainChestIdx = 0
-    for (let mi = 0; mi < mainNodeCells.length; mi++) {
-      const [r, c] = mainNodeCells[mi]
+    for (let mi = 0; mi < mainPath.length; mi++) {
+      const [r, c] = mainPath[mi]
       if (mi === 0) {
         if (config.entrance) {
           const stairId = typeof config.entrance === "object" ? config.entrance.stairId : `${siteId}:entrance`
@@ -676,23 +700,26 @@ export const assembleFloor = (siteId: string, config: FloorConfig, seed: number)
         } else {
           roomSpecs.set(posKey(r, c), { roomType: "entrance" })
         }
-      } else if (mi === mainNodeCells.length - 1) {
+      } else if (mi === goalIndex) {
         roomSpecs.set(posKey(r, c), {
           roomType: "treasure",
           reward: config.mainEndReward ?? { type: "mosaicPiece" },
         })
-      } else if (intermediateTypes[mi - 1] === "chest") {
-        roomSpecs.set(posKey(r, c), {
-          roomType: "treasure",
-          reward: config.chestRewards?.[mainChestIdx++] ?? { type: "hieroglyphs" },
-        })
-      } else {
-        const isLastPuzzle = mi - 1 === lastPuzzleIntermediateIdx
-        const family =
-          isLastPuzzle && config.lastMainPuzzleFamily
-            ? config.lastMainPuzzleFamily
-            : (config.puzzleFamily ?? "sumplete")
-        roomSpecs.set(posKey(r, c), { roomType: "puzzle", family })
+      } else if (puzzleChestRole.has(mi)) {
+        const k = puzzleChestRole.get(mi)!
+        if (intermediateTypes[k] === "chest") {
+          roomSpecs.set(posKey(r, c), {
+            roomType: "treasure",
+            reward: config.chestRewards?.[mainChestIdx++] ?? { type: "hieroglyphs" },
+          })
+        } else {
+          const isLastPuzzle = k === lastPuzzleIntermediateIdx
+          const family =
+            isLastPuzzle && config.lastMainPuzzleFamily
+              ? config.lastMainPuzzleFamily
+              : (config.puzzleFamily ?? "sumplete")
+          roomSpecs.set(posKey(r, c), { roomType: "puzzle", family })
+        }
       }
     }
 

--- a/src/game/siteTypes.ts
+++ b/src/game/siteTypes.ts
@@ -86,6 +86,8 @@ export type FloorConfig = {
   puzzleFamily?: PuzzleFamily
   /** If set, the last main-path puzzle room uses this family instead of puzzleFamily. */
   lastMainPuzzleFamily?: PuzzleFamily
+  /** How often the maze continues straight instead of turning, 0-1. Defaults to 0.65 (fairly straight); lower = more winding. */
+  corridorStraightness?: number
 }
 
 // A site is one or more floors. Index 0 = surface.

--- a/src/worldGen/configBuilder.ts
+++ b/src/worldGen/configBuilder.ts
@@ -446,6 +446,7 @@ const buildSiteConfigs = (plan: PyramidPlan[]): Record<string, SiteConfig[]> => 
           const floorSideSections = buildSideSections(tier, floorDiff, false, false, null, floorSections, 0, floorPP)
           const floorChests = buildChestRewards(journeyId, chestOffset, floorPP, constraint.consumableRates)
           chestOffset += chestCountFor(floorPP)
+          const floorStraightness = fc.corridorStraightness ?? constraint.corridorStraightness
           floorConfigs.push({
             pathPuzzles: floorPP,
             chestEvery: chestEveryFor(floorPP),
@@ -456,6 +457,7 @@ const buildSiteConfigs = (plan: PyramidPlan[]): Record<string, SiteConfig[]> => 
             ...(isLast ? { mainEndReward } : {}),
             ...(floorChests.length > 0 ? { chestRewards: floorChests } : {}),
             ...(fc.decorations?.length ? { decorations: fc.decorations } : {}),
+            ...(floorStraightness !== undefined ? { corridorStraightness: floorStraightness } : {}),
           } satisfies FloorConfig)
         }
         pyramidConfigs.push(floorConfigs)
@@ -492,6 +494,9 @@ const buildSiteConfigs = (plan: PyramidPlan[]): Record<string, SiteConfig[]> => 
             mainEndReward,
             chestRewards,
             ...(consumableDensity !== undefined ? { consumableDensity } : {}),
+            ...(constraint.corridorStraightness !== undefined
+              ? { corridorStraightness: constraint.corridorStraightness }
+              : {}),
           } satisfies FloorConfig,
         ])
       }
@@ -607,6 +612,8 @@ const buildTombConfigs = (): Record<string, SiteConfig[]> => {
           ? buildSideSections(authored.sideSections as SideSectionConstraint<"tombTreasure">[])
           : []
 
+      const straightness = authored?.corridorStraightness ?? constraint.corridorStraightness
+
       return {
         pathPuzzles: isLast && hasCroc ? 2 : 1,
         chestEvery: 0,
@@ -619,6 +626,7 @@ const buildTombConfigs = (): Record<string, SiteConfig[]> => {
         ...(isLast && hasCroc ? { lastMainPuzzleFamily: "crocodile" as const } : {}),
         ...(mainEndReward ? { mainEndReward } : {}),
         ...(authored?.decorations?.length ? { decorations: authored.decorations } : {}),
+        ...(straightness !== undefined ? { corridorStraightness: straightness } : {}),
       }
     })
 

--- a/src/worldGen/dsl.ts
+++ b/src/worldGen/dsl.ts
@@ -39,6 +39,8 @@ export type FloorConstraint<TExtra extends string = never> = {
   pathPuzzles?: PathPuzzlesPreset | number
   difficulty?: Difficulty
   puzzleFamily?: PuzzleFamily | PuzzleFamily[]
+  /** How often the maze continues straight instead of turning, 0-1. Defaults to 0.65; lower = more winding. */
+  corridorStraightness?: number
   mainEndReward?: RewardHint | TExtra
   chestReward?: RewardHint | TExtra
   /** Pool of decoration kinds the main path's fork/endpoint rooms may draw from. */
@@ -82,6 +84,8 @@ export type PyramidConstraint = {
   keyColors?: number
   difficulty?: Difficulty
   puzzleFamily?: PuzzleFamily | PuzzleFamily[]
+  /** How often the maze continues straight instead of turning, 0-1. Defaults to 0.65; lower = more winding. */
+  corridorStraightness?: number
   theme?: Theme
   mainEndReward?: RewardSpec
   gateHint?: GateType


### PR DESCRIPTION
## Summary
- Puzzles, chests, and the goal room on a floor's main path were packed against the entrance, leaving a long empty corridor tail (measured at 70-83% of the entrance-to-exit route across 60 seeds) after the last content room, with zero branches ever landing in it. Content is now spread evenly across the whole path, with the goal placed last so the tail shrinks to near-zero automatically (9-22% in the same measurement).
- Adds `corridorStraightness` (0-1, default 0.65, matching prior fixed behavior) to `FloorConfig` and the world-spec DSL (`FloorConstraint`/`PyramidConstraint`), so pyramids/floors can dial maze windiness instead of the previously hardcoded bias. Not used by any rule yet — pure opt-in knob.

## Test plan
- [x] `yarn tsc -b --noEmit` — clean
- [x] `yarn vitest run` — 610 tests pass
- [x] `yarn lint` — clean
- [x] Verified empirically with a throwaway seed-sweep script (not committed): tail ratio dropped from 70-83% to 9-22% across small/medium/large/huge site profiles; confirmed `corridorStraightness` measurably changes turn count (11.4 → 18.0 avg turns going from 0.9 → 0.2)

https://claude.ai/code/session_013L2NVyxvE7rSBew4yRj7ZM