### PR TITLE
fix: base "still stuff to find" marker on uncollected rewards

### DIFF
--- a/src/app/SiteMap/SiteMapScreen.tsx
+++ b/src/app/SiteMap/SiteMapScreen.tsx
@@ -109,36 +109,46 @@ export const SiteMapScreen = ({ journeyId, siteConfig, seed, onSiteComplete, onC
   // gate coloring.
   const ownedKeys = useMemo(() => (grid ? new Set([...getOwnedKeys(grid), ...wardKeys]) : wardKeys), [grid, wardKeys])
 
-  // Per-floor exploration summary for the Travel "unexplored here" marker — computed here (grid
-  // assembled = cheap) and persisted so the travel screen reads it without re-assembling. `openable`
-  // = a reachable, not-completed cell the player can walk to now (skipped side path / partial section
-  // / a ward door whose key is held); a locked door the player can't pass yet is excluded (its cells
-  // stay fogged, and its own gate room is soft-reachable but filtered out by the held-key check).
-  // `wardKeys` = tomb-key doors not yet opened, kept so a later-earned key re-lights this pyramid.
+  // Per-floor "still stuff to find here" summary for the Travel marker — computed here (grid
+  // assembled = cheap) and persisted so the travel screen reads it without re-assembling. The
+  // signal is an UNCOLLECTED REWARD, not walk-state: a chest revealed on the map but never opened
+  // still counts (a skipped side path's chest sits deep in its section — often still fogged — so a
+  // reachability/visible test would miss it). "Collected" = the cell is `completed` (the player
+  // stood on it and its reward flow ran). Grouped by section so a reward behind a tomb-key door
+  // feeds `wardKeys` (re-checked against held keys on Travel — the earned-later case) instead of
+  // `hasReward` (ungated loot you can just go get). Hidden-corridor loot is excluded — it has its
+  // own 👁 marker.
   const floorExploration = useMemo(() => {
     if (!grid) return null
-    let openable = false
-    const doors = new Set<string>()
+    const sections = new Map<string, { wardKey?: string; uncollected: boolean }>()
     for (const row of grid.cells) {
       for (const cell of row) {
-        if (cell.type === "empty" || cell.hidden) continue
-        const reachableNow = cell.state === "reachable" || cell.state === "visible"
-        const gateKey = cell.type === "room" ? cell.requiredKeyId : undefined
-        if (reachableNow && (!gateKey || ownedKeys.has(gateKey))) openable = true
-        if (cell.type === "room" && cell.gateVariant === "tomb-key" && cell.state !== "completed" && cell.requiredKeyId)
-          doors.add(cell.requiredKeyId)
+        if (cell.type === "empty" || cell.hidden || cell.type !== "room") continue
+        const h = cell.sectionHash ?? ""
+        const s = sections.get(h) ?? { uncollected: false }
+        if (cell.gateVariant === "tomb-key" && cell.requiredKeyId) s.wardKey = cell.requiredKeyId
+        const hasLoot = cell.reward !== undefined || (cell.stock?.some(Boolean) ?? false)
+        if (hasLoot && cell.state !== "completed") s.uncollected = true
+        sections.set(h, s)
       }
     }
-    return { openable, wardKeys: [...doors].sort() }
-  }, [grid, ownedKeys])
+    let hasReward = false
+    const doors = new Set<string>()
+    for (const s of sections.values()) {
+      if (!s.uncollected) continue
+      if (s.wardKey) doors.add(s.wardKey)
+      else hasReward = true
+    }
+    return { hasReward, wardKeys: [...doors].sort() }
+  }, [grid])
   // Key the effect on the stable summary string, not `journeys` (a fresh object each render) — the
   // reducer's no-op guard then prevents a write loop, same pattern as registerHiddenCorridors above.
   const floorExplorationKey = floorExploration
-    ? `${floorExploration.openable}|${floorExploration.wardKeys.join(",")}`
+    ? `${floorExploration.hasReward}|${floorExploration.wardKeys.join(",")}`
     : ""
   useEffect(() => {
     if (floorExploration)
-      journeys.registerFloorExploration(currentFloor, floorExploration.openable, floorExploration.wardKeys)
+      journeys.registerFloorExploration(currentFloor, floorExploration.hasReward, floorExploration.wardKeys)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [floorExplorationKey, currentFloor, journeyId])
 

--- a/src/app/state/useJourneys.spec.ts
+++ b/src/app/state/useJourneys.spec.ts
@@ -299,7 +299,7 @@ describe("hidden corridor tracking", () => {
   })
 })
 
-// ── floor exploration: "unexplored here" travel marker ──────────────────────────
+// ── floor exploration: "still stuff to find here" travel marker ─────────────────
 
 describe("floor exploration tracking", () => {
   const run = (steps: (api: ReturnType<typeof makeApi>) => void, initial: Partial<StoredJourneyStateV3> = {}) => {
@@ -318,7 +318,7 @@ describe("floor exploration tracking", () => {
   }
   const NO_KEYS: ReadonlySet<string> = new Set()
 
-  it("openable floor marks its levelNr regardless of held keys", () => {
+  it("a floor with uncollected loot marks its levelNr regardless of held keys", () => {
     const { api } = run(a => a.registerFloorExploration(0, true, []))
     expect([...api.getUnexploredLevels(REAL_ID, NO_KEYS)]).toEqual([1])
   })
@@ -329,9 +329,9 @@ describe("floor exploration tracking", () => {
     expect([...api.getUnexploredLevels(REAL_ID, new Set(["junior_a_1"]))]).toEqual([1]) // key earned → lit
   })
 
-  it("re-registering a floor overwrites its summary (walked → cleared)", () => {
+  it("re-registering a floor overwrites its summary (loot collected → cleared)", () => {
     const { api } = run(a => a.registerFloorExploration(0, false, []), {
-      floorExploration: { "1:0": { openable: true, wardKeys: [] } },
+      floorExploration: { "1:0": { hasReward: true, wardKeys: [] } },
     })
     expect(api.getUnexploredLevels(REAL_ID, NO_KEYS).size).toBe(0)
   })

--- a/src/app/state/useJourneys.ts
+++ b/src/app/state/useJourneys.ts
@@ -26,14 +26,14 @@ export type StoredJourneyStateV3 = {
   // them at. Outstanding (known \ found) drives the L3 pyramid + L4 travel "unexplored corridor" markers.
   knownHiddenCorridors?: string[]
   foundHiddenCorridors?: string[]
-  // Per-floor exploration summary, keyed `${levelNr}:${floorIndex}`, recomputed each time a floor
-  // is viewed (the grid is assembled there, so it's cheap — the travel screen has only configs and
-  // must not re-assemble). `openable` = a reachable, not-yet-completed node exists on the floor (a
-  // skipped side path, a partly-explored section, a chest/puzzle/corridor you can walk to now).
-  // `wardKeys` = tomb-key doors on the floor not yet opened; stored so the travel screen can re-check
-  // them against the CURRENTLY-held keys — a newly-earned ward key lights up a pyramid the player
-  // already left, with no re-assembly. Drives the Travel "unexplored here" marker.
-  floorExploration?: Record<string, { openable: boolean; wardKeys: string[] }>
+  // Per-floor "still stuff to find here" summary, keyed `${levelNr}:${floorIndex}`, recomputed each
+  // time a floor is viewed (the grid is assembled there, so it's cheap — the travel screen has only
+  // configs and must not re-assemble). `hasReward` = an uncollected reward sits in an ungated part
+  // of the floor (a chest/loot/puzzle the player skipped — revealed-but-unopened still counts).
+  // `wardKeys` = tomb-key doors with uncollected loot behind them; stored so the travel screen can
+  // re-check them against the CURRENTLY-held keys — a newly-earned ward key lights up a pyramid the
+  // player already left, with no re-assembly. Drives the Travel "still stuff to find" marker.
+  floorExploration?: Record<string, { hasReward: boolean; wardKeys: string[] }>
 }
 
 export type CombinedJourneyState = StoredJourneyStateV3 & {
@@ -67,9 +67,9 @@ export type JourneyAPI = {
   markCorridorFound: (sectionHash: string) => void
   getFoundHiddenCorridors: (journeyId: string) => ReadonlySet<string>
   getOutstandingHiddenCorridorCount: (journeyId: string) => number
-  registerFloorExploration: (floorIndex: number, openable: boolean, wardKeys: string[]) => void
-  // 1-based levelNrs of this journey's pyramids that still hold reachable, unexplored content given
-  // the passed held keys (a skipped node, or a ward door a now-held key opens). Empty set = nothing
+  registerFloorExploration: (floorIndex: number, hasReward: boolean, wardKeys: string[]) => void
+  // 1-based levelNrs of this journey's pyramids that still hold uncollected loot given the passed
+  // held keys (a skipped chest, or one behind a ward door a now-held key opens). Empty set = nothing
   // to go back for. Read cheaply on the travel screen from the persisted floorExploration summary.
   getUnexploredLevels: (journeyId: string, heldKeys: ReadonlySet<string>) => ReadonlySet<number>
 }
@@ -366,7 +366,7 @@ export const createJourneysV3Api = ({
     return (j.knownHiddenCorridors ?? []).filter(key => !found.has(key)).length
   }
 
-  const registerFloorExploration = (floorIndex: number, openable: boolean, wardKeys: string[]) => {
+  const registerFloorExploration = (floorIndex: number, hasReward: boolean, wardKeys: string[]) => {
     if (!activeJourneyId) return
     setJourneys(prev =>
       prev.map(j => {
@@ -375,8 +375,9 @@ export const createJourneysV3Api = ({
         const sorted = [...wardKeys].sort()
         const prevEntry = j.floorExploration?.[key]
         // No churn: identical summary lets React bail (the effect that calls this fires every render).
-        if (prevEntry && prevEntry.openable === openable && prevEntry.wardKeys.join(",") === sorted.join(",")) return j
-        return { ...j, floorExploration: { ...j.floorExploration, [key]: { openable, wardKeys: sorted } } }
+        if (prevEntry && prevEntry.hasReward === hasReward && prevEntry.wardKeys.join(",") === sorted.join(","))
+          return j
+        return { ...j, floorExploration: { ...j.floorExploration, [key]: { hasReward, wardKeys: sorted } } }
       })
     )
   }
@@ -386,7 +387,7 @@ export const createJourneysV3Api = ({
     const levels = new Set<number>()
     if (!j?.floorExploration) return levels
     for (const [key, entry] of Object.entries(j.floorExploration)) {
-      if (!entry.openable && !entry.wardKeys.some(k => heldKeys.has(k))) continue
+      if (!entry.hasReward && !entry.wardKeys.some(k => heldKeys.has(k))) continue
       levels.add(Number(key.split(":")[0]))
     }
     return levels

--- a/src/ui/organisms/JourneyCard.tsx
+++ b/src/ui/organisms/JourneyCard.tsx
@@ -126,7 +126,7 @@ export const JourneyCard: FC<PropsWithChildren<JourneyCardProps>> = ({
           {(completionCount > 0 || hasMapPiece || hasUnexploredCorridors || hasReachableUnexplored) && (
             <span className="ml-auto inline-flex items-center font-bold text-amber-800">
               {hasReachableUnexplored && (
-                <span className="mr-1 inline-flex items-center" title="Unexplored paths you can now reach">
+                <span className="mr-1 inline-flex items-center" title="Still treasure to find here">
                   🔑
                 </span>
               )}


### PR DESCRIPTION
Follow-up to #135 (playtest fix). The "still stuff to find here" journey marker was keying on the wrong signal.

## Problem
Completed a journey, skipped all its side paths, never opened the end chests — no marker appeared. The old signal keyed on cell **walk-state** (`visible`/`reachable`/not-`completed`), but a skipped side-path chest sits **deep** in its section and stays `fogged`, so it was never seen. Meanwhile a merely-revealed corridor read as "explored."

## Fix
Redefine the signal as an **uncollected reward**: a room cell with a `reward` or shop `stock` whose cell isn't `completed` (the player never stood on it and ran its reward flow). Fog-independent, so a revealed-but-unopened chest counts.

Cells are grouped by section so loot behind a tomb-key door feeds `wardKeys` (re-checked against currently-held keys on the Travel screen — the key-earned-later case) rather than the ungated `hasReward` signal. A ward chest you can't reach yet no longer shows a false "go here."

Renamed the stored field `openable` → `hasReward` to match the new meaning (optional field, no migration).

## Testing
- tsc clean; app/state + SiteMap + ui suites green.
- The 3 marker tests retitled/updated to the loot meaning.
- Author to re-playtest: complete a journey skipping side chests → 🔑 badge + emerald map dot; fully clear one → marker clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)