### PR TITLE
fix: entrance staircase shown completed + floor-switch walk animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- The entrance staircase on a tomb/pyramid floor no longer shows a "completed" checkmark and dimming — a staircase is a passage, not a puzzle to finish.
+- Switching floors now places you at the new floor's entrance instantly, instead of showing your marker gliding across the map to the staircase from your position on the previous floor.
 
 ## 0.29.3 - 2026-07-18
 ### Changed

--- a/src/app/SiteMap/SiteMapScreen.tsx
+++ b/src/app/SiteMap/SiteMapScreen.tsx
@@ -341,6 +341,7 @@ export const SiteMapScreen = ({ journeyId, siteConfig, seed, onSiteComplete, onC
           grid={grid}
           onCellClick={handleCellClick}
           explorerPos={explorerPos}
+          currentFloor={currentFloor}
           pendingCells={pendingConsumableCells}
           ownedKeys={ownedKeys}
           className="h-full w-full"

--- a/src/app/SiteMap/SiteMapView.spec.tsx
+++ b/src/app/SiteMap/SiteMapView.spec.tsx
@@ -52,6 +52,16 @@ const straightCorridor = (state: CellState, dirs: Direction[]): GridCell => ({
   state,
 })
 
+// A portal room. With a stairId it renders as a stairhead (a staircase); without, entrance/exit by
+// position.
+const portal = (state: CellState, stairId?: string): GridCell => ({
+  type: "room",
+  roomType: "portal",
+  stairId,
+  dirs: new Set<Direction>(["s"]),
+  state,
+})
+
 const makeGrid = (cells: GridCell[][]): FloorGrid => ({
   cells,
   rows: cells.length,
@@ -245,6 +255,41 @@ describe("SiteMapView — diagonal claim stability across a hidden-passage revea
       expect(hasWallRect(container, cellCenter(1, 1).cx, cellCenter(1, 1).cy, "n")).toBe(true)
       expect(hasWallRect(container, cellCenter(1, 1).cx, cellCenter(1, 1).cy, "w")).toBe(false)
     }
+  })
+})
+
+describe("SiteMapView — portals never render as completed", () => {
+  // A staircase/entrance/exit is a transition, not a task — the entrance is always marked explored
+  // and used staircases complete, but they must not show the ✓ badge that implies a solved room.
+  it("does not badge a completed stairhead (staircase) with the ✓", () => {
+    // stairhead at (0,1); entrancePos is (0,0), so this is unambiguously a stairhead, not the entrance.
+    const { container } = render(<SiteMapView grid={makeGrid([[room("reachable"), portal("completed", "s:main")]])} />)
+    expect(container.textContent).not.toContain("✓")
+  })
+
+  it("still badges a completed regular room with the ✓ (control)", () => {
+    const { container } = render(<SiteMapView grid={makeGrid([[room("completed"), empty]])} />)
+    expect(container.textContent).toContain("✓")
+  })
+})
+
+describe("SiteMapView — explorer dot snaps on floor switch", () => {
+  Element.prototype.scrollTo = vi.fn()
+
+  const dotAt = (container: HTMLElement) => container.querySelector('circle[fill="#ffd060"]')
+
+  it("places the dot at the new floor's entrance immediately instead of animating a walk", () => {
+    const floor0 = makeGrid([[room("completed"), room("reachable")]])
+    const { container, rerender } = render(<SiteMapView grid={floor0} explorerPos={[0, 1]} currentFloor={0} />)
+
+    // Floor switch: new grid + new currentFloor key → the dot remounts and snaps to (0,0),
+    // rather than gliding from the previous floor's (0,1).
+    const floor1 = makeGrid([[room("reachable"), room("reachable")]])
+    rerender(<SiteMapView grid={floor1} explorerPos={[0, 0]} currentFloor={1} />)
+
+    const { cx, cy } = cellCenter(0, 0)
+    expect(dotAt(container)?.getAttribute("cx")).toBe(String(cx))
+    expect(dotAt(container)?.getAttribute("cy")).toBe(String(cy))
   })
 })
 

--- a/src/app/SiteMap/SiteMapView.tsx
+++ b/src/app/SiteMap/SiteMapView.tsx
@@ -32,6 +32,9 @@ type Props = {
   onCellClick?: (row: number, col: number) => void
   revealAllCells?: boolean
   explorerPos?: readonly [number, number]
+  /** Current floor index. Keys the explorer dot so a floor switch remounts it (instant snap to the
+   * new floor's entrance) instead of animating a walk from the previous floor's coordinates. */
+  currentFloor?: number
   /** "row,col" keys of completed treasure cells with a reward still waiting to be picked up */
   pendingCells?: ReadonlySet<string>
   /** Keys the player already holds — used only to color a gate as locked/unlocked on the map. */
@@ -954,6 +957,7 @@ export const SiteMapView = ({
   onCellClick,
   revealAllCells = false,
   explorerPos,
+  currentFloor,
   pendingCells,
   ownedKeys,
   className,
@@ -1117,6 +1121,10 @@ export const SiteMapView = ({
             // guards against stale coordinates in pendingCells (e.g. left over from before a site
             // was regenerated) painting the badge onto whatever room now occupies that cell.
             const shapeKind = shapeKindFor(grid, r, c, cell.roomType, cell.tags, cell.stairId)
+            // Portals (entrance/stairhead/exit) are transitions, not tasks — they can't be
+            // "completed", so they never get the completed dim or the ✓ badge even though the
+            // entrance is always marked explored (useAssembledFloor) and used staircases complete.
+            const isPortal = shapeKind === "entrance" || shapeKind === "stairhead" || shapeKind === "exit"
             const isPending =
               isCompleted &&
               shapeKind === "treasure" &&
@@ -1140,7 +1148,7 @@ export const SiteMapView = ({
                 style={{ cursor: clickable ? "pointer" : "default" }}
               >
                 <FloorTile state={displayState} open={open} kind="room" />
-                <g opacity={isCompleted && !isPending ? 0.45 : 1}>
+                <g opacity={isCompleted && !isPending && !isPortal ? 0.45 : 1}>
                   <NodeShape
                     type={shapeKind}
                     state={displayState}
@@ -1151,8 +1159,8 @@ export const SiteMapView = ({
                   />
                 </g>
                 {isCompleted &&
+                  !isPortal &&
                   shapeKind !== "fork" &&
-                  shapeKind !== "entrance" &&
                   (isPending ? <PendingLootBadge r={roomR} /> : <CompletedBadge r={roomR} />)}
               </g>
             )
@@ -1160,7 +1168,12 @@ export const SiteMapView = ({
         })}
 
         {explorerPos && (
-          <ExplorerDot grid={grid} pos={explorerPos} onArrive={() => setSettledExplorerPos(explorerPos)} />
+          <ExplorerDot
+            key={currentFloor}
+            grid={grid}
+            pos={explorerPos}
+            onArrive={() => setSettledExplorerPos(explorerPos)}
+          />
         )}
       </svg>
     </div>


### PR DESCRIPTION
Two SiteMap display bugs reported from mobile playtest.

## 1. Entrance staircase renders as completed
Portals (entrance/stairhead/exit) are transitions, not tasks. The completed treatment — 45% dim + ✓ badge — only excluded the `entrance` shape, but the entrance on deeper floors is a **stairhead** (it has a stairId), and `useAssembledFloor` force-marks the entrance cell explored → completed. So it showed a ✓ and dimmed. Fix: exclude all portal kinds (`entrance`/`stairhead`/`exit`) from the dim and the badge.

## 2. Player marker walks to the staircase on floor switch
`ExplorerDot` wasn't keyed by floor, so a floor change kept the same component and animated a walk from the previous floor's coordinates to the new entrance. `grid` reference identity can't gate this (it changes on every in-floor room completion too). Fix: pass `currentFloor` and key the dot by it — a floor switch remounts the dot, hitting its existing first-render **snap** (no walk). Within a floor the key is stable, so normal step animation is untouched.

## Tests
- A completed stairhead shows no ✓ (a completed regular room still does — control).
- The dot lands at the new floor's entrance immediately after a floor switch.
- 846 tests pass; `yarn check-types`, `yarn lint` clean. No world/data changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)