### PR TITLE
fix: marker never appeared — load-timing fix lost before merge, re-applied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- The "still something here" marker now actually appears. A pyramid's exploration wasn't being recorded on entry (the recording ran before the journey had finished loading and never retried), so a completed expedition's tile stayed blank even when it clearly still held loot. It now records reliably and the 🔑 shows on the tile; the pyramid's node on the map also pulses as soon as you finish it.
 
 ## 0.30.2 - 2026-07-19
 ### Fixed

--- a/src/app/SiteMap/SiteMapScreen.tsx
+++ b/src/app/SiteMap/SiteMapScreen.tsx
@@ -117,6 +117,11 @@ export const SiteMapScreen = ({ journeyId, siteConfig, seed, onSiteComplete, onC
   const floorExploration = useMemo(() => (grid ? computeFloorExploration(grid) : null), [grid])
   // Key the effect on the stable summary string, not `journeys` (a fresh object each render) — the
   // reducer's no-op guard then prevents a write loop, same pattern as registerHiddenCorridors above.
+  // `activeJourneyId` MUST be a dep: the journeys store loads async, so on the interior's first mount
+  // it can still be undefined — registerFloorExploration bails, and without this dep the effect would
+  // never re-fire once the journey resolves, so the floor would never get recorded (the marker then
+  // never shows). Verified live: without it, registerFloorExploration only ever runs with
+  // activeJourneyId undefined and floorExploration stays empty.
   const floorExplorationKey = floorExploration
     ? `${floorExploration.open}|${floorExploration.keySets.map(k => k.join(",")).join(";")}`
     : ""
@@ -124,7 +129,7 @@ export const SiteMapScreen = ({ journeyId, siteConfig, seed, onSiteComplete, onC
     if (floorExploration)
       journeys.registerFloorExploration(currentFloor, floorExploration.open, floorExploration.keySets)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [floorExplorationKey, currentFloor, journeyId])
+  }, [floorExplorationKey, currentFloor, journeyId, journeys.activeJourneyId])
 
   const pendingConsumableCells = useMemo(() => {
     const prefix = `${currentFloor}:`

--- a/src/app/pages/Travel.tsx
+++ b/src/app/pages/Travel.tsx
@@ -134,10 +134,13 @@ export const TravelPage: FC<{
       })
   }, [journeys, isTombDiscovered, mapPieceCount])
 
-  // Pyramids of the currently-shown (completed) journey that still hold reachable, unexplored
-  // content — marks those nodes on the map so a player with a fresh ward key knows where to go back.
-  const mapUnexploredNodes =
-    journey && revisiting ? getUnexploredLevels(journey.id, heldKeys) : (new Set<number>() as ReadonlySet<number>)
+  // Pyramids of the currently-shown journey that still hold unvisited content. Not gated on
+  // `revisiting`: a pyramid you finished mid-journey is a completed node too, so its dot shows as
+  // soon as you move past it. JourneyPathView only draws the dot on completed nodes, so the pyramid
+  // you're currently in never lights.
+  const mapUnexploredNodes = journey
+    ? getUnexploredLevels(journey.id, heldKeys)
+    : (new Set<number>() as ReadonlySet<number>)
 
   const scrollContainerRef = useRef<HTMLDivElement>(null)
 

--- a/src/ui/atoms/JourneyPathView.spec.tsx
+++ b/src/ui/atoms/JourneyPathView.spec.tsx
@@ -1,0 +1,39 @@
+import { render } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+import { JourneyPathView } from "./JourneyPathView"
+
+const EMERALD = "rgb(16,185,129)"
+
+const renderView = (unexploredNodes?: ReadonlySet<number>) =>
+  render(
+    <JourneyPathView
+      onClick={() => {}}
+      label="go"
+      inJourney
+      levelCount={3}
+      levelNr={2} // currentIdx = 1 → node index 0 completed, node 1 current, node 2 future
+      journeyLength="long"
+      type="pyramid"
+      unexploredNodes={unexploredNodes}
+    />
+  )
+
+const emeraldPulses = (container: HTMLElement) =>
+  [...container.querySelectorAll("circle")].filter(c => c.getAttribute("stroke") === EMERALD)
+
+describe("JourneyPathView unexplored-node marker", () => {
+  it("pulses a completed node that has unvisited content", () => {
+    const { container } = renderView(new Set([1])) // node 1 (1-based) = index 0 = completed
+    expect(emeraldPulses(container)).toHaveLength(1)
+  })
+
+  it("does not pulse the current node, even if it's in the set", () => {
+    const { container } = renderView(new Set([2])) // node 2 = index 1 = the current node
+    expect(emeraldPulses(container)).toHaveLength(0)
+  })
+
+  it("does not pulse when there is nothing unexplored", () => {
+    const { container } = renderView(new Set())
+    expect(emeraldPulses(container)).toHaveLength(0)
+  })
+})

--- a/src/ui/atoms/JourneyPathView.tsx
+++ b/src/ui/atoms/JourneyPathView.tsx
@@ -132,16 +132,6 @@ export const JourneyPathView: FC<Props> = ({
         </span>
       )}
 
-      {/* Unexplored-content marker: a completed journey still holds reachable content (a skipped path
-          or a ward door a now-held key opens). Same glowing-dot style as the nudge, emerald to set it
-          apart. Shown when revisiting (nudge is for the not-yet-started overview), so they never overlap. */}
-      {unexploredNodes && unexploredNodes.size > 0 && (
-        <span className="absolute top-3 left-3 flex h-4 w-4 items-center justify-center">
-          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-500 opacity-75" />
-          <span className="relative inline-flex h-3 w-3 rounded-full bg-emerald-500" />
-        </span>
-      )}
-
       {/* Grid lines */}
       <div className="absolute inset-0 opacity-20">
         {isPyramid ? (
@@ -224,6 +214,20 @@ export const JourneyPathView: FC<Props> = ({
                     strokeWidth="0.8"
                     className="pointer-events-none"
                   />
+                  {/* Emerald pulse: this completed pyramid still holds unvisited content (a skipped
+                      chest/puzzle, or a ward path/tableau a key you now hold unlocks). Only completed
+                      nodes light — the pyramid you're currently in never does. */}
+                  {unexploredNodes?.has(i + 1) && (
+                    <circle
+                      cx={pos.x}
+                      cy={pos.y}
+                      r="5.5"
+                      fill="none"
+                      stroke="rgb(16,185,129)"
+                      strokeWidth="1"
+                      className="pointer-events-none animate-ping"
+                    />
+                  )}
                 </g>
               )
             }


### PR DESCRIPTION
## Why the marker never showed (root cause, confirmed)
The load-timing fix I made while debugging **never reached `main`** — it was lost in a branch shuffle. So the deployed build (v0.30.2) still has the original bug:

`SiteMapScreen`'s recording effect reads `activeJourneyId`, but the journeys store loads **async**. On the interior's first mount it's `undefined`, so `registerFloorExploration` bails — and the effect's deps didn't include `activeJourneyId`, so it **never re-fired** once the journey resolved. `floorExploration` stayed empty → `getUnexploredLevels` returned nothing → the completed-journey tile never showed `🔑`.

I verified on `origin/main` that `SiteMapScreen.tsx` deps were `[floorExplorationKey, currentFloor, journeyId]` — no `activeJourneyId`. That's why every "it's fixed" was wrong: my dev tests ran on a branch that *had* the fix, but it wasn't in what shipped.

## Re-applied (checked against main this time)
- **`SiteMapScreen`**: add `journeys.activeJourneyId` to the recording effect deps → recording runs the moment the active journey is known. (Verified live earlier: without it, `registerFloorExploration` only ever ran with `activeJourneyId` undefined and `floorExploration` stayed empty; with it, it persists and the tile shows `🔑`.)
- **`Travel`**: light map nodes for any shown journey (drop the `revisiting` gate) so a pyramid finished mid-journey pulses once you move past it.
- **`JourneyPathView`**: emerald pulse **per completed node** (was a whole-card corner dot); only completed nodes light — the current pyramid never does. Re-adds its render test.

## Testing
- tsc clean; 26 tests green (`useJourneys`, `floorExploration`, `JourneyPathView`).
- `release --dry-run` → fixed=1.
- **Post-merge I'll re-check `main` directly** to confirm the deps landed — that's the step I skipped last time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)