### PR TITLE
feat: ward treasures first in Collection screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- The Collection screen now lists ward treasures first (the most valuable — ward keys and their perks), then hieroglyph fragments, then junk.
 
 ## 0.29.0 - 2026-07-18
 ### Added

--- a/src/mods/hieroglyph/app/collection.ts
+++ b/src/mods/hieroglyph/app/collection.ts
@@ -5,4 +5,4 @@ import { HieroglyphCollectionSection } from "./HieroglyphCollectionSection"
 // Side-effect registration, gated on the mod: with hieroglyph off, the section never registers,
 // so the Collection screen renders no hieroglyph categories and core names nothing.
 if (isModEnabled("hieroglyph"))
-  registerCollectionSection({ id: "hieroglyph", order: 10, Component: HieroglyphCollectionSection })
+  registerCollectionSection({ id: "hieroglyph", order: 20, Component: HieroglyphCollectionSection })

--- a/src/mods/shop/app/index.ts
+++ b/src/mods/shop/app/index.ts
@@ -19,7 +19,7 @@ import "./fezShop/plugin" // the Fez shop encounter family (self-gated)
 // - the reward contribution: money is banked and a sellable is added to the inventory (the
 //   effects) — the mod owns the reward ids, core owns the money bucket + inventory it writes to.
 if (isModEnabled("shop")) {
-  registerCollectionSection({ id: "shop", order: 20, Component: ShopCollectionSection })
+  registerCollectionSection({ id: "shop", order: 30, Component: ShopCollectionSection })
   registerHudWidget({ id: "shop", order: 10, Component: ShopHud })
   registerShopRewardDisplay()
   registerRewardSchema("money", moneyRewardSchema)

--- a/src/mods/tombTreasure/app/index.ts
+++ b/src/mods/tombTreasure/app/index.ts
@@ -42,7 +42,8 @@ if (isModEnabled("tomb-treasure")) {
     }
   })
   registerHeldKeysProvider(() => useTombTreasureProgress().tombKeyIds)
-  // The 5 per-difficulty treasure groups (order after hieroglyph=10 / shop=20). "Collected" = own
-  // the tombKey; drops out of the Collection screen when the mod is off.
-  registerCollectionSection({ id: "tomb-treasure", order: 30, Component: TombTreasureCollectionSection })
+  // The 5 per-difficulty treasure groups. Ordered first (before hieroglyph=20 / shop=30) — ward
+  // treasures are the most valuable collectibles (ward keys + their perks). "Collected" = own the
+  // tombKey; drops out of the Collection screen when the mod is off.
+  registerCollectionSection({ id: "tomb-treasure", order: 10, Component: TombTreasureCollectionSection })
 }


### PR DESCRIPTION
Reorders the Collection screen so the most valuable collectibles sit on top: **ward treasures** (ward keys + their perks), then **hieroglyph fragments**, then **junk**.

## Change
The screen sorts registered sections ascending by `order`. Reassigned the three values:

| section | before | after |
|---------|--------|-------|
| tomb-treasure (ward treasures) | 30 | **10** |
| hieroglyph (fragments) | 10 | 20 |
| shop (junk) | 20 | 30 |

## Verification
`yarn check-types`, `yarn lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)