### PR TITLE
Journey/tomb card fixes: length indicator, tomb revisit label + re-entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Removed the length indicator from journey and tomb cards.
+
+### Fixed
+- Re-entering a completed tomb from the travel screen now works — clicking its revisit card used to end the journey instead of taking you back in. The tomb's card also now reads "Revisit — re-enter the tomb" instead of "pick a pyramid" (a tomb is a single site, not a set of pyramids).
 
 ## 0.28.1 - 2026-07-18
 ### Fixed

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -55,6 +55,7 @@
     "startExpedition": "Start Expedition",
     "planExpedition": "Plan Expedition",
     "revisitExpedition": "Revisit — pick a pyramid",
+    "revisitTomb": "Revisit — re-enter the tomb",
     "or": "Or",
     "selectAnotherExpedition": "Select another expedition",
     "interruptExpedition": "Interrupt expedition",

--- a/public/locales/nl/common.json
+++ b/public/locales/nl/common.json
@@ -55,6 +55,7 @@
     "startExpedition": "Start Expeditie",
     "planExpedition": "Plan Expeditie",
     "revisitExpedition": "Opnieuw bezoeken — kies een piramide",
+    "revisitTomb": "Opnieuw bezoeken — betreed de tombe",
     "or": "Of",
     "selectAnotherExpedition": "Selecteer een andere expeditie",
     "interruptExpedition": "Onderbreek expeditie",

--- a/src/app/pages/Travel.tsx
+++ b/src/app/pages/Travel.tsx
@@ -47,17 +47,23 @@ export const TravelPage: FC<{
   }, [showJourneySelection, showConversation])
 
   const journey = activeJourneyInfo?.journey ?? selectedJourney
+  // A tomb is played as a SINGLE-level exterior journey (its multi-floor interior is one site), so
+  // its effective exterior level count is always 1 — regardless of the raw multi-floor `levelCount`
+  // (2–5). Re-entry must resume a tomb at level 1: resuming at its raw levelCount (where a completed
+  // tomb's stored levelNr sits) makes the expedition read `levelNr > 1` as "already complete" and
+  // immediately end the journey, blocking re-entry (PyramidExpedition's expeditionCompleted guard).
+  const effectiveLevelCount = journey?.type === "treasure_tomb" ? 1 : (journey?.levelCount ?? 1)
   // Revisit/explore: a completed journey (completionCount > 0). Every pyramid stays a pickable node
   // even while one is open, so drive the path view past the last level regardless of stored levelNr.
   const revisiting = !!journey && (activeJourneyInfo?.completionCount ?? 0) > 0
-  const pathLevelNr = revisiting && journey ? journey.levelCount + 1 : (activeJourneyInfo?.levelNr ?? 1)
+  const pathLevelNr = revisiting && journey ? effectiveLevelCount + 1 : (activeJourneyInfo?.levelNr ?? 1)
 
   const handleMapClick = () => {
     if (revisiting && journey) {
       // Tapping the map background (not a node) re-enters the last-picked pyramid, re-solving its
       // exterior board (visitLevel clears the interior).
       const info = getJourney(journey.id)
-      const resumeAt = info && info.levelNr >= 1 && info.levelNr <= journey.levelCount ? info.levelNr : 1
+      const resumeAt = info && info.levelNr >= 1 && info.levelNr <= effectiveLevelCount ? info.levelNr : 1
       visitLevel(journey.id, resumeAt)
       startGame()
     } else if (activeJourneyInfo?.inProgress) {
@@ -84,7 +90,8 @@ export const TravelPage: FC<{
 
   const handleNodeClick = (levelNr: number) => {
     if (!journey) return
-    visitLevel(journey.id, levelNr)
+    // A tomb has a single exterior level; every "node" re-enters that one site (see effectiveLevelCount).
+    visitLevel(journey.id, journey.type === "treasure_tomb" ? 1 : levelNr)
     startGame()
   }
 
@@ -148,11 +155,7 @@ export const TravelPage: FC<{
                 <>
                   <h3 className="mb-4 text-center font-pyramid text-xl">{journey.name}</h3>
                   <p className="mb-4 max-w-md">{journey.description}</p>
-                  <div className="mb-4 flex items-center justify-between gap-2">
-                    <p>
-                      {t("ui.length")}: {journey.lengthLabel}
-                    </p>
-                    {/* show difficulty pill */}
+                  <div className="mb-4 flex items-center justify-end gap-2">
                     <DifficultyPill difficulty={journey.difficulty} label={journey.difficultyLabel} />
                   </div>
                 </>
@@ -162,13 +165,15 @@ export const TravelPage: FC<{
                 onClick={handleMapClick}
                 onNodeClick={journey ? handleNodeClick : undefined}
                 inJourney={!!journey}
-                levelCount={journey?.levelCount ?? 1}
+                levelCount={effectiveLevelCount}
                 levelNr={pathLevelNr}
                 journeyLength={journey?.journeyLength ?? "long"}
                 type={journey?.type ?? "pyramid"}
                 label={
                   revisiting
-                    ? t("ui.revisitExpedition")
+                    ? journey?.type === "treasure_tomb"
+                      ? t("ui.revisitTomb")
+                      : t("ui.revisitExpedition")
                     : activeJourneyInfo?.inProgress
                       ? t("ui.continueExpedition")
                       : t("ui.planExpedition")
@@ -281,7 +286,6 @@ export const TravelPage: FC<{
                     }
                     lang={i18n.language}
                     labels={{
-                      length: t("ui.length"),
                       chambers: t("ui.chambers"),
                       progressLevel: t("ui.progressLevel"),
                     }}

--- a/src/ui/organisms/JourneyCard.stories.tsx
+++ b/src/ui/organisms/JourneyCard.stories.tsx
@@ -85,7 +85,6 @@ const meta = {
   },
   args: {
     labels: {
-      length: "Length",
       chambers: "chambers",
       progressLevel: "Progress: Level",
     },

--- a/src/ui/organisms/JourneyCard.tsx
+++ b/src/ui/organisms/JourneyCard.tsx
@@ -4,7 +4,6 @@ import type { TranslatedJourney } from "@/app/translations/useJourneyTranslation
 import { DifficultyPill } from "@/ui/atoms/DifficultyPill"
 
 type JourneyCardLabels = {
-  length: string
   chambers: string
   progressLevel: string
 }
@@ -109,9 +108,6 @@ export const JourneyCard: FC<PropsWithChildren<JourneyCardProps>> = ({
             "text-amber-700": !disabled && !isTreasureTomb,
           })}
         >
-          <span className="flex-shrink-0">
-            {labels.length}: {journey.lengthLabel}
-          </span>
           {journey.type === "treasure_tomb" && (
             <span className="flex-shrink-0">
               {labels.chambers}: {journey.levelCount}


### PR DESCRIPTION
Three journey/tomb card issues.

## 1. Remove the length indicator
Journey and tomb cards showed a "Length: …" indicator (both the detail view and the grid card). Removed, along with the now-unused `length` label threaded through `JourneyCard`.

## 2. Tomb revisit card said "pick a pyramid"
The revisit card for a completed tomb reused the pyramid label "Revisit — pick a pyramid", but a tomb is a single site. Now reads "Revisit — re-enter the tomb" (new `ui.revisitTomb`, en + nl).

## 3. Re-entering a completed tomb ended the journey (couldn't get back in)
Root cause: a tomb is played as a **single-level** exterior journey (`levelCount 1`, its multi-floor interior is one site), but its raw data `levelCount` is 2–5. After completing a tomb the stored `levelNr` sits at `2`. The revisit handlers clamped the resume level against the **raw** `levelCount`, so they resumed at level 2 — which `PyramidExpedition`'s `expeditionCompleted` guard (`levelNr > 1`) reads as "already complete" and immediately ends the journey.

Fix: resume a tomb at its **effective** exterior level count (`1`) in both re-entry handlers (`handleMapClick`, `handleNodeClick`), and pass that effective count to `JourneyPathView` so a completed tomb draws a single node. Pyramids are unaffected (their raw and effective counts already match).

## Verification
- 771 tests pass, `yarn lint` + `yarn check-types` clean.
- Re-entry fix is a state-flow correction matching a confirmed root-cause trace; not unit-tested in isolation (reproducing needs a full tomb playthrough).

🤖 Generated with [Claude Code](https://claude.com/claude-code)