### PR TITLE
fix: tier-unlock treasure says 'expeditions', not 'tombs'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- The tier-unlock treasure now correctly reads "Unlocks {tier} expeditions" — it opens the next difficulty of expeditions, not tombs.
 
 ## 0.28.0 - 2026-07-18
 ### Added

--- a/public/locales/en/treasures.json
+++ b/public/locales/en/treasures.json
@@ -12,7 +12,7 @@
     "compass": "Fragment compass (Lv {{level}})",
     "detection": "Hidden-corridor detector (Lv {{level}})",
     "scribes-eye": "Tableau hint slots (Lv {{level}})",
-    "tier-unlock": "Unlocks {{tier}} tombs",
+    "tier-unlock": "Unlocks {{tier}} expeditions",
     "location-key": "Reveals another tomb"
   },
   "tiers": {

--- a/public/locales/nl/treasures.json
+++ b/public/locales/nl/treasures.json
@@ -12,7 +12,7 @@
     "compass": "Fragmentkompas (niv {{level}})",
     "detection": "Verborgen-gangdetector (niv {{level}})",
     "scribes-eye": "Tableau-hintvakken (niv {{level}})",
-    "tier-unlock": "Ontgrendelt {{tier}}-tombes",
+    "tier-unlock": "Ontgrendelt {{tier}}-expedities",
     "location-key": "Onthult een andere tombe"
   },
   "tiers": {


### PR DESCRIPTION
The first ward key's treasure (a tier-unlock perk) read "Unlocks {tier} tombs", but the tier-unlock ladder opens the next difficulty of **expeditions** (pyramids) — tombs unlock via map pieces instead. Reworded `perks.tier-unlock` to "Unlocks {tier} expeditions" (en + nl).

🤖 Generated with [Claude Code](https://claude.com/claude-code)