### PR TITLE
Ward gates tinted by difficulty + themed gate description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Ward gates on the pyramid/tomb interior map are now tinted by the tier of the key that opens them, so you can read a locked ward's difficulty at a glance. The gate screen also shows a short themed line about who sealed it — a merchant, a nobleman, a high priest, a pharaoh, or the gods.
 
 ## 0.27.5 - 2026-07-17
 ### Fixed

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -101,7 +101,14 @@
     "locked": "You don't have the right key yet.",
     "unlocked": "You have the key.",
     "pass": "Pass through",
-    "turnAround": "Turn around"
+    "turnAround": "Turn around",
+    "wardDescription": {
+      "starter": "A merchant's seal bars this passage — only their ward key will part it.",
+      "junior": "A nobleman's crest locks this way — his ward key alone lifts it.",
+      "expert": "A high priest's temple ward guards this door — its sacred key must open it.",
+      "master": "A pharaoh's royal seal binds this passage — only the sovereign's key breaks it.",
+      "wizard": "A ward of the gods holds this gate — nothing but its divine key will pass."
+    }
   },
   "chest": {
     "tapToOpen": "Tap to open",

--- a/public/locales/nl/common.json
+++ b/public/locales/nl/common.json
@@ -101,7 +101,14 @@
     "locked": "Je hebt de juiste sleutel nog niet.",
     "unlocked": "Je hebt de sleutel.",
     "pass": "Doorgaan",
-    "turnAround": "Omdraaien"
+    "turnAround": "Omdraaien",
+    "wardDescription": {
+      "starter": "Een handelaarszegel verspert deze doorgang — enkel hun wachtsleutel opent hem.",
+      "junior": "Het wapen van een edelman sluit deze weg — alleen zijn wachtsleutel licht het op.",
+      "expert": "De tempelban van een hogepriester bewaakt deze deur — enkel de heilige sleutel opent hem.",
+      "master": "Het koninklijke zegel van een farao bindt deze doorgang — enkel de sleutel van de vorst verbreekt het.",
+      "wizard": "Een ban van de goden houdt deze poort — niets dan de goddelijke sleutel komt erlangs."
+    }
   },
   "chest": {
     "tapToOpen": "Tik om te openen",

--- a/src/app/SiteMap/SiteMapBuilder.stories.tsx
+++ b/src/app/SiteMap/SiteMapBuilder.stories.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react"
 import type { Meta, StoryObj } from "@storybook/react-vite"
 import { assembleFloor } from "../../game/siteAssembler"
 import { completeCell, getCell } from "../../game/gridNavigation"
-import type { FloorConfig, FloorGrid, GateConfig, SideSection, SiteConfig } from "../../game/siteTypes"
+import type { Difficulty, FloorConfig, FloorGrid, GateConfig, SideSection, SiteConfig } from "../../game/siteTypes"
 import { SiteMapView } from "./SiteMapView"
 
 type GateOption = "none" | GateConfig["type"]
@@ -38,12 +38,14 @@ const SiteMapBuilder = ({
   section2End,
   section2Gate,
 }: Props) => {
-  const toGate = (opt: GateOption): GateConfig | undefined =>
+  // A real ward key is `<difficulty>_a_<n>`, so a tomb-key gate uses its section's own tier — the
+  // map then tints the gate by that difficulty, exactly as in the generated world.
+  const toGate = (opt: GateOption, difficulty: Difficulty): GateConfig | undefined =>
     opt === "none"
       ? undefined
       : opt === "floor-key"
         ? { type: "floor-key" }
-        : { type: "tomb-key", wardKeyId: "preview_ward" }
+        : { type: "tomb-key", wardKeyId: `${difficulty}_a_1` }
 
   const sideSections: SideSection[] = []
   if (section1)
@@ -51,14 +53,14 @@ const SiteMapBuilder = ({
       pathPuzzles: section1Puzzles,
       difficulty: "starter",
       end: section1End,
-      gate: toGate(section1Gate),
+      gate: toGate(section1Gate, "starter"),
     })
   if (section2)
     sideSections.push({
       pathPuzzles: section2Puzzles,
       difficulty: "junior",
       end: section2End,
-      gate: toGate(section2Gate),
+      gate: toGate(section2Gate, "junior"),
     })
 
   const config: FloorConfig = {

--- a/src/app/SiteMap/SiteMapView.tsx
+++ b/src/app/SiteMap/SiteMapView.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react"
 import type {
   CellState,
   DecorationKind,
+  Difficulty,
   Direction,
   FloorGrid,
   GateVariant,
@@ -9,6 +10,7 @@ import type {
   KeyColor,
   RoomType,
 } from "../../game/siteTypes"
+import { wardKeyDifficulty } from "../../data/difficultyLevels"
 import { revealAll } from "../../game/gridNavigation"
 import { ExplorerDot } from "./ExplorerDot"
 import {
@@ -89,7 +91,14 @@ const PendingLootBadge = ({ r }: { r: number }) => (
 
 // ─── Node shape geometry ──────────────────────────────────────────────────────
 
-type ShapeProps = { state: CellState; gateVariant?: GateVariant; keyColor?: KeyColor; keyColors?: KeyColor[] }
+type ShapeProps = {
+  state: CellState
+  gateVariant?: GateVariant
+  keyColor?: KeyColor
+  keyColors?: KeyColor[]
+  // A ward (tomb-key) gate's tier, derived from its key id — tints the gate by difficulty.
+  difficulty?: Difficulty
+}
 
 const KEY_COLOR_HEX: Record<KeyColor, { visible: string; reachable: string }> = {
   blue: { visible: "#2060c0", reachable: "#4090e0" },
@@ -176,18 +185,21 @@ const ForkShape = ({ state }: ShapeProps) => {
   return <polygon points={`0,${-r} ${r},0 0,${r} ${-r},0`} fill="#1e160e" stroke={stroke} strokeWidth={1.5} />
 }
 
-const GateNodeShape = ({ state, gateVariant, keyColor }: ShapeProps) => {
+const GateNodeShape = ({ state, gateVariant, keyColor, difficulty }: ShapeProps) => {
   const r = NODE_RADIUS_LARGE
   const isTomb = gateVariant === "tomb-key"
   const colorKey = state === "visible" ? "visible" : "reachable"
   const fill = isTomb ? tombGateFill[state] : gateFill[state]
+  // A ward gate is tinted by its key's difficulty tier (so the map reads which tier a locked ward
+  // belongs to); tombGate* stays the fallback when no difficulty is known (or the default purple).
+  const tombAccent = difficulty ? DIFFICULTY_GATE_ACCENT[difficulty][colorKey] : undefined
   const stroke =
     state === "fogged"
       ? isTomb
         ? tombGateStroke[state]
         : gateStroke[state]
       : isTomb
-        ? tombGateStroke[state]
+        ? (tombAccent ?? tombGateStroke[state])
         : keyColor
           ? KEY_COLOR_HEX[keyColor][colorKey]
           : gateStroke[state]
@@ -195,9 +207,7 @@ const GateNodeShape = ({ state, gateVariant, keyColor }: ShapeProps) => {
     state === "fogged"
       ? "#3a2a10"
       : isTomb
-        ? colorKey === "visible"
-          ? "#8040c0"
-          : "#9060e0"
+        ? (tombAccent ?? (colorKey === "visible" ? "#8040c0" : "#9060e0"))
         : keyColor
           ? KEY_COLOR_HEX[keyColor][colorKey]
           : colorKey === "visible"
@@ -355,8 +365,8 @@ const nodeRadius: Record<ShapeKind, number> = {
   exit: NODE_RADIUS_LARGE,
 }
 
-const NodeShape = ({ type, state, gateVariant, keyColor, keyColors }: ShapeProps & { type: ShapeKind }) => {
-  const p = { state, gateVariant, keyColor, keyColors }
+const NodeShape = ({ type, state, gateVariant, keyColor, keyColors, difficulty }: ShapeProps & { type: ShapeKind }) => {
+  const p = { state, gateVariant, keyColor, keyColors, difficulty }
   switch (type) {
     case "entrance":
       return <EntranceShape {...p} />
@@ -422,6 +432,17 @@ const tombGateStroke: Record<CellState, string> = {
   visible: "#604898",
   reachable: "#7060c0",
   completed: "#7060c0",
+}
+
+// Ward (tomb-key) gate tint per difficulty tier — `visible` is the dimmer locked hue, `reachable`
+// the brighter one (also used for `completed`). Hues track the tier material palette
+// (difficultyColors.ts): stone / amber / slate / gold / emerald.
+const DIFFICULTY_GATE_ACCENT: Record<Difficulty, { visible: string; reachable: string }> = {
+  starter: { visible: "#8a857e", reachable: "#c4bcb2" },
+  junior: { visible: "#c2740e", reachable: "#f59e0b" },
+  expert: { visible: "#586274", reachable: "#94a3b8" },
+  master: { visible: "#c2a10b", reachable: "#eab308" },
+  wizard: { visible: "#0e9268", reachable: "#10b981" },
 }
 
 const treasureFill: Record<CellState, string> = {
@@ -1126,6 +1147,7 @@ export const SiteMapView = ({
                     gateVariant={cell.gateVariant}
                     keyColor={cell.keyColor}
                     keyColors={cell.keyColors}
+                    difficulty={wardKeyDifficulty(cell.requiredKeyId)}
                   />
                 </g>
                 {isCompleted &&

--- a/src/data/difficultyLevels.spec.ts
+++ b/src/data/difficultyLevels.spec.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest"
+import { wardKeyDifficulty } from "./difficultyLevels"
+
+// Ward gates are tinted + described by their key's difficulty, derived from the key id prefix
+// (`<difficulty>_<wing>_<n>`, e.g. "junior_a_2"). Guards the parse used by the map + gate encounter.
+describe("wardKeyDifficulty", () => {
+  it("reads the tier prefix of every ward-key shape", () => {
+    expect(wardKeyDifficulty("starter_a_1")).toBe("starter")
+    expect(wardKeyDifficulty("junior_a_6")).toBe("junior")
+    expect(wardKeyDifficulty("expert_b_3")).toBe("expert")
+    expect(wardKeyDifficulty("master_a_5")).toBe("master")
+    expect(wardKeyDifficulty("wizard_c_2")).toBe("wizard")
+  })
+
+  it("returns undefined for non-tier keys and missing ids", () => {
+    expect(wardKeyDifficulty(undefined)).toBeUndefined()
+    expect(wardKeyDifficulty("blue")).toBeUndefined() // a floor-key color, not a ward key
+    expect(wardKeyDifficulty("")).toBeUndefined()
+  })
+})

--- a/src/data/difficultyLevels.ts
+++ b/src/data/difficultyLevels.ts
@@ -4,3 +4,11 @@ export type Difficulty = (typeof difficulties)[number]
 
 export const difficultyCompare = (a: Difficulty, b: Difficulty): number =>
   difficulties.indexOf(a) - difficulties.indexOf(b)
+
+// A ward key id is `<difficulty>_<wing>_<n>` (e.g. "junior_a_2"), so its prefix is the tier the
+// gate it opens belongs to. Used to tint/describe a ward gate by its key's difficulty. Returns
+// undefined for anything that isn't a tier-prefixed key (e.g. a floor-key color id).
+export const wardKeyDifficulty = (keyId: string | undefined): Difficulty | undefined => {
+  const prefix = keyId?.split("_")[0] as Difficulty | undefined
+  return prefix && (difficulties as readonly string[]).includes(prefix) ? prefix : undefined
+}

--- a/src/mods/core/app/keyGate/plugin.tsx
+++ b/src/mods/core/app/keyGate/plugin.tsx
@@ -2,6 +2,7 @@
 import { useTranslation } from "react-i18next"
 import { registerFamily, type FamilyContext, type FamilyPlugin } from "@/app/families/familyRegistry"
 import { KEY_GATE_META } from "@/mods/core/game/keyGate/meta"
+import { wardKeyDifficulty } from "@/data/difficultyLevels"
 
 type KeyGatePuzzle = { satisfied: boolean }
 
@@ -12,12 +13,20 @@ const generate = (_seed: number, ctx: FamilyContext): KeyGatePuzzle => ({
   satisfied: !ctx.requiredKeyId || (ctx.ownedKeys?.has(ctx.requiredKeyId) ?? false),
 })
 
-const KeyGateComponent: FamilyPlugin["Component"] = ({ puzzle, onSolved, onCancel }) => {
+const KeyGateComponent: FamilyPlugin["Component"] = ({ puzzle, ctx, onSolved, onCancel }) => {
   const { satisfied } = puzzle as KeyGatePuzzle
   const { t } = useTranslation("common")
+  // A ward (tomb-key) gate carries the flavor of the tier that sealed it (merchant, noble, ...),
+  // derived from its key's difficulty. Floor-key/color gates have no such theme.
+  const wardDifficulty = ctx.gateVariant === "tomb-key" ? wardKeyDifficulty(ctx.requiredKeyId) : undefined
   return (
     <div className="fixed inset-0 z-30 flex flex-col items-center justify-center gap-6 bg-black/85">
       <p className="font-pyramid text-2xl text-amber-300">{t("gate.title")}</p>
+      {wardDifficulty && (
+        <p className="max-w-xs text-center text-sm text-stone-400 italic">
+          {t(`gate.wardDescription.${wardDifficulty}`)}
+        </p>
+      )}
       <p className="text-sm text-stone-300">{satisfied ? t("gate.unlocked") : t("gate.locked")}</p>
       <div className="flex flex-col items-center gap-3">
         {satisfied && (


### PR DESCRIPTION
Two related additions for ward (tomb-key) gates, so their tier reads at a glance.

## 1. Interior map: tint ward gates by difficulty
Each ward gate on the pyramid/tomb interior map is now tinted by the difficulty tier of the key that opens it (stone / amber / slate / gold / emerald), instead of a single fixed purple. The tier is derived from the key id prefix (`<difficulty>_a_<n>`).

## 2. Gate encounter: themed description
The gate screen now shows a short in-world line about who sealed it, themed per tier — a merchant (starter), a nobleman (junior), a high priest (expert), a pharaoh (master), or the gods (wizard). English + Dutch.

## Implementation
- New shared `wardKeyDifficulty(keyId)` helper (unit-tested) — the one place that parses a ward key's tier, used by both the map and the encounter.
- `SiteMapView`: `DIFFICULTY_GATE_ACCENT` palette; tomb-gate stroke/bars use the tier hue, falling back to the old purple when no tier is known (e.g. a non-ward key).
- `keyGate` encounter: `gate.wardDescription.<tier>` line.
- `SiteMapBuilder` story: tomb-key gates now use a realistic `<tier>_a_1` key so the preview shows the real tint.

## Verification
- Map tint confirmed in Storybook: a starter ward gate renders `#8a857e` (stone), a junior one orange — not the uniform purple fallback.
- Data path confirmed: an assembled ward-gate cell carries `requiredKeyId` + `gateVariant`, which both the map and the encounter read.
- 770 tests pass (new: `wardKeyDifficulty`), `yarn lint` + `yarn check-types` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)