### PR TITLE
Playtest fixes: interior exits, collection detail, tutorials, item text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,9 +30,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Some pyramids at higher difficulties now have extra winding corridors or a larger, more sprawling layout.
 - Expert, master, and wizard treasure tombs also now sometimes have extra winding corridors or a larger, more sprawling layout, matching their tier's pyramids.
 - Every pyramid now has at least one hidden path holding a puzzle or a trap to find.
+- Leaving a pyramid or tomb through any exit now finishes that site and continues your journey; deeper floors you skipped stay open to revisit later.
 
 ### Fixed
 
+- Turning tutorials off now survives clearing your game data — the intro no longer replays after a reset.
 - A gated area (one requiring a floor key or ward key) could occasionally generate with an unintended shortcut around its own gate, letting it be reached without the key it should have required.
 - A hidden, trapped area could occasionally generate with a way to reach its reward without passing through the trap.
 - Some treasure rooms at the end of a path could generate empty; every treasure room now holds something (a currency, a mosaic tile, or a little loot).

--- a/public/locales/en/sellables.json
+++ b/public/locales/en/sellables.json
@@ -8,7 +8,7 @@
   },
   "sell_stone_1": {
     "name": "Chipped Ostracon",
-    "description": "A broken pottery shard scratched with a scribe's practice notes — worthless to read, but Fez pays for the clay."
+    "description": "A broken pottery shard scratched with a scribe's practice notes — the letters too faded to read."
   },
   "sell_stone_2": {
     "name": "Cracked Clay Jar",
@@ -28,7 +28,7 @@
   },
   "sell_bronze_1": {
     "name": "Bent Bronze Amulet",
-    "description": "A cheap protective charm, cast crooked and never fixed. Common enough that no collector wants it — but bronze is bronze."
+    "description": "A cheap protective charm, cast crooked and never fixed."
   },
   "sell_bronze_2": {
     "name": "Corroded Bronze Mirror",
@@ -48,7 +48,7 @@
   },
   "sell_silver_1": {
     "name": "Tarnished Silver Ankh",
-    "description": "A symbol of life, worn dull by centuries underground. Too tarnished to display, still worth its weight."
+    "description": "A symbol of life, worn dull by centuries underground."
   },
   "sell_silver_2": {
     "name": "Silver Kohl Applicator",
@@ -68,7 +68,7 @@
   },
   "sell_gold_1": {
     "name": "Small Gold Bead",
-    "description": "One bead from a burial necklace, scattered long ago. A jeweler's delight, if you can find the rest."
+    "description": "One bead from a burial necklace, scattered long ago."
   },
   "sell_gold_2": {
     "name": "Gold Leaf Fragment",
@@ -76,7 +76,7 @@
   },
   "sell_gold_3": {
     "name": "Thin Gold Earring",
-    "description": "Hammered thin to stretch a noble's gold further — still enough to catch a merchant's eye."
+    "description": "Hammered thin to stretch a noble's gold further."
   },
   "sell_gold_4": {
     "name": "Gold-Flecked Shard",
@@ -88,7 +88,7 @@
   },
   "sell_divine_1": {
     "name": "Faded Lapis Scarab",
-    "description": "Carved from precious lapis lazuli, imported at great cost for a pharaoh's rebirth. The color has faded, the value hasn't."
+    "description": "Carved from precious lapis lazuli, imported at great cost for a pharaoh's rebirth. The color has faded with the centuries."
   },
   "sell_divine_2": {
     "name": "Carnelian Eye Amulet",

--- a/public/locales/nl/sellables.json
+++ b/public/locales/nl/sellables.json
@@ -8,7 +8,7 @@
   },
   "sell_stone_1": {
     "name": "Gebroken Ostracon",
-    "description": "Een gebroken aardewerkscherf met oefennotities van een schrijver — waardeloos om te lezen, maar Fez betaalt voor de klei."
+    "description": "Een gebroken aardewerkscherf met oefennotities van een schrijver — de letters te vervaagd om te lezen."
   },
   "sell_stone_2": {
     "name": "Gebarsten Kleikruik",
@@ -28,7 +28,7 @@
   },
   "sell_bronze_1": {
     "name": "Verbogen Bronzen Amulet",
-    "description": "Een goedkope beschermende hanger, scheef gegoten en nooit rechtgezet. Zo gewoon dat geen verzamelaar hem wil — maar brons is brons."
+    "description": "Een goedkope beschermende hanger, scheef gegoten en nooit rechtgezet."
   },
   "sell_bronze_2": {
     "name": "Verweerde Bronzen Spiegel",
@@ -48,7 +48,7 @@
   },
   "sell_silver_1": {
     "name": "Verkleurde Zilveren Ankh",
-    "description": "Een symbool van leven, dof geworden door eeuwen onder de grond. Te verkleurd om uit te stallen, nog steeds zijn gewicht waard."
+    "description": "Een symbool van leven, dof geworden door eeuwen onder de grond."
   },
   "sell_silver_2": {
     "name": "Zilveren Kohl-Applicator",
@@ -68,7 +68,7 @@
   },
   "sell_gold_1": {
     "name": "Kleine Gouden Kraal",
-    "description": "Één kraal van een grafketting, lang geleden verstrooid. Een juwelier zou er blij mee zijn, als je de rest kunt vinden."
+    "description": "Één kraal van een grafketting, lang geleden verstrooid."
   },
   "sell_gold_2": {
     "name": "Gouden Bladfragment",
@@ -76,7 +76,7 @@
   },
   "sell_gold_3": {
     "name": "Dunne Gouden Oorring",
-    "description": "Dun geslagen om het goud van een edele verder te rekken — nog steeds genoeg om een handelaar te verleiden."
+    "description": "Dun geslagen om het goud van een edele verder te rekken."
   },
   "sell_gold_4": {
     "name": "Goudgespikkelde Scherf",
@@ -88,7 +88,7 @@
   },
   "sell_divine_1": {
     "name": "Vervaagde Lapis Scarabee",
-    "description": "Gesneden uit kostbare lapis lazuli, tegen hoge kosten ingevoerd voor de wedergeboorte van een farao. De kleur is vervaagd, de waarde niet."
+    "description": "Gesneden uit kostbare lapis lazuli, tegen hoge kosten ingevoerd voor de wedergeboorte van een farao. De kleur is vervaagd met de eeuwen."
   },
   "sell_divine_2": {
     "name": "Carneool Oog-Amulet",

--- a/src/app/SettingsModal.tsx
+++ b/src/app/SettingsModal.tsx
@@ -17,6 +17,8 @@ export const SettingsModal: FC<SettingsModalProps> = ({ isOpen, onClose }) => {
 
   const handleClearGameData = async () => {
     await clearGameData()
+    // Preserve the tutorials preference across a data wipe.
+    await setTutorialsEnabled(tutorialsEnabled)
     window.location.reload()
   }
 

--- a/src/app/SiteMap/SiteMapScreen.tsx
+++ b/src/app/SiteMap/SiteMapScreen.tsx
@@ -376,11 +376,9 @@ export const SiteMapScreen = ({ journeyId, siteConfig, seed, onSiteComplete, onC
       {exiting && (
         <EntranceTransitionOverlay
           origin="50% 50%"
-          // A non-last floor's "exit" is a pause, not a completion — its ward-path shortcut
-          // (once its key is held) is the real way onward; only the true last floor's exit
-          // finishes the site. Leaving here must not touch levelNr/trigger the hieroglyph
-          // minigame the way onSiteComplete does — onCancel already does exactly that.
-          onComplete={currentFloor === siteConfig.length - 1 ? onSiteComplete : onCancel}
+          // Any exit portal finishes the site and advances the journey. Floors past the exit stay
+          // reachable on a later revisit (with keys); the interior is a persistent, stable-seed site.
+          onComplete={onSiteComplete}
         />
       )}
       {activeEncounter && ActiveEncounterComponent && encounterCtx && (

--- a/src/mods/core/app/treasureChest/plugin.tsx
+++ b/src/mods/core/app/treasureChest/plugin.tsx
@@ -15,7 +15,9 @@ const TreasureComponent: FamilyPlugin["Component"] = ({ onSolved }) => {
   const handleOpen = () => {
     if (opened) return
     setOpened(true)
-    onSolved()
+    // Let the chest open animation (shackle transition, 500ms) play out before
+    // the node closes and RewardFlow takes over.
+    setTimeout(onSolved, 600)
   }
 
   return (

--- a/src/mods/shop/app/ShopCollectionSection.spec.tsx
+++ b/src/mods/shop/app/ShopCollectionSection.spec.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest"
-import { render, screen, cleanup } from "@testing-library/react"
+import { render, screen, cleanup, fireEvent } from "@testing-library/react"
 import { ALL_SELLABLES } from "@/data/sellables"
 
 afterEach(cleanup)
@@ -30,5 +30,18 @@ describe("ShopCollectionSection hide-until-collected", () => {
     inventory = { [ALL_SELLABLES[0].id]: 1 }
     render(<ShopCollectionSection selectedItem={null} onSelect={() => {}} />)
     expect(screen.getByText(JUNK_TITLE)).toBeTruthy()
+  })
+
+  // Regression: the detail panel's HieroglyphTile throws without a difficulty (sellables aren't
+  // hieroglyphs, so it can't derive one from the id) — clicking a junk item blacked out the screen.
+  it("emits a difficulty on select so the detail panel can render", () => {
+    const item = ALL_SELLABLES[0]
+    inventory = { [item.id]: 1 }
+    const onSelect = vi.fn()
+    render(<ShopCollectionSection selectedItem={null} onSelect={onSelect} />)
+    fireEvent.click(screen.getByText(item.symbol))
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ id: item.id, symbol: item.symbol, difficulty: expect.any(String) })
+    )
   })
 })

--- a/src/mods/shop/app/ShopCollectionSection.tsx
+++ b/src/mods/shop/app/ShopCollectionSection.tsx
@@ -35,6 +35,9 @@ export const ShopCollectionSection: FC<CollectionSectionProps> = ({ selectedItem
               onSelect({
                 id: item.id,
                 symbol: item.symbol,
+                // Sellables aren't hieroglyphs, so the detail panel can't derive a difficulty from
+                // the id — carry the tier's difficulty on the emitted item (as tomb treasures do).
+                difficulty: difficultyByMaterialTier[item.tier],
                 name: t(`${item.id}.name`, { ns: "sellables" }),
                 description: t(`${item.id}.description`, { ns: "sellables" }),
               })


### PR DESCRIPTION
Batch of fixes found during playtesting.

## Changes

- **Tutorials survive clear-data.** Disabling tutorials then clearing game data re-enabled them (the pref lives in the wiped store, defaulting back to on). The preference is now preserved across a wipe, so the intro no longer replays. *(Fixed a released bug — in CHANGELOG.)*
- **Any interior exit finishes the site.** Previously only the *last* floor's exit portal advanced the journey; an exit on an earlier floor dumped you back to the travel map. Now any exit completes the pyramid/tomb and continues to the next level. Skipped deeper floors stay reachable on revisit (persistent, stable-seed interior — key-gated loot isn't lost). Applies to pyramids and tombs. *(Reworked flow — in CHANGELOG.)*
- **Chest open animation.** The treasure chest now plays its open animation (~600ms) before the encounter node closes, instead of closing instantly on click.
- **Junk item descriptions.** Removed sellability/value hints from 6 sellable descriptions (EN + NL) — plain flavor only; players discover sellability at the shop.
- **Junk detail no longer blacks out.** Clicking a junk item crashed to a black screen: the detail tile throws without a difficulty, and sellables (not hieroglyphs) can't derive one from their id. The collection item now carries the tier difficulty. Added a regression test.

## Changelog

Only the two fixes touching **released** behavior were logged (per `docs/instructions/changelog.md` — unreleased bugs are skipped). The chest animation, junk descriptions, and junk-detail crash all concern unreleased content, so they're excluded.

## Testing

- `tsc -b` clean
- `ShopCollectionSection.spec.tsx` — 3 pass (incl. new regression test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)