### PR TITLE
Fix blank tableau story + staircase back-travel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- The short story is shown again above a tomb tableau — it had gone blank.
+- You can now travel back down a staircase to a previous floor. Clicking a staircase you'd already used (including the one you arrive on) did nothing instead of taking you back.
 
 ## 0.28.2 - 2026-07-18
 ### Changed

--- a/src/app/SiteMap/SiteMapScreen.tsx
+++ b/src/app/SiteMap/SiteMapScreen.tsx
@@ -224,6 +224,27 @@ export const SiteMapScreen = ({ journeyId, siteConfig, seed, onSiteComplete, onC
       const edgeId = encodeEdge(currentFloor, row, col)
       const sectionHash = cell.sectionHash ?? ""
 
+      // A staircase teleports between floors regardless of the cell's state — handled BEFORE the
+      // completed-cell block below. The entrance stairhead you arrive on (and any up-staircase after
+      // its first use) is marked "completed", so without this the completed block would just
+      // reposition the player and swallow the click, blocking back-travel down a staircase.
+      if (cell.type === "room" && cell.roomType === "portal" && cell.stairId) {
+        journeys.markCellExplored(sectionHash, edgeId)
+        const stairId = cell.stairId
+        for (let fi = 0; fi < siteConfig.length; fi++) {
+          if (fi === currentFloor) continue
+          const result = assembleFloor(journeyId, siteConfig[fi], seed + fi, resolveEncounter)
+          if (!result.success) continue
+          const peerPos = result.grid.staircases[stairId]
+          if (peerPos) {
+            journeys.updatePosition(journeyId, encodeEdge(fi, peerPos[0], peerPos[1]))
+            setCurrentFloor(fi)
+            break
+          }
+        }
+        return
+      }
+
       // Completed cells just reposition the player, except a shop with unbought stock or an
       // unfitted consumable, which reopen.
       if (cell.state === "completed") {
@@ -278,22 +299,9 @@ export const SiteMapScreen = ({ journeyId, siteConfig, seed, onSiteComplete, onC
           setActiveEncounter({ pos: [row, col], freshArrival: true })
         )
       } else if (cell.roomType === "portal") {
-        if (cell.stairId) {
-          // Find the peer stairhead across floors and teleport there
-          journeys.markCellExplored(sectionHash, edgeId)
-          const stairId = cell.stairId
-          for (let fi = 0; fi < siteConfig.length; fi++) {
-            if (fi === currentFloor) continue
-            const result = assembleFloor(journeyId, siteConfig[fi], seed + fi, resolveEncounter)
-            if (!result.success) continue
-            const peerPos = result.grid.staircases[stairId]
-            if (peerPos) {
-              journeys.updatePosition(journeyId, encodeEdge(fi, peerPos[0], peerPos[1]))
-              setCurrentFloor(fi)
-              break
-            }
-          }
-        } else if (row === grid.entrancePos[0] && col === grid.entrancePos[1]) {
+        // Staircase portals (with a stairId) are handled by the early teleport guard above; here a
+        // portal is either this floor's own entrance (reposition only) or a real exit (leave the site).
+        if (row === grid.entrancePos[0] && col === grid.entrancePos[1]) {
           journeys.markCellExplored(sectionHash, edgeId)
           journeys.updatePosition(journeyId, edgeId)
         } else {

--- a/src/mods/hieroglyph/app/plugin.tsx
+++ b/src/mods/hieroglyph/app/plugin.tsx
@@ -10,6 +10,7 @@ import type { Operation } from "@/game/formulas/formulas"
 import { TombPuzzle } from "@/app/TombLevel/TombPuzzle"
 import { getTableauLevel, type TableauLevel } from "@/data/tableaus"
 import { journeys, type TreasureTombJourney } from "@/data/journeys"
+import { useTableauTranslations } from "@/app/translations/useTableauTranslations"
 import { tableauEncounterArgsSchema } from "@/mods/hieroglyph/game/keyRequirements"
 import { PuzzleFamilyShell } from "@/mods/core/app/PuzzleFamilyShell"
 import { TABLEAU_META } from "@/mods/hieroglyph/game/meta"
@@ -40,20 +41,32 @@ const TABLEAU_CONFIG: Record<string, TableauConfig> = {
 
 const TableauComponent: FamilyPlugin<RewardCalculation>["Component"] = ({ puzzle, ctx, onSolved, onCancel }) => {
   const difficulty = ctx.difficulty ?? "starter"
-  const dummyTableau: TableauLevel = {
-    id: "plugin",
-    levelNr: 1,
+  // Resolve this floor's authored TableauLevel so the puzzle shows its title + micro-story
+  // (translated), matching what the solver placed fragments for. Same (journeyId, runNr, levelNr)
+  // key the generate + world-gen resolvers use; the tableau id/symbols still come from the
+  // generated calculation. Without this the puzzle rendered an empty name/description (no story).
+  const translatedTableaus = useTableauTranslations()
+  const parsed = tableauEncounterArgsSchema.safeParse(ctx.encounterArgs)
+  const levelNr = (ctx.pathIndex ?? 0) + 1
+  const authored = parsed.success
+    ? translatedTableaus.find(
+        t => t.tombJourneyId === ctx.journeyId && t.runNumber === parsed.data.runNr && t.levelNr === levelNr
+      )
+    : undefined
+  const tableau: TableauLevel = {
+    id: authored?.id ?? "plugin",
+    levelNr,
     symbolCount: Object.keys(puzzle.symbolCounts).length,
     inventoryIds: Object.values(puzzle.symbolMapping),
-    tombJourneyId: "plugin",
-    runNumber: 1,
-    name: "",
-    description: "",
+    tombJourneyId: ctx.journeyId,
+    runNumber: parsed.success ? parsed.data.runNr : 1,
+    name: authored?.name ?? "",
+    description: authored?.description ?? "",
   }
   return (
     <PuzzleFamilyShell onSolved={onSolved} onCancel={onCancel}>
       {handleSolved => (
-        <TombPuzzle tableau={dummyTableau} calculation={puzzle} difficulty={difficulty} onComplete={handleSolved} />
+        <TombPuzzle tableau={tableau} calculation={puzzle} difficulty={difficulty} onComplete={handleSolved} />
       )}
     </PuzzleFamilyShell>
   )


### PR DESCRIPTION
Two more issues from play-testing.

## 1. Tableau micro-story went blank
The played tomb tableau's Component (`hieroglyph/app/plugin.tsx`) built a dummy `TableauLevel` with empty `name`/`description`, so nothing rendered above the equations (the earlier "story fully readable" change fixed the display, but the data feeding it was empty). Now the Component resolves this floor's authored, translated `TableauLevel` — same `(journeyId, runNr, levelNr)` key the calculation + world-gen resolvers use — and passes its `name`/`description` to `TombPuzzle`.

## 2. Can't travel back down a staircase
Going UP a floor works, but clicking the staircase to go back down did nothing. Root cause: the staircase teleport in `handleCellClick` was only reachable while the stairhead was in state `reachable`. The entrance stairhead you land on after going up is force-marked `completed` (`useAssembledFloor` always injects the entrance as explored), and the `cell.state === "completed"` block returned early (reposition only) before ever reaching the portal-teleport branch. So the click was swallowed. (The up-staircase would also break on repeat trips once it became `completed`.)

Fix: handle a portal-with-`stairId` teleport up front, before the completed-cell block, regardless of cell state. Removed the now-redundant `stairId` case from the later portal branch.

## Verification
- 771 tests pass, `yarn lint` + `yarn check-types` clean.
- Story resolution verified to return a non-empty authored tableau.
- Both are state/flow fixes backed by confirmed root-cause traces; not unit-tested in isolation (each needs an in-tomb playthrough to exercise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)