### PR TITLE
Tableau story fully readable + ward-key loot shows the real treasure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- The short story on a tomb tableau is now fully readable from the start, instead of unscrambling letter by letter as you solve the puzzle.
+
+### Fixed
+- Claiming a tomb ward key now shows the actual treasure you found — its name and icon — instead of a generic "tomb key".
 
 ## 0.27.5 - 2026-07-17
 ### Fixed

--- a/src/app/SiteMap/RewardFlow.tsx
+++ b/src/app/SiteMap/RewardFlow.tsx
@@ -13,7 +13,7 @@ type Props = {
 }
 
 export const RewardFlow: FC<Props> = ({ pendingReward, onDismiss }) => {
-  const { t } = useTranslation(["common", "inventory", "sellables"])
+  const { t } = useTranslation(["common", "inventory", "sellables", "treasures"])
   const displays = useMergedRewardDisplays()
   const [showLoot, setShowLoot] = useState(false)
   const [scheduleLoot] = useTimeout()

--- a/src/app/TombLevel/TombPuzzle.tsx
+++ b/src/app/TombLevel/TombPuzzle.tsx
@@ -21,28 +21,6 @@ import { FezContext } from "../fez/context"
 import { createPositionOverview } from "@/mods/hieroglyph/game/filledPositions"
 import { mulberry32, shuffle } from "@/game/random"
 import { hashString } from "@/support/hashString"
-import type { Formula as FormulaType } from "@/game/formulas/formulas"
-
-// Counts the number of number-tile slots in a formula (used for solved-percentage display)
-const countFormulaSlots = (formula: FormulaType): number => {
-  let count = 0
-  if (typeof formula.left === "number") {
-    // nothing to do
-  } else if ("symbol" in formula.left) {
-    count += 1
-  } else {
-    count += countFormulaSlots(formula.left)
-  }
-  if (typeof formula.right === "number") {
-    // nothing to do
-  } else if ("symbol" in formula.right) {
-    count += 1
-  } else {
-    count += countFormulaSlots(formula.right)
-  }
-  return count
-}
-
 export const TombPuzzle: FC<{
   tableau: TableauLevel
   calculation: RewardCalculation
@@ -102,14 +80,6 @@ export const TombPuzzle: FC<{
   }, [notEnough, showConversation])
 
   const resolveTile = useMemo(() => (symbolId: string) => resolveHieroglyphSymbol(symbolId, difficulty), [difficulty])
-
-  const solvedPercentage = useMemo(() => {
-    const totalSlots =
-      calculation.hintFormulas.reduce((sum, formula) => sum + countFormulaSlots(formula), 0) +
-      countFormulaSlots(calculation.mainFormula)
-    const filledSlots = Object.keys(filledPositions).length
-    return totalSlots > 0 ? filledSlots / totalSlots : 0
-  }, [calculation, filledPositions])
 
   const hintFormulas: OrderedFormula[] = useMemo(() => {
     const ordered = calculation.hintFormulas.map((f, i) => ({ formula: f, index: i }))
@@ -211,7 +181,6 @@ export const TombPuzzle: FC<{
       filledState={{ filledPositions, symbolCounts }}
       resolveTile={resolveTile}
       hintFormulas={hintFormulas}
-      solvedPercentage={solvedPercentage}
       annotations={annotations}
       onTileClick={handleTileClick}
       onAnnotationChange={handleAnnotationChange}

--- a/src/mods/tombTreasure/app/TombTreasureCollectionSection.tsx
+++ b/src/mods/tombTreasure/app/TombTreasureCollectionSection.tsx
@@ -1,12 +1,12 @@
 import type { FC } from "react"
 import { useTranslation } from "react-i18next"
-import { difficulties, type Difficulty } from "@/data/difficultyLevels"
+import { difficulties } from "@/data/difficultyLevels"
 import { useMergedPerkContributions } from "@/app/SiteMap/perkContributions"
 import { CategoryGrid } from "@/ui/atoms/CategoryGrid"
 import { CollectionSection } from "@/ui/atoms/CollectionSection"
 import { CollectibleSlot } from "@/ui/molecules/CollectibleSlot"
 import type { CollectionSectionProps } from "@/app/pages/collectionSectionRegistry"
-import { difficultyTreasures, keyIdByTreasureId } from "../game/treasures"
+import { CATEGORY_BY_DIFFICULTY, difficultyTreasures, keyIdByTreasureId } from "../game/treasures"
 import { TREASURE_PERKS } from "../game/treasurePerks"
 import { useTombTreasureProgress } from "./useTombTreasureProgress"
 
@@ -15,15 +15,6 @@ import { useTombTreasureProgress } from "./useTombTreasureProgress"
 // shows the treasure's perk bonus as its effect line — a stat/detector perk via the merged perk
 // `describe` (the owning mod's i18n), a tier-unlock/location-key described here, `none` blank.
 // Registered app-side gated on the mod (see ./index), so it drops out when tomb-treasure is off.
-
-// The catalog difficulty → its treasures.json category (the authored name/description namespace).
-const CATEGORY_BY_DIFFICULTY: Record<Difficulty, string> = {
-  starter: "merchantCache",
-  junior: "nobleVault",
-  expert: "templeSecrets",
-  master: "ancientRelics",
-  wizard: "mythicalArtifacts",
-}
 
 export const TombTreasureCollectionSection: FC<CollectionSectionProps> = ({ selectedItem, onSelect }) => {
   const { t } = useTranslation(["common", "treasures"])

--- a/src/mods/tombTreasure/app/rewardDisplay.ts
+++ b/src/mods/tombTreasure/app/rewardDisplay.ts
@@ -1,4 +1,6 @@
 import { registerRewardHandler } from "@/app/SiteMap/rewardHandlerRegistry"
+import { treasureDisplayByKeyId } from "../game/treasures"
+import { tombKeySchema } from "./rewardSchemas"
 
 // The map-piece / tomb-key rewards' synchronous popup text/emoji (used by the generic RewardFlow
 // fallback and the shop stock list). The claim EFFECTS are the mod's reward contribution (see
@@ -16,6 +18,17 @@ export const registerTombTreasureRewardDisplay = () => {
   registerRewardHandler({
     type: "tombKey",
     emoji: "🗝",
-    text: (_reward, t) => ({ itemName: t("chest.tombKey"), icon: "🗝" }),
+    // A tomb key IS a specific treasure (the perk stream — "the treasure IS the key"), so show the
+    // treasure actually received, not the opaque key type. Falls back to the generic label if the
+    // keyId isn't a catalog treasure (e.g. a bare structural key).
+    text: (reward, t) => {
+      const info = treasureDisplayByKeyId[tombKeySchema.parse(reward).keyId]
+      if (!info) return { itemName: t("chest.tombKey"), icon: "🗝" }
+      return {
+        itemName: t(`${info.category}.${info.treasureId}.name`, { ns: "treasures" }),
+        itemDescription: t(`${info.category}.${info.treasureId}.description`, { ns: "treasures" }),
+        icon: info.symbol,
+      }
+    },
   })
 }

--- a/src/mods/tombTreasure/game/treasures.spec.ts
+++ b/src/mods/tombTreasure/game/treasures.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { TOMB_PERK_IDS } from "@/data/treasurePerks"
-import { TOMB_TREASURES, keyIdByTreasureId, treasureByKeyId, allTreasures } from "./treasures"
+import { TOMB_TREASURES, keyIdByTreasureId, treasureByKeyId, treasureDisplayByKeyId, allTreasures } from "./treasures"
 import { TREASURE_PERKS } from "./treasurePerks"
 
 // The Collection section derives "collected" from a treasure's keyId (a tombKey), so the zip of
@@ -27,5 +27,18 @@ describe("tomb treasure ↔ keyId mapping", () => {
     for (const keyId of Object.keys(TREASURE_PERKS)) {
       expect(treasureByKeyId[keyId], `${keyId} has a treasure`).toBeDefined()
     }
+  })
+
+  // The tomb-key loot popup names the treasure a claimed ward key grants (not a generic "tomb key"),
+  // resolving it through treasureDisplayByKeyId — so every keyId must map to its treasure's own
+  // i18n category/id + symbol.
+  it("resolves every keyId to its treasure's display info", () => {
+    for (const [keyId, treasure] of Object.entries(treasureByKeyId)) {
+      const info = treasureDisplayByKeyId[keyId]
+      expect(info, `${keyId} has display info`).toBeDefined()
+      expect(info.treasureId).toBe(treasure.id)
+      expect(info.symbol).toBe(treasure.symbol)
+    }
+    expect(treasureDisplayByKeyId["starter_a_1"]?.category).toBe("merchantCache")
   })
 })

--- a/src/mods/tombTreasure/game/treasures.ts
+++ b/src/mods/tombTreasure/game/treasures.ts
@@ -337,3 +337,25 @@ for (const [tombId, treasures] of Object.entries(TOMB_TREASURES)) {
     treasureByKeyId[keyId] = treasure
   })
 }
+
+// The Collection groups treasures by difficulty under these i18n category keys (`<category>.<id>.name`
+// in the `treasures` ns). Shared with the tomb-key reward display so a claimed ward key shows the
+// actual treasure's name + symbol instead of a generic "tomb key".
+export const CATEGORY_BY_DIFFICULTY: Record<Difficulty, string> = {
+  starter: "merchantCache",
+  junior: "nobleVault",
+  expert: "templeSecrets",
+  master: "ancientRelics",
+  wizard: "mythicalArtifacts",
+}
+
+// keyId → what the tomb-key reward popup needs to name the treasure it grants (its i18n key parts +
+// symbol), so the loot screen shows the item received rather than the opaque key type.
+export const treasureDisplayByKeyId: Record<string, { category: string; treasureId: string; symbol: string }> = {}
+for (const [difficulty, treasures] of Object.entries(difficultyTreasures) as [Difficulty, Treasure[]][]) {
+  const category = CATEGORY_BY_DIFFICULTY[difficulty]
+  for (const treasure of treasures) {
+    const keyId = keyIdByTreasureId[treasure.id]
+    if (keyId) treasureDisplayByKeyId[keyId] = { category, treasureId: treasure.id, symbol: treasure.symbol }
+  }
+}

--- a/src/ui/organisms/TombPuzzleView.stories.tsx
+++ b/src/ui/organisms/TombPuzzleView.stories.tsx
@@ -42,7 +42,6 @@ export const InProgress: Story = {
         filledState={{ symbolCounts: {}, filledPositions: {} }}
         resolveTile={resolveTile}
         hintFormulas={calculation.hintFormulas.map((f, i) => ({ formula: f, index: i }))}
-        solvedPercentage={0.3}
         annotations={{}}
         isPuzzleCompleted={false}
         lockState="empty"

--- a/src/ui/organisms/TombPuzzleView.tsx
+++ b/src/ui/organisms/TombPuzzleView.tsx
@@ -17,7 +17,6 @@ export const TombPuzzleView: FC<{
   filledState: FilledTileState
   resolveTile: HieroglyphSymbolResolver
   hintFormulas: OrderedFormula[]
-  solvedPercentage: number
   annotations: Record<string, string>
   onTileClick?: (symbolId: string, position: string) => void
   onAnnotationChange?: (symbolId: string, value: string) => void
@@ -39,7 +38,6 @@ export const TombPuzzleView: FC<{
   filledState,
   resolveTile,
   hintFormulas,
-  solvedPercentage,
   annotations,
   onTileClick,
   onAnnotationChange,
@@ -82,7 +80,6 @@ export const TombPuzzleView: FC<{
           filledState={filledState}
           resolveTile={resolveTile}
           hintFormulas={hintFormulas}
-          solvedPercentage={solvedPercentage}
           annotations={annotations}
           onTileClick={onTileClick}
           onAnnotationChange={onAnnotationChange}

--- a/src/ui/organisms/TombTableau.stories.tsx
+++ b/src/ui/organisms/TombTableau.stories.tsx
@@ -114,7 +114,6 @@ const meta = {
           }}
           resolveTile={symbolId => resolveHieroglyphSymbol(symbolId, journey.difficulty)}
           hintFormulas={calculation.hintFormulas.map((f, i) => ({ formula: f, index: i }))}
-          solvedPercentage={filled}
           annotations={{}}
         />
       </div>

--- a/src/ui/organisms/TombTableau.tsx
+++ b/src/ui/organisms/TombTableau.tsx
@@ -3,7 +3,6 @@ import { difficultyMaterialFlat } from "@/ui/tokens/difficultyColors"
 import type { TableauLevel } from "@/data/tableaus"
 import type { RewardCalculation } from "@/mods/hieroglyph/game/generateRewardCalculation"
 import type { Formula as FormulaType } from "@/game/formulas/formulas"
-import { revealText } from "@/support/revealText"
 import clsx from "clsx"
 import type { FC } from "react"
 import { Formula } from "@/ui/molecules/Formula"
@@ -19,7 +18,6 @@ export const TombTableau: FC<{
   filledState: FilledTileState
   resolveTile: HieroglyphSymbolResolver
   hintFormulas: OrderedFormula[]
-  solvedPercentage: number
   annotations: Record<string, string>
   onTileClick?: (symbolId: string, position: string) => void
   onAnnotationChange?: (symbolId: string, value: string) => void
@@ -31,7 +29,6 @@ export const TombTableau: FC<{
   filledState,
   resolveTile,
   hintFormulas,
-  solvedPercentage,
   annotations,
   onTileClick,
   onAnnotationChange,
@@ -43,8 +40,8 @@ export const TombTableau: FC<{
       difficultyMaterialFlat[difficulty]
     )}
   >
-    <h1 className="text-center font-pyramid text-2xl">{revealText(tableau.name, solvedPercentage)}</h1>
-    <div>{revealText(tableau.description, solvedPercentage)}</div>
+    <h1 className="text-center font-pyramid text-2xl">{tableau.name}</h1>
+    <div>{tableau.description}</div>
 
     {hintFormulas.map(({ formula, index }, key) => (
       <div key={key} className="text-2xl">


### PR DESCRIPTION
Two small user-reported fixes.

## 1. Tableau micro-story shown in full (was a solve-gated reveal)
The tomb tableau's title + short story unscrambled letter by letter as you solved the puzzle (`revealText` tied to solved percentage). Now shown fully readable from the start. Removed the now-dead `solvedPercentage` prop chain and the `countFormulaSlots` helper that only fed it.

`src/ui/organisms/TombTableau.tsx`, `TombPuzzleView.tsx`, `src/app/TombLevel/TombPuzzle.tsx` (+ stories).

## 2. Ward-key loot popup showed a generic "tomb key"
A claimed ward/tomb key is a specific treasure ("the treasure IS the key"), but the loot popup rendered a hardcoded `chest.tombKey` label, ignoring the reward's `keyId`. Now resolves the `keyId` to its treasure and shows that treasure's name, description, and symbol.

- New `treasureDisplayByKeyId` (keyId → treasure's i18n category/id + symbol).
- `CATEGORY_BY_DIFFICULTY` shared with the Collection section (was duplicated).
- `RewardFlow`'s `t` now includes the `treasures` namespace.

## Verification
- 769 tests pass (new: keyId → treasure display resolution)
- `yarn lint`, `yarn check-types` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)