### PR TITLE
feat: pick-a-pyramid map when revisiting a completed journey

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ dist-ssr
 *storybook.log
 storybook-static
 .claude/worktrees
+.playwright-mcp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Revisiting a completed journey now opens its map so you can pick which pyramid to explore, instead of dropping you straight into the first one. Each re-entry replays the pyramid's exterior puzzle, and finishing or leaving a pyramid returns you to the map to pick another.
 
 ## 0.27.0 - 2026-07-17
 ### Added

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -54,6 +54,7 @@
     "continueExpedition": "Continue Expedition",
     "startExpedition": "Start Expedition",
     "planExpedition": "Plan Expedition",
+    "revisitExpedition": "Revisit — pick a pyramid",
     "or": "Or",
     "selectAnotherExpedition": "Select another expedition",
     "interruptExpedition": "Interrupt expedition",

--- a/public/locales/nl/common.json
+++ b/public/locales/nl/common.json
@@ -54,6 +54,7 @@
     "continueExpedition": "Ga door met Expeditie",
     "startExpedition": "Start Expeditie",
     "planExpedition": "Plan Expeditie",
+    "revisitExpedition": "Opnieuw bezoeken — kies een piramide",
     "or": "Of",
     "selectAnotherExpedition": "Selecteer een andere expeditie",
     "interruptExpedition": "Onderbreek expeditie",

--- a/src/app/PyramidExpedition.tsx
+++ b/src/app/PyramidExpedition.tsx
@@ -187,12 +187,25 @@ export const PyramidExpedition: FC<{
   const handleInteriorSiteComplete = useCallback(() => {
     setInteriorLevel(activeJourney.journeyId, null)
     setShowingInterior(false)
+    if (activeJourney.completionCount > 0) {
+      // Revisit/explore: each pyramid is an isolated re-exploration — return to the map instead of
+      // advancing to the next level or re-completing the journey.
+      onClose?.()
+      return
+    }
     transitionTimersRef.current.forEach(clearTimeout)
     transitionTimersRef.current = [
       setTimeout(() => setTransitionToLevel(activeJourney.levelNr + 1), 300),
       setTimeout(() => onNextLevel?.(), 2000),
     ]
-  }, [setInteriorLevel, activeJourney.journeyId, activeJourney.levelNr, onNextLevel])
+  }, [
+    setInteriorLevel,
+    activeJourney.journeyId,
+    activeJourney.levelNr,
+    activeJourney.completionCount,
+    onNextLevel,
+    onClose,
+  ])
 
   const onCompletionFinished = useCallback(() => {
     setLevelCompleted(false)

--- a/src/app/pages/Travel.tsx
+++ b/src/app/pages/Travel.tsx
@@ -24,6 +24,9 @@ export const TravelPage: FC<{
 
   const { activeJourneyId, startJourney, visitLevel, cancelJourney, getJourney, getOutstandingHiddenCorridorCount } =
     useJourneys()
+  // A completed journey (completionCount > 0) is in revisit/explore mode: selecting it from the grid
+  // lands on the map (not the game) so the player picks which pyramid to re-enter.
+  const isRevisit = (journeyId: string) => (getJourney(journeyId)?.completionCount ?? 0) > 0
   // Corridor detector L4 (§7.2): only the top detector level surfaces the world-wide marker.
   const corridorDetectorLevel = useMergedDetectorLevels().corridor
   const { isTombDiscovered, mapPieceCount, hasMapPiece: hasFoundMapPiece } = useTombTreasureProgress()
@@ -44,12 +47,20 @@ export const TravelPage: FC<{
   }, [showJourneySelection, showConversation])
 
   const journey = activeJourneyInfo?.journey ?? selectedJourney
+  // Revisit/explore: a completed journey (completionCount > 0). Every pyramid stays a pickable node
+  // even while one is open, so drive the path view past the last level regardless of stored levelNr.
+  const revisiting = !!journey && (activeJourneyInfo?.completionCount ?? 0) > 0
+  const pathLevelNr = revisiting && journey ? journey.levelCount + 1 : (activeJourneyInfo?.levelNr ?? 1)
 
   const handleMapClick = () => {
-    if (activeJourneyInfo) {
+    if (revisiting && journey) {
+      // Tapping the map background (not a node) re-enters the last-picked pyramid, re-solving its
+      // exterior board (visitLevel clears the interior).
+      const info = getJourney(journey.id)
+      const resumeAt = info && info.levelNr >= 1 && info.levelNr <= journey.levelCount ? info.levelNr : 1
+      visitLevel(journey.id, resumeAt)
       startGame()
-    } else if (selectedJourney && !activeJourneyInfo) {
-      startJourney(selectedJourney)
+    } else if (activeJourneyInfo?.inProgress) {
       startGame()
     } else {
       setShowJourneySelection(true)
@@ -57,6 +68,12 @@ export const TravelPage: FC<{
   }
 
   const handleJourneySelect = (journey: TranslatedJourney) => {
+    if (isRevisit(journey.id)) {
+      // Don't jump in — return to the map with the journey loaded so the player picks a pyramid.
+      setSelectedJourney(journey)
+      setShowJourneySelection(false)
+      return
+    }
     startJourney(journey)
     startGame()
   }
@@ -146,23 +163,24 @@ export const TravelPage: FC<{
                 onNodeClick={journey ? handleNodeClick : undefined}
                 inJourney={!!journey}
                 levelCount={journey?.levelCount ?? 1}
-                levelNr={activeJourneyInfo?.levelNr ?? 1}
+                levelNr={pathLevelNr}
                 journeyLength={journey?.journeyLength ?? "long"}
                 type={journey?.type ?? "pyramid"}
                 label={
-                  activeJourneyInfo?.inProgress
-                    ? t("ui.continueExpedition")
-                    : selectedJourney
-                      ? t("ui.startExpedition")
+                  revisiting
+                    ? t("ui.revisitExpedition")
+                    : activeJourneyInfo?.inProgress
+                      ? t("ui.continueExpedition")
                       : t("ui.planExpedition")
                 }
                 nudge={!journey && hasPendingMapPieceProgress}
               />
-              {!activeJourneyInfo && selectedJourney && (
+              {revisiting && (
                 <div className="mt-4 text-center text-sm">
                   {t("ui.or")}{" "}
                   <button
                     onClick={() => {
+                      if (activeJourneyId) cancelJourney()
                       setSelectedJourney(null)
                       setShowJourneySelection(true)
                     }}
@@ -172,7 +190,7 @@ export const TravelPage: FC<{
                   </button>
                 </div>
               )}
-              {activeJourneyInfo && (
+              {!revisiting && activeJourneyInfo?.inProgress && (
                 <div className="mt-4 text-center text-sm">
                   {t("ui.or")}{" "}
                   <button

--- a/src/ui/atoms/JourneyPathView.tsx
+++ b/src/ui/atoms/JourneyPathView.tsx
@@ -165,6 +165,9 @@ export const JourneyPathView: FC<Props> = ({
       {/* Path + site nodes */}
       {inJourney && (
         <svg className="absolute inset-0 h-full w-full" viewBox="0 0 100 100" preserveAspectRatio="none">
+          {/* Node hover halo — plain CSS so it doesn't depend on Tailwind JIT picking up SVG hover
+              utilities, and pointer-events:all so the transparent-when-idle circle still captures. */}
+          <style>{`.jpv-node{fill:#fcd34d;opacity:0;pointer-events:all;cursor:pointer;transition:opacity .15s}.jpv-node:hover{opacity:.6}`}</style>
           {/* Faint full path */}
           <path
             d={path}
@@ -179,20 +182,25 @@ export const JourneyPathView: FC<Props> = ({
             const isCurrent = i === currentIdx
             if (isCompleted) {
               return (
-                <g
-                  key={i}
-                  onClick={
-                    onNodeClick
-                      ? e => {
-                          e.stopPropagation()
-                          e.nativeEvent.stopImmediatePropagation()
-                          onNodeClick(i + 1)
-                        }
-                      : undefined
-                  }
-                  style={onNodeClick ? { cursor: "pointer" } : undefined}
-                >
-                  {onNodeClick && <circle cx={pos.x} cy={pos.y} r="7" fill="transparent" />}
+                <g key={i}>
+                  {/* Single hit-target + hover halo. pointer-events on the dot are disabled so the
+                      whole radius (center included) hovers this circle, not the dot on top of it. */}
+                  <circle
+                    cx={pos.x}
+                    cy={pos.y}
+                    r="9"
+                    onClick={
+                      onNodeClick
+                        ? e => {
+                            e.stopPropagation()
+                            e.nativeEvent.stopImmediatePropagation()
+                            onNodeClick(i + 1)
+                          }
+                        : undefined
+                    }
+                    // eslint-disable-next-line tailwindcss/no-custom-classname -- plain CSS hover class defined above
+                    className={onNodeClick ? "jpv-node" : "pointer-events-none fill-transparent"}
+                  />
                   <circle
                     cx={pos.x}
                     cy={pos.y}
@@ -200,6 +208,7 @@ export const JourneyPathView: FC<Props> = ({
                     fill="rgb(245,158,11)"
                     stroke="rgb(180,83,9)"
                     strokeWidth="0.8"
+                    className="pointer-events-none"
                   />
                 </g>
               )
@@ -234,9 +243,9 @@ export const JourneyPathView: FC<Props> = ({
         </svg>
       )}
 
-      {/* Label */}
+      {/* Label — pointer-events-none so node clicks/hovers underneath still reach the SVG circles */}
       <span
-        className={`relative z-10 text-2xl font-bold transition-colors duration-300 ${
+        className={`pointer-events-none relative z-10 text-2xl font-bold transition-colors duration-300 ${
           isPyramid ? "text-amber-900 group-hover:text-amber-800" : "text-amber-200 group-hover:text-amber-100"
         }`}
       >
@@ -245,7 +254,7 @@ export const JourneyPathView: FC<Props> = ({
 
       {/* Corner icon */}
       <div
-        className={`absolute right-2 bottom-2 flex h-6 w-6 items-center justify-center rounded-full border text-xs ${
+        className={`pointer-events-none absolute right-2 bottom-2 flex h-6 w-6 items-center justify-center rounded-full border text-xs ${
           isPyramid ? "border-amber-700 bg-amber-100 text-amber-800" : "border-amber-600 bg-stone-700 text-amber-400"
         }`}
       >


### PR DESCRIPTION
## What

Revisiting a **completed** journey (`completionCount > 0`) now opens its map so the player picks which pyramid to explore, instead of dropping straight into the first one.

- Every pyramid is a pickable node on the map.
- Each re-entry replays the pyramid's exterior puzzle.
- Finishing or leaving a pyramid returns to the map to pick another — the map stays fully pickable even while a pyramid is open.
- `levelNr` / `completionCount` never mutate during revisit.

First-run journeys are unchanged (normal progression; only completed nodes pickable).

## Changes

- **Travel** — revisit mode keyed on `completionCount`; map background tap re-enters the last-picked pyramid; footer offers "select another" (cancels the revisit) instead of the "interrupt — progress lost" flow.
- **PyramidExpedition** — in revisit, completing the interior returns to the map rather than advancing the level or re-completing the journey.
- **JourneyPathView** — node hover halo + reliable hit target; label and corner icon set `pointer-events-none` so node clicks/hovers reach the SVG circles (this was the root cause of clicks falling through to the wrong pyramid and the missing halo).

## Testing

- `yarn check-types`, `yarn lint`, `yarn test` (763 tests) all pass.
- Driven end-to-end in-browser (Playwright): revisit → pick node 1 → pyramid 1/2 exterior → exit → map (both nodes pickable) → pick node 2 → pyramid 2/2, no advancement. Hover halo scoped to the hovered node.
- Not auto-driven: finish-interior→map path (needs a solved puzzle); it reuses the confirmed `onClose`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)