### PR TITLE
feat: escalate tomb tableau calculation by room position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Tomb tableau puzzles now ramp up as you descend: each room down a tomb widens the numbers and brings in more operators (starting from addition), so a later room asks a genuinely harder sum rather than the same shape as the one before — including two rooms on the same floor. Starter tomb sums now range 1–6.
 
 ## 0.29.1 - 2026-07-18
 ### Changed

--- a/src/data/journeys.ts
+++ b/src/data/journeys.ts
@@ -205,7 +205,7 @@ export const journeys: Journey[] = [
     piecesRequired: 4,
     levelSettings: {
       symbolCount: 2,
-      numberRange: [1, 5],
+      numberRange: [1, 6],
       operators: ["+"],
       compareAmount: 0,
     },

--- a/src/mods/hieroglyph/app/plugin.tsx
+++ b/src/mods/hieroglyph/app/plugin.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/mods/hieroglyph/game/generateRewardCalculation"
 import type { Operation } from "@/game/formulas/formulas"
 import { TombPuzzle } from "@/app/TombLevel/TombPuzzle"
-import { getTableauLevel, type TableauLevel } from "@/data/tableaus"
+import { getTableauLevel, TABLEAUS_PER_FLOOR, type TableauLevel } from "@/data/tableaus"
 import { journeys, type TreasureTombJourney } from "@/data/journeys"
 import { useTableauTranslations } from "@/app/translations/useTableauTranslations"
 import { tableauEncounterArgsSchema } from "@/mods/hieroglyph/game/keyRequirements"
@@ -92,9 +92,21 @@ if (isModEnabled("hieroglyph"))
         (j): j is TreasureTombJourney => j.id === ctx.journeyId && j.type === "treasure_tomb"
       )
       if (parsed.success && journey) {
-        const tableau = getTableauLevel(ctx.journeyId, parsed.data.runNr, (ctx.pathIndex ?? 0) + 1)
-        if (tableau)
-          return generateRewardCalculation(buildTombCalculationSettings(journey.levelSettings, tableau), random)
+        const levelNr = (ctx.pathIndex ?? 0) + 1
+        const tableau = getTableauLevel(ctx.journeyId, parsed.data.runNr, levelNr)
+        if (tableau) {
+          // Escalate by the room's position across the whole tomb (floor AND room), so two tableaus
+          // on the same floor still ramp — not just floor-to-floor.
+          const roomsPerFloor = TABLEAUS_PER_FLOOR[journey.difficulty]
+          const escalation = {
+            position: (parsed.data.runNr - 1) * roomsPerFloor + levelNr,
+            total: journey.levelCount * roomsPerFloor,
+          }
+          return generateRewardCalculation(
+            buildTombCalculationSettings(journey.levelSettings, tableau, escalation),
+            random
+          )
+        }
       }
       // Fallback for generation without a resolvable tomb floor (dummy/non-tomb): random draw from
       // the tier pool. A real tomb floor always carries encounterArgs, so it never takes this path.

--- a/src/mods/hieroglyph/game/generateRewardCalculation.spec.ts
+++ b/src/mods/hieroglyph/game/generateRewardCalculation.spec.ts
@@ -311,6 +311,25 @@ describe(generateRewardCalculation, () => {
       const settings = buildTombCalculationSettings(levelSettings, tableau)
       expect(settings.maxMultiplyOperandResult).toBeUndefined()
     })
+
+    it("escalates operators and range by room position — first room minimal, last room full", () => {
+      const levelSettings = {
+        numberRange: [1, 10] as [number, number],
+        operators: ["+", "-", "*"] as RewardCalculationSettings["operations"],
+      }
+      const tableau = { symbolCount: 3, inventoryIds: ["𓁧", "𓃯", "𓁝"] }
+      const first = buildTombCalculationSettings(levelSettings, tableau, { position: 1, total: 16 })
+      const last = buildTombCalculationSettings(levelSettings, tableau, { position: 16, total: 16 })
+      // First room: one operator, base range. Last room: all operators, range widened by the base span.
+      expect(first.operations).toEqual(["+"])
+      expect(first.numberRange).toEqual([1, 10])
+      expect(last.operations).toEqual(["+", "-", "*"])
+      expect(last.numberRange).toEqual([1, 19])
+      // Two rooms on the same floor still differ (the bug this fixes).
+      const room1 = buildTombCalculationSettings(levelSettings, tableau, { position: 1, total: 16 })
+      const room2 = buildTombCalculationSettings(levelSettings, tableau, { position: 2, total: 16 })
+      expect(room2.numberRange[1]).toBeGreaterThan(room1.numberRange[1])
+    })
   })
 
   it("can generate a puzzle with low difficulty", () => {

--- a/src/mods/hieroglyph/game/generateRewardCalculation.ts
+++ b/src/mods/hieroglyph/game/generateRewardCalculation.ts
@@ -31,16 +31,42 @@ export type TombTableauSettings = {
   inventoryIds: string[]
 }
 
+// A tableau room's position in the tomb's whole tableau sequence, for difficulty escalation. Keyed by
+// ROOM, not floor, so two rooms on one floor still differ. `position` is 1-based across all the tomb's
+// tableau rooms in descent order (`(floor-1) * roomsPerFloor + room`); `total` is that room count.
+export type CalcEscalation = { position: number; total: number }
+
+// Per-room escalation: later tableau rooms (deeper floor, or a later room on the same floor) widen the
+// number range and reveal more of the tomb's authored operators, so the arithmetic ramps across the
+// whole descent instead of every tableau asking the same shape of sum. `progress` runs 0 (first room)
+// → 1 (last): the first room uses one operator and the base range, the last uses all authored
+// operators and a range widened by the base span. Omit `escalation` (or a single-room tomb) for
+// neutral, full-operator settings — used by the vestigial inventory previews, which have no position.
 export const buildTombCalculationSettings = (
   levelSettings: TombLevelSettings,
-  tableau: TombTableauSettings
-): RewardCalculationSettings => ({
-  amountSymbols: tableau.symbolCount,
-  hieroglyphIds: tableau.inventoryIds,
-  numberRange: levelSettings.numberRange,
-  operations: levelSettings.operators,
-  maxMultiplyOperandResult: levelSettings.maxMultiplyOperandResult,
-})
+  tableau: TombTableauSettings,
+  escalation?: CalcEscalation
+): RewardCalculationSettings => {
+  const [min, max] = levelSettings.numberRange
+  const ops = levelSettings.operators
+  const base: RewardCalculationSettings = {
+    amountSymbols: tableau.symbolCount,
+    hieroglyphIds: tableau.inventoryIds,
+    numberRange: levelSettings.numberRange,
+    operations: ops,
+    maxMultiplyOperandResult: levelSettings.maxMultiplyOperandResult,
+  }
+  if (!escalation || escalation.total <= 1) return base
+
+  const progress = Math.min(1, Math.max(0, (escalation.position - 1) / (escalation.total - 1)))
+  const opCount = 1 + Math.round(progress * (ops.length - 1))
+  const rangeBoost = Math.round(progress * (max - min))
+  return {
+    ...base,
+    numberRange: [min, max + rangeBoost],
+    operations: ops.slice(0, opCount),
+  }
+}
 
 export type RewardCalculation = {
   pickedNumbers: number[]


### PR DESCRIPTION
Fixes the "second tableau needed the exact same calculation" report: every tableau in a tomb drew its calculation *shape* (operator set, symbol count, number range) from the tomb's `levelSettings`, fixed tomb-wide. So two rooms on a floor differed only in seeded numbers — with the same reused glyphs and the same shape, they read as identical.

## Change
`buildTombCalculationSettings` now takes an optional room **position** across the tomb's whole tableau sequence and ramps difficulty:
- `position = (floor-1) * roomsPerFloor + room`, `total = levelCount * roomsPerFloor` — keyed by room, so two rooms on one floor still differ.
- first room → one operator + base range; last room → all authored operators + range widened by the base span; linear in between.
- Optional arg: the vestigial inventory previews (no position) stay neutral/full-operator. Play-time only — formula is generated live, so **no world regen, no reachability impact**.

Also: starter tomb number range `1–5` → `1–6`.

## Escalation curve
```
starter (4×2, ops [+]):        f1r1 [1,6] → f1r2 [1,7] → … → last [1,11]
expert  (4×4, ops [+,-,*]):    f1r1 [+][1,10] → f2r1 [+,-][1,12] → last [+,-,*][1,19]
```

## Verification
840 tests pass (incl. new escalation spec); `yarn check-types`, `yarn lint` clean; `generatedWorld.ts` unchanged (play-time only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)