### PR TITLE
Migrate remaining puzzle state to DDD pattern (D1, D2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,9 +96,9 @@ Code is split into three layers with strict one-way dependencies (domain ← app
 | **App**           | `src/app/`               | State hooks, orchestration, flow. Composes from ui/. No HTML/CSS of its own.                                                        |
 | **Design system** | `src/ui/`                | Stateless components — props in, JSX out. No hooks except `useRef` for DOM ops. Strings passed as props, not from `useTranslation`. |
 
-### 9. Puzzle State Models
+### 9. State Models
 
-Any puzzle family with non-trivial in-progress state (a grid, marks, a partial solution) gets its state modeled in `src/game/` as a domain object: a state type + factory, named action functions that mutate via immer, and plain query functions for checks (win state, line status, etc.). See **[`docs/instructions/state-models.md`](docs/instructions/state-models.md)** — Sumplete (`src/game/puzzles/sumplete/sumpleteState.ts`) is the reference implementation.
+Any feature with non-trivial in-progress state (a grid, marks, a partial solution, a block-id → value map) gets its state modeled in `src/game/` as a domain object: a state type + factory, named action functions that mutate via immer, and plain query functions for checks (win state, line status, etc.). Applies beyond puzzles/traps — level progress, journeys, inventory, anything with nested structure or more than one kind of move. See **[`docs/instructions/state-models.md`](docs/instructions/state-models.md)** — Sumplete (`src/game/puzzles/sumplete/sumpleteState.ts`) is the reference implementation.
 
 ---
 

--- a/docs/instructions/state-models.md
+++ b/docs/instructions/state-models.md
@@ -1,19 +1,26 @@
-# Puzzle State Models (DDD)
+# State Models (DDD)
 
-For any puzzle family with non-trivial in-progress state (a grid of cell
-states, marks, a partial solution — Sumplete, and future families like it),
-model that state as a domain object in `src/game/puzzles/<family>/`,
-independent of React. Sumplete is the reference implementation
-(`src/game/puzzles/sumplete/sumpleteState.ts`,
+For any feature with non-trivial in-progress state — a grid of cell states,
+marks, a partial solution, a block-id → value map, anything with nested
+structure or more than one kind of move — model that state as a domain
+object in `src/game/`, independent of React. This applies wherever such
+state lives: puzzle families, trap families, pyramid levels, journeys,
+inventory, progression — not just puzzles. Sumplete is the reference
+implementation (`src/game/puzzles/sumplete/sumpleteState.ts`,
 `src/game/puzzles/sumplete/sumpleteStatus.ts`).
 
 ## Where it lives
 
-Each puzzle family gets its own folder under `src/game/puzzles/`, holding its
+Puzzle families get their own folder under `src/game/puzzles/`, holding
 generation, state, and checks together: `src/game/puzzles/<family>/`. Shared
 puzzle infra (`puzzlePlugin.ts`, `puzzleRegistry.ts`) stays directly under
 `src/game/puzzles/`, not inside a family folder. Trap families follow the
-same idea under `src/game/traps/`.
+same idea under `src/game/traps/`. Everything else with domain state that
+doesn't belong to a puzzle/trap family (level progress, journey state,
+inventory, etc.) lives directly under `src/game/`, next to the module that
+already owns the related checks/queries — e.g. `src/game/state.ts` holds
+`PyramidAnswers`/`createPyramidAnswers`/`setBlockAnswer` alongside the
+pyramid's existing `isComplete`/`isValid`/`getAnswers` checks.
 
 ## Shape
 
@@ -59,7 +66,9 @@ from the current state to derive props for `src/ui/`.
 
 ## When NOT to do this
 
-A puzzle family with state that's just a single primitive or flat value
-(e.g. "current guess index") doesn't need this split — a plain `useState`
-call in the `src/app/` wrapper is enough. Reach for the state/actions/checks
-split when there's a grid, nested structure, or more than one kind of move.
+A feature with state that's just a single primitive or flat value (e.g.
+"current guess index", a boolean toggle) doesn't need this split — a plain
+`useState` call in the `src/app/` wrapper is enough. Reach for the
+state/actions/checks split when there's a grid, nested structure, or more
+than one kind of move — regardless of whether it's a puzzle, a trap, or
+some other piece of game state.

--- a/docs/technical-debt.md
+++ b/docs/technical-debt.md
@@ -17,13 +17,13 @@ Rule: `src/ui/` components must be stateless — no `useState`, `useEffect`, or 
 
 Production components (highest priority — these ship):
 
-| File | Violation |
-|---|---|
-| `src/ui/molecules/HieroglyphUnlockPanel.tsx` | Imports `useState`; two `useState()` calls |
-| `src/ui/molecules/InputBlock.tsx` | Imports `useEffect`; two `useEffect()` calls |
-| `src/ui/atoms/LootPopup.tsx` | Imports `useState`/`useEffect`; `useState(false)`, `useState("hidden")`, two `useEffect()` calls |
+| File                                         | Violation                                                                                        |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `src/ui/molecules/HieroglyphUnlockPanel.tsx` | Imports `useState`; two `useState()` calls                                                       |
+| `src/ui/molecules/InputBlock.tsx`            | Imports `useEffect`; two `useEffect()` calls                                                     |
+| `src/ui/atoms/LootPopup.tsx`                 | Imports `useState`/`useEffect`; `useState(false)`, `useState("hidden")`, two `useEffect()` calls |
 
-Storybook files under `src/ui/` (lower priority — storybook.md explicitly allows local `useState` in *stories*, so these are likely false positives against architecture.md, not real violations — flagged for triage):
+Storybook files under `src/ui/` (lower priority — storybook.md explicitly allows local `useState` in _stories_, so these are likely false positives against architecture.md, not real violations — flagged for triage):
 
 - `src/ui/molecules/NumberChest.stories.tsx`
 - `src/ui/atoms/StainedGlassMosaic.stories.tsx`
@@ -39,28 +39,28 @@ Rule: no React/DOM imports, no imports from `src/app/` or `src/ui/`.
 
 Real runtime React/i18n dependencies in `src/data/` (highest severity — hooks, not stray types):
 
-| File | Violation |
-|---|---|
-| `src/data/useTableauTranslations.ts` | `useTranslation("tableaus")` hook |
-| `src/data/useInventoryTranslations.ts` | `useTranslation("inventory")` hook |
-| `src/data/useJourneyTranslations.ts` | `useTranslation("journeys")`/`useTranslation("common")` hooks |
-| `src/data/useTreasureTranslations.ts` | `useTranslation("treasures")` hook |
+| File                                   | Violation                                                     |
+| -------------------------------------- | ------------------------------------------------------------- |
+| `src/data/useTableauTranslations.ts`   | `useTranslation("tableaus")` hook                             |
+| `src/data/useInventoryTranslations.ts` | `useTranslation("inventory")` hook                            |
+| `src/data/useJourneyTranslations.ts`   | `useTranslation("journeys")`/`useTranslation("common")` hooks |
+| `src/data/useTreasureTranslations.ts`  | `useTranslation("treasures")` hook                            |
 
 Type-only React imports in `src/game/` (lower severity — no runtime dependency, but still a literal rule violation):
 
-| File | Violation |
-|---|---|
-| `src/game/trapPlugin.ts:1` | `import type { FC } from "react"` for a `Component: FC<...>` field |
-| `src/game/puzzlePlugin.ts:1` | Same pattern |
+| File                         | Violation                                                          |
+| ---------------------------- | ------------------------------------------------------------------ |
+| `src/game/trapPlugin.ts:1`   | `import type { FC } from "react"` for a `Component: FC<...>` field |
+| `src/game/puzzlePlugin.ts:1` | Same pattern                                                       |
 
 Cross-layer dependency cycle — `src/game/` importing from `src/app/`:
 
-| File | Violation |
-|---|---|
-| `src/game/generateCompareLevel.ts:1` | Imports `createVerifiedFormula`, `Formula`, `Operation` from `../app/Formulas/formulas` |
-| `src/game/generateRewardCalculation.ts:8` | Same import target |
-| `src/game/generateCompareLevel.spec.ts` | Same import |
-| `src/game/generateRewardCalculation.spec.ts` | Same import |
+| File                                         | Violation                                                                               |
+| -------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `src/game/generateCompareLevel.ts:1`         | Imports `createVerifiedFormula`, `Formula`, `Operation` from `../app/Formulas/formulas` |
+| `src/game/generateRewardCalculation.ts:8`    | Same import target                                                                      |
+| `src/game/generateCompareLevel.spec.ts`      | Same import                                                                             |
+| `src/game/generateRewardCalculation.spec.ts` | Same import                                                                             |
 
 Most notable finding in category A: `src/app/Formulas/formulas.ts` contains what is really domain logic (`createVerifiedFormula`, `formulaToString`, `Formula`/`Operation` types) but lives under `src/app/`, while `src/game/` depends on it back — an actual upward-then-downward dependency cycle (`formulas.ts` itself imports `src/game/random`). Recommended fix: relocate `Formulas/` into `src/game/` or `src/data/`.
 
@@ -177,35 +177,15 @@ Skipped as trivial: `src/worldGen/spec/*.ts` (declarative `Rule[]` literals), `t
 
 ## D. Puzzle state not following the DDD pattern (`docs/instructions/state-models.md`)
 
-**2 findings.**
+**2 findings — both fixed.**
 
-### D1. `src/app/TombLevel/ComparePuzzle.tsx` + `src/app/TombLevel/useComparePuzzleControls.ts` — abandoned duplicate of Crocodile
+### D1. `src/app/TombLevel/ComparePuzzle.tsx` + `src/app/TombLevel/useComparePuzzleControls.ts` — abandoned duplicate of Crocodile — **fixed**
 
-A second, still-live implementation of the same comparison-puzzle mechanic that `src/game/crocodileState.ts` already models, and that `src/app/PuzzleFamilies/Crocodile/plugin.tsx` already consumes. This older file was never switched over — a partial/abandoned migration, not dead code (still rendered from `src/app/TombExpedition.tsx`).
+`useComparePuzzleControls.ts` now uses `previewLeft`/`commitLeft`/`previewRight`/`commitRight`/`advanceFocus`/`resetCrocodileState` from `src/game/puzzles/crocodile/crocodileState.ts`, same as the Crocodile plugin wrapper, instead of hand-duplicating the `{ focus, answers }` shape.
 
-- State shape (`useComparePuzzleControls.ts:22-24,93`) hand-duplicates `CrocodileState = { focus, answers }`:
-  ```ts
-  const [answers, setAnswers] = useState<{
-    [key: number]: "left" | "right" | "noneLeft" | "noneRight"
-  }>({})
-  const [focus, setFocus] = useState(0)
-  ```
-- Inline mutation instead of named actions (`useComparePuzzleControls.ts:159-162`), plus a manual double-reset (`handleIDontKnow`, lines 95-98) instead of `resetCrocodileState`.
-- Fix: replace with `previewLeft`/`commitLeft`/`previewRight`/`commitRight`/`advanceFocus`/`resetCrocodileState` from `src/game/crocodileState.ts`, same as the Crocodile plugin wrapper.
+### D2. `src/app/PyramidLevel/Level.tsx` — pyramid block answers never migrated — **fixed**
 
-### D2. `src/app/PyramidLevel/Level.tsx` — pyramid block answers never migrated
-
-The core Pyramid Level fill-in-the-blanks puzzle stores in-progress answers as a block-id → value map in a plain storage-backed `useState` wrapper, mutated via hand-rolled spread.
-
-- State shape (`Level.tsx:16-19`):
-  ```ts
-  const [storedAnswers, setAnswers] = useGameStorage<{
-    key: string
-    values: Record<string, number | undefined>
-  }>("levelAnswers", { key: storageKey ?? "dummy", values: {} })
-  ```
-- Inline mutation (`Level.tsx:54-62`) spreads `prev.values` by hand instead of calling a named action.
-- `src/game/state.ts` already has the *check* half of the pattern (`isComplete`, `isValid`, `getAnswers`, `getBlockChildIndices`) but no state type/factory/named actions (e.g. a `setBlockAnswer` action) — a half-migrated domain module, missing the action layer.
+`src/game/state.ts` gained `PyramidAnswers`, `createPyramidAnswers()`, and a `setBlockAnswer()` action (with spec coverage); `Level.tsx` now calls `setBlockAnswer()` instead of hand-rolled spreading.
 
 ### Checked, compliant — no action needed
 
@@ -215,11 +195,11 @@ The core Pyramid Level fill-in-the-blanks puzzle stores in-progress answers as a
 
 ## Summary
 
-| Category | Findings |
-|---|---|
-| A — Layer boundary violations | ~49 (12 ui/, 7 game+data, 30 pre-existing app/ className — low priority) |
-| B — Missing Storybook stories | 0 |
-| C — Missing tests | 27 (18 game/data, 5 support, 2 worldGen, 1 app/state, 1 Logic/Calc) |
-| D — DDD puzzle-state violations | 2 (ComparePuzzle/Crocodile duplicate, PyramidLevel Level.tsx) |
+| Category                        | Findings                                                                 |
+| ------------------------------- | ------------------------------------------------------------------------ |
+| A — Layer boundary violations   | ~49 (12 ui/, 7 game+data, 30 pre-existing app/ className — low priority) |
+| B — Missing Storybook stories   | 0                                                                        |
+| C — Missing tests               | 27 (18 game/data, 5 support, 2 worldGen, 1 app/state, 1 Logic/Calc)      |
+| D — DDD puzzle-state violations | 2 (ComparePuzzle/Crocodile duplicate, PyramidLevel Level.tsx)            |
 
 Highest-signal items for prioritization: the `src/data/use*Translations.ts` files (4 files, real React/i18n hooks in the domain layer — breaks both A and C simultaneously), the `src/game/` ↔ `src/app/Formulas/formulas.ts` dependency cycle (architectural, not just a lint nit), `src/game/random.ts` having zero tests despite being the seed backbone for the entire generated world, and the two D-category findings (both are concrete, scoped refactors following an existing template).

--- a/docs/technical-debt.md
+++ b/docs/technical-debt.md
@@ -175,9 +175,9 @@ Skipped as trivial: `src/worldGen/spec/*.ts` (declarative `Rule[]` literals), `t
 
 ---
 
-## D. Puzzle state not following the DDD pattern (`docs/instructions/state-models.md`)
+## D. State not following the DDD pattern (`docs/instructions/state-models.md`)
 
-**2 findings — both fixed.**
+**2 findings fixed, 4 new candidates exposed after broadening the rule beyond puzzle/trap families (2026-07-07).**
 
 ### D1. `src/app/TombLevel/ComparePuzzle.tsx` + `src/app/TombLevel/useComparePuzzleControls.ts` — abandoned duplicate of Crocodile — **fixed**
 
@@ -187,19 +187,50 @@ Skipped as trivial: `src/worldGen/spec/*.ts` (declarative `Rule[]` literals), `t
 
 `src/game/state.ts` gained `PyramidAnswers`, `createPyramidAnswers()`, and a `setBlockAnswer()` action (with spec coverage); `Level.tsx` now calls `setBlockAnswer()` instead of hand-rolled spreading.
 
-### Checked, compliant — no action needed
+### D3. `src/app/state/useJourneys.ts` — journey progress, no domain module
 
-`src/app/PuzzleFamilies/Sumplete/*`, `src/app/PuzzleFamilies/Crocodile/plugin.tsx`, `src/app/TombLevel/TombPuzzle.tsx` (Tableau) — correctly wired to their `src/game/*State.ts` modules. `src/app/TrapFamilies/ArithmeticReflex/plugin.tsx`, `PyramidLevel/LevelCompletionHandler.tsx`, `PyramidExpedition.tsx`, `TombExpedition.tsx`, `SiteMap/SiteMapScreen.tsx`, `SiteMap/SiteMapView.tsx`, `SiteMap/ChestRewardFlow.tsx` — local state found is flat primitives/booleans, exempt per state-models.md's "single primitive" carve-out. `src/app/SiteMap/useAssembledFloor.ts` — derived `useMemo` over domain-owned grid data, nothing to migrate. `src/app/state/useDetector.ts`, `useJourneys.ts`, `useProgression.ts` — no complex inline mutation found.
+State: `StoredJourneyStateV3[]` — array of nested objects, each with `exploredSections: Record<string, string[]>`, `disabledTraps?: string[]`, `skippedConsumables?: string[]`.
+
+- 10+ functions (`startJourney`, `completeJourney`, `visitLevel`, `cancelJourney`, `completeLevel`, `markCellExplored`, `updatePosition`, `setInteriorLevel`, `markTrapDisabled`, `markConsumableSkipped`, `clearConsumableSkipped`) all do inline `setJourneys(prev => prev.map(j => j.journeyId === id ? {...j, ...} : j))` spread chains.
+- No `src/game/*State.ts` module backs this at all — clearest violation of the broadened rule (array + record-of-arrays, many distinct mutation kinds).
+- Previously marked "no complex inline mutation found" under the old puzzle-only rule — that call is superseded.
+
+### D4. `src/app/state/useProgression.ts` — 243-line state machine, no domain module
+
+State: `ProgressionState` — nested object with `collectedFragments: string[]`, `tombKeys: Record<string, true>`, `discoveredTombs: string[]`, `collectedMapPieces: Record<string, number>`, `mapPieceJourneys: string[]`, `consumables: {...}`, `perks: PerkState` (7 fields).
+
+- ~15 API methods (`addTombKey`, `applyTreasurePerk`, `discoverTomb`, `collectMapPiece`, `markMapPieceFound`, `takeTrapDamage`, `heal`, `addConsumable`, `useConsumable`, etc.) each do inline `setState(prev => ({...prev, nested: {...prev.nested, ...}}))`, including a large `switch` inside `applyTreasurePerk`.
+- Same "no complex inline mutation found" call as D3, now superseded.
+
+### D5. `src/app/Inventory/useInventory.ts` — inventory counts, no domain module
+
+State: `Record<string, number>`.
+
+- `addItem`, `removeItem`, `addItems`, `removeItems` each hand-roll `setInventory(prev => ({...prev, [id]: ...}))` or a manual loop-copy for the batch versions — a Record with multiple entries and multiple distinct mutation kinds (add/remove/batch-add/batch-remove).
+- Consumed by `useComparePuzzleControls.ts` and `TombPuzzle.tsx`.
+
+### D6. `src/app/TombLevel/TombPuzzle.tsx` — `annotations` state (minor)
+
+State: `useState<Record<string, string>>({})`, separate from the already-compliant Tableau puzzle domain state (`createTableauPuzzleState`/`toggleTableauTile`) in the same file.
+
+- Single `handleAnnotationChange` does `setAnnotations(prev => ({...prev, [symbolId]: value}))`.
+- Technically a Record with multiple entries per the rule, but only one mutation kind exists — lowest priority of the four, candidate for folding into the same domain module or documenting as an accepted exception.
+
+### Checked, still compliant — no action needed
+
+`src/app/PuzzleFamilies/Sumplete/*`, `src/app/PuzzleFamilies/Crocodile/plugin.tsx`, `src/app/TombLevel/TombPuzzle.tsx`'s puzzle state (Tableau, not its `annotations` — see D6) — correctly wired to their `src/game/*State.ts` modules. `src/app/state/useDetector.ts` — two independent flat `useState` (`DetectorMode`, `compassTarget`), rest derived via `useMemo`. `src/app/SiteMap/SiteMapScreen.tsx`'s `pendingReward` — always replaced wholesale, never incrementally spread. `src/app/TrapFamilies/ArithmeticReflex/plugin.tsx`, `PyramidLevel/LevelCompletionHandler.tsx`, `PyramidExpedition.tsx`, `TombExpedition.tsx`, `SiteMap/SiteMapView.tsx`, `SiteMap/ChestRewardFlow.tsx`, `FezCompanion.tsx`, `Travel.tsx`, `Collection.tsx`, `usePyramidNavigation.ts`, `ExplorerDot.tsx` — flat primitives/whole-value replacement, exempt per state-models.md's "single primitive" carve-out. `src/app/SiteMap/useAssembledFloor.ts` — derived `useMemo` over domain-owned grid data, nothing to migrate. `src/support/useGameStorage.ts`/`useOfflineStorage.ts` — generic persistence wrappers, not domain logic themselves (though they're the mechanism storing D3–D5's non-compliant state).
+
+Priority order for remediation: D3 (`useJourneys`) > D4 (`useProgression`) > D5 (`useInventory`) > D6 (`TombPuzzle` annotations).
 
 ---
 
 ## Summary
 
-| Category                        | Findings                                                                 |
-| ------------------------------- | ------------------------------------------------------------------------ |
-| A — Layer boundary violations   | ~49 (12 ui/, 7 game+data, 30 pre-existing app/ className — low priority) |
-| B — Missing Storybook stories   | 0                                                                        |
-| C — Missing tests               | 27 (18 game/data, 5 support, 2 worldGen, 1 app/state, 1 Logic/Calc)      |
-| D — DDD puzzle-state violations | 2 (ComparePuzzle/Crocodile duplicate, PyramidLevel Level.tsx)            |
+| Category                      | Findings                                                                            |
+| ----------------------------- | ----------------------------------------------------------------------------------- |
+| A — Layer boundary violations | ~49 (12 ui/, 7 game+data, 30 pre-existing app/ className — low priority)            |
+| B — Missing Storybook stories | 0                                                                                   |
+| C — Missing tests             | 27 (18 game/data, 5 support, 2 worldGen, 1 app/state, 1 Logic/Calc)                 |
+| D — DDD state violations      | 2 fixed + 4 new (useJourneys, useProgression, useInventory, TombPuzzle annotations) |
 
 Highest-signal items for prioritization: the `src/data/use*Translations.ts` files (4 files, real React/i18n hooks in the domain layer — breaks both A and C simultaneously), the `src/game/` ↔ `src/app/Formulas/formulas.ts` dependency cycle (architectural, not just a lint nit), `src/game/random.ts` having zero tests despite being the seed backbone for the entire generated world, and the two D-category findings (both are concrete, scoped refactors following an existing template).

--- a/src/app/PyramidLevel/Level.tsx
+++ b/src/app/PyramidLevel/Level.tsx
@@ -1,7 +1,7 @@
 import { type FC, useEffect, useRef } from "react"
 import type { PyramidLevel } from "@/game/types"
 import { PyramidDisplay } from "@/app/PyramidLevel/PyramidDisplay"
-import { isValid } from "@/game/state"
+import { createPyramidAnswers, isValid, setBlockAnswer, type PyramidAnswers } from "@/game/state"
 import { useGameStorage } from "@/support/useGameStorage"
 import type { DayNightCycleStep } from "@/ui/atoms/backdropSelection"
 
@@ -15,8 +15,8 @@ export const Level: FC<{
 }> = ({ content, storageKey, onComplete, decorationOffset = 0, dayTime, entranceBlockId }) => {
   const [storedAnswers, setAnswers] = useGameStorage<{
     key: string
-    values: Record<string, number | undefined>
-  }>("levelAnswers", { key: storageKey ?? "dummy", values: {} })
+    values: PyramidAnswers
+  }>("levelAnswers", { key: storageKey ?? "dummy", values: createPyramidAnswers() })
 
   const answers = storedAnswers.key === storageKey && storageKey ? storedAnswers.values : {}
 
@@ -52,13 +52,8 @@ export const Level: FC<{
             storageKey
               ? (blockId: string, value: number | undefined) => {
                   setAnswers(prev => {
-                    if (prev.key !== storageKey) {
-                      return { key: storageKey, values: { [blockId]: value } }
-                    }
-                    return {
-                      key: storageKey,
-                      values: { ...prev.values, [blockId]: value },
-                    }
+                    const values = prev.key === storageKey ? prev.values : createPyramidAnswers()
+                    return { key: storageKey, values: setBlockAnswer(values, blockId, value) }
                   })
                 }
               : undefined

--- a/src/app/TombLevel/useComparePuzzleControls.ts
+++ b/src/app/TombLevel/useComparePuzzleControls.ts
@@ -6,6 +6,15 @@ import { mulberry32 } from "@/game/random"
 import { eligibleTreasures, treasureSelectionSeed } from "@/game/tombTreasureSelection"
 import { tableauLevels } from "@/data/tableaus"
 import { generateCompareLevel } from "@/game/puzzles/crocodile/generateCompareLevel"
+import {
+  advanceFocus,
+  commitLeft,
+  commitRight,
+  createCrocodileState,
+  previewLeft,
+  previewRight,
+  resetCrocodileState,
+} from "@/game/puzzles/crocodile/crocodileState"
 
 export const useCrocodilePuzzleControls = ({
   activeJourney,
@@ -19,9 +28,8 @@ export const useCrocodilePuzzleControls = ({
   const [showLoot, setShowLoot] = useState(false)
   const { inventory, addItem } = useInventory()
   const [lockValue, setLockValue] = useState("")
-  const [answers, setAnswers] = useState<{
-    [key: number]: "left" | "right" | "noneLeft" | "noneRight"
-  }>({})
+  const [state, setState] = useState(createCrocodileState)
+  const { focus, answers } = state
 
   const journey = activeJourney.journey as TreasureTombJourney
 
@@ -90,12 +98,9 @@ export const useCrocodilePuzzleControls = ({
 
   const hasComparison = levelData.comparisons.length > 0
 
-  const [focus, setFocus] = useState(0)
-
   const handleIDontKnow = useCallback(() => {
-    setFocus(0)
-    setAnswers({})
-  }, [setFocus, setAnswers])
+    setState(prev => resetCrocodileState(prev))
+  }, [])
 
   const handleLockSubmit = (value: string) => {
     // Prevent multiple submissions during processing
@@ -105,8 +110,7 @@ export const useCrocodilePuzzleControls = ({
     if (levelData.requirements.digit.toString() !== value) {
       setLockState("error")
       setIsProcessingCompletion(false)
-      setFocus(0)
-      setAnswers({})
+      setState(prev => resetCrocodileState(prev))
       return
     }
 
@@ -119,33 +123,9 @@ export const useCrocodilePuzzleControls = ({
     }, 1500)
   }
 
-  const handleMouseOverLeft = useCallback(() => {
-    setAnswers(answers => {
-      const currentAnswer = answers[focus] ?? "noneRight"
-      if (!currentAnswer.startsWith("none")) {
-        return answers
-      }
+  const handleMouseOverLeft = useCallback(() => setState(prev => previewLeft(prev)), [])
 
-      return {
-        ...answers,
-        [focus]: "noneLeft",
-      }
-    })
-  }, [focus])
-
-  const handleMouseOverRight = useCallback(() => {
-    setAnswers(answers => {
-      const currentAnswer = answers[focus] ?? "noneLeft"
-      if (!currentAnswer.startsWith("none")) {
-        return answers
-      }
-
-      return {
-        ...answers,
-        [focus]: "noneRight",
-      }
-    })
-  }, [focus])
+  const handleMouseOverRight = useCallback(() => setState(prev => previewRight(prev)), [])
 
   const handleLeftClick = useCallback(() => {
     const activeCompare = levelData.comparisons[focus]
@@ -156,25 +136,12 @@ export const useCrocodilePuzzleControls = ({
     if (!currentAnswer.startsWith("none")) return
     const needsTurn = currentAnswer !== "noneLeft"
 
-    setAnswers(answers => ({
-      ...answers,
-      [focus]: needsTurn ? "noneLeft" : "left",
-    }))
+    setState(prev => (needsTurn ? previewLeft(prev) : commitLeft(prev)))
     if (needsTurn) {
-      setTimeout(() => {
-        setAnswers(answers => ({
-          ...answers,
-          [focus]: "left",
-        }))
-      }, 500)
+      setTimeout(() => setState(prev => commitLeft(prev)), 500)
     }
 
-    setTimeout(
-      () => {
-        setFocus(prev => prev + 1)
-      },
-      needsTurn ? 800 : 200
-    )
+    setTimeout(() => setState(prev => advanceFocus(prev)), needsTurn ? 800 : 200)
   }, [focus, levelData.comparisons, answers])
 
   const handleRightClick = useCallback(() => {
@@ -186,26 +153,13 @@ export const useCrocodilePuzzleControls = ({
     const currentAnswer = answers[focus] ?? "noneRight"
     if (!currentAnswer.startsWith("none")) return
     const needsTurn = currentAnswer !== "noneRight"
-    setAnswers(answers => ({
-      ...answers,
-      [focus]: needsTurn ? "noneRight" : "right",
-    }))
 
+    setState(prev => (needsTurn ? previewRight(prev) : commitRight(prev)))
     if (needsTurn) {
-      setTimeout(() => {
-        setAnswers(answers => ({
-          ...answers,
-          [focus]: "right",
-        }))
-      }, 500)
+      setTimeout(() => setState(prev => commitRight(prev)), 500)
     }
 
-    setTimeout(
-      () => {
-        setFocus(prev => prev + 1)
-      },
-      needsTurn ? 800 : 200
-    )
+    setTimeout(() => setState(prev => advanceFocus(prev)), needsTurn ? 800 : 200)
   }, [focus, levelData.comparisons, answers])
 
   return {

--- a/src/game/state.spec.ts
+++ b/src/game/state.spec.ts
@@ -1,7 +1,45 @@
-import { getAnswers, getBlockChildIndices, isComplete, isValid } from "@/game/state"
+import {
+  createPyramidAnswers,
+  getAnswers,
+  getBlockChildIndices,
+  isComplete,
+  isValid,
+  setBlockAnswer,
+} from "@/game/state"
 import { describe, it, expect } from "vitest"
 import type { PyramidLevel } from "@/game/types"
 import { createPyramid } from "@/game/test-utils/pyramidfactory"
+
+describe(createPyramidAnswers, () => {
+  it("starts empty", () => {
+    expect(createPyramidAnswers()).toEqual({})
+  })
+})
+
+describe(setBlockAnswer, () => {
+  it("sets a block's value", () => {
+    const state = setBlockAnswer(createPyramidAnswers(), "1", 5)
+    expect(state).toEqual({ "1": 5 })
+  })
+
+  it("does not mutate the previous state", () => {
+    const state = createPyramidAnswers()
+    setBlockAnswer(state, "1", 5)
+    expect(state).toEqual({})
+  })
+
+  it("keeps other blocks' values", () => {
+    const state = setBlockAnswer(createPyramidAnswers(), "1", 5)
+    const next = setBlockAnswer(state, "2", 7)
+    expect(next).toEqual({ "1": 5, "2": 7 })
+  })
+
+  it("can clear a block's value", () => {
+    const state = setBlockAnswer(createPyramidAnswers(), "1", 5)
+    const next = setBlockAnswer(state, "1", undefined)
+    expect(next).toEqual({ "1": undefined })
+  })
+})
 
 describe(isComplete, () => {
   it("returns true when all open blocks have corresponding values", () => {

--- a/src/game/state.ts
+++ b/src/game/state.ts
@@ -1,4 +1,13 @@
+import { produce } from "immer"
 import type { Pyramid, PyramidLevel } from "@/game/types"
+
+export type PyramidAnswers = Record<string, number | undefined>
+
+export const createPyramidAnswers = (): PyramidAnswers => ({})
+
+export const setBlockAnswer = produce((state: PyramidAnswers, blockId: string, value: number | undefined) => {
+  state[blockId] = value
+})
 
 export const isComplete = (state: PyramidLevel): boolean => {
   const openBlocks = state.pyramid.blocks.filter(block => block.isOpen).map(block => block.id)


### PR DESCRIPTION
## Summary
- `useComparePuzzleControls.ts` (ComparePuzzle) now uses `previewLeft`/`commitLeft`/`previewRight`/`commitRight`/`advanceFocus`/`resetCrocodileState` from `src/game/puzzles/crocodile/crocodileState.ts` instead of hand-duplicating the `{ focus, answers }` shape — same pattern the Crocodile plugin already follows (D1)
- `src/game/state.ts` gains `PyramidAnswers` / `createPyramidAnswers()` / `setBlockAnswer()`, completing the domain module (it already had the check half: `isComplete`, `isValid`, `getAnswers`); `Level.tsx` now calls the named action instead of hand-rolled spreading (D2)
- Update `docs/technical-debt.md` to mark both D-category findings resolved

Independent of #97 (which fixes the A2 layer-cycle/i18n-hook debt) — both branch off `main`, no shared files besides the debt doc.

## Test plan
- [x] `yarn check-types` clean
- [x] `yarn test run` — 635/635 passing (added 4 specs for `setBlockAnswer`/`createPyramidAnswers`)
- [ ] Manual: play a Crocodile treasure-tomb comparison puzzle and a Pyramid fill-in-the-blanks level, verify no behavior change