### PR TITLE
fix: mosaic reward popup crashed to a black screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Opening a chest that held a mosaic tile crashed the game to a black screen. The reward popup now shows correctly.
 
 ## 0.27.2 - 2026-07-17
 ### Changed

--- a/src/mods/mosaic/app/rewardDisplay.spec.ts
+++ b/src/mods/mosaic/app/rewardDisplay.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest"
+import { registerMosaicRewardDisplay } from "./rewardDisplay"
+import { getRewardHandler } from "@/app/SiteMap/rewardHandlerRegistry"
+
+describe("mosaic reward display", () => {
+  it("builds popup text from (reward, t) — first arg is the reward, not the translator", () => {
+    registerMosaicRewardDisplay()
+    const handler = getRewardHandler("mosaicPiece")
+    expect(handler).toBeDefined()
+
+    // Call it exactly as rewardText/RewardFlow does: (reward, t). A lone-`t` handler would bind the
+    // reward object to its first param and call it as a function here — the black-screen crash.
+    const t = (key: string) => `t:${key}`
+    const text = handler!.text({ type: "mosaicPiece" }, t)
+
+    expect(text.itemName).toBe("t:chest.mosaicPiece")
+    expect(text.itemDescription).toBe("t:chest.mosaicPieceDescription")
+    expect(text.icon).toBe("🟦")
+  })
+})

--- a/src/mods/mosaic/app/rewardDisplay.ts
+++ b/src/mods/mosaic/app/rewardDisplay.ts
@@ -7,6 +7,13 @@ export const registerMosaicRewardDisplay = () => {
   registerRewardHandler({
     type: "mosaicPiece",
     emoji: "🔷", // no dedicated icon; text().icon below is the real one
-    text: t => ({ itemName: t("chest.mosaicPiece"), itemDescription: t("chest.mosaicPieceDescription"), icon: "🟦" }),
+    // Signature is (reward, t) — the first arg is the reward, `t` is the translator. Taking a lone
+    // `t =>` param bound it to the reward object, so t("chest.mosaicPiece") called the reward as a
+    // function and crashed the reward popup (black screen) on the first mosaic a player ever opened.
+    text: (_reward, t) => ({
+      itemName: t("chest.mosaicPiece"),
+      itemDescription: t("chest.mosaicPieceDescription"),
+      icon: "🟦",
+    }),
   })
 }


### PR DESCRIPTION
## The crash
Opening a chest holding a mosaic tile crashed the game to a black screen — reproducible in the first pyramid of the first journey, on a fresh save.

**Root cause:** `src/mods/mosaic/app/rewardDisplay.ts` declared the reward handler's text builder as `text: t => (...)`, but the `RewardHandler` contract is `text: (reward, t) => RewardText` and `rewardText` invokes it positionally as `handler.text(reward, t)`. So `t` bound to the **reward object**, and `t("chest.mosaicPiece")` called a plain object as a function → `TypeError` inside `RewardFlow`'s render → black screen. It fired for every `mosaicPiece` chest.

TypeScript didn't catch it: `registerRewardHandler` takes `RewardHandler<any>`, and a 1-arg function is assignable to the 2-arg type.

**Why now:** the bug has existed since the handler was introduced, but no mosaic tile was reachable that early until v0.27.2's early-mosaic change put one in the opening pyramid. Every other mod's handler uses the correct `(reward, t)` / `(_reward, t)` — mosaic was the only broken one.

## Fix
- Correct the signature to `(_reward, t)`.
- Add a regression test that invokes the handler exactly as `rewardText` does (`handler.text(reward, t)`), which throws on the old wrong-arity version.

Typecheck, lint, and the new test are green.

## Follow-up (not in this PR)
`mosaicPiece` registers no `skip`/dedup guard, so re-opening an already-collected mosaic chest re-grants and re-reveals it (other currencies like hieroglyph fragments skip when already owned). Harmless now that the popup works, but worth a look — say the word and I'll open a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)