### PR TITLE
fix: render-loop freeze at exit chamber — record exploration on leave, not reactively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Fixed a freeze/flicker that could make a pyramid impossible to finish: as the chamber with the exit was revealed, the screen flickered and the marker refused to move. Tracking "still something here" was running on every map change and feeding a render loop. It's now recorded once, when you leave the floor — no more loop.
 
 ## 0.30.3 - 2026-07-19
 ### Fixed

--- a/src/app/SiteMap/SiteMapScreen.tsx
+++ b/src/app/SiteMap/SiteMapScreen.tsx
@@ -1,4 +1,4 @@
-import { use, useCallback, useEffect, useMemo, useState } from "react"
+import { use, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { findPath, getCell, getOwnedKeys } from "@/game/gridNavigation"
 import { getFamilyPlugin, resolveEncounter, type FamilyContext } from "@/app/families/familyRegistry"
@@ -110,26 +110,31 @@ export const SiteMapScreen = ({ journeyId, siteConfig, seed, onSiteComplete, onC
   // gate coloring.
   const ownedKeys = useMemo(() => (grid ? new Set([...getOwnedKeys(grid), ...wardKeys]) : wardKeys), [grid, wardKeys])
 
-  // Per-floor "still stuff to find here" summary for the Travel marker — computed here (grid
-  // assembled = cheap) and persisted so the travel screen reads it without re-assembling. The pure
-  // classification (loot nodes / key-gated nodes / fogged corridors, keys-and-gates only, no mod
-  // names) lives in floorExploration.ts and is unit-tested there.
+  // Per-floor "still stuff to find here" summary for the Travel marker. The pure classification
+  // (loot nodes / key-gated nodes / fogged corridors, keys-and-gates only, no mod names) lives in
+  // floorExploration.ts and is unit-tested there.
+  //
+  // Persist it when the player LEAVES the floor (switches floor or exits the interior), read from a
+  // ref in the cleanup — NOT reactively on every grid change. A reactive write fed a render loop:
+  // writing re-rendered SiteMapScreen → the grid recomputed (getExploredSections returns a fresh
+  // object each render, so useAssembledFloor rebuilds) → the effect could re-fire while the exit
+  // chamber was mid-reveal, pegging the CPU (flicker, input starvation). Recording on-leave captures
+  // the floor's final state (exactly what "still stuff to find" means) and can never re-enter render.
   const floorExploration = useMemo(() => (grid ? computeFloorExploration(grid) : null), [grid])
-  // Key the effect on the stable summary string, not `journeys` (a fresh object each render) — the
-  // reducer's no-op guard then prevents a write loop, same pattern as registerHiddenCorridors above.
-  // `activeJourneyId` MUST be a dep: the journeys store loads async, so on the interior's first mount
-  // it can still be undefined — registerFloorExploration bails, and without this dep the effect would
-  // never re-fire once the journey resolves, so the floor would never get recorded (the marker then
-  // never shows). Verified live: without it, registerFloorExploration only ever runs with
-  // activeJourneyId undefined and floorExploration stays empty.
-  const floorExplorationKey = floorExploration
-    ? `${floorExploration.open}|${floorExploration.keySets.map(k => k.join(",")).join(";")}`
-    : ""
+  const floorExplorationRef = useRef(floorExploration)
+  floorExplorationRef.current = floorExploration
+  // Latest register fn (journeyId passed explicitly, so it records even after the journey goes
+  // inactive on completion — the interior unmounts right after completeJourney).
+  const recordExploration = useRef<(floor: number, open: boolean, keySets: string[][]) => void>(() => {})
+  recordExploration.current = (floor, open, keySets) =>
+    journeys.registerFloorExploration(journeyId, floor, open, keySets)
   useEffect(() => {
-    if (floorExploration)
-      journeys.registerFloorExploration(currentFloor, floorExploration.open, floorExploration.keySets)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [floorExplorationKey, currentFloor, journeyId, journeys.activeJourneyId])
+    const floor = currentFloor
+    return () => {
+      const fe = floorExplorationRef.current
+      if (fe) recordExploration.current(floor, fe.open, fe.keySets)
+    }
+  }, [currentFloor, journeyId])
 
   const pendingConsumableCells = useMemo(() => {
     const prefix = `${currentFloor}:`

--- a/src/app/state/useJourneys.spec.ts
+++ b/src/app/state/useJourneys.spec.ts
@@ -319,20 +319,28 @@ describe("floor exploration tracking", () => {
   const NO_KEYS: ReadonlySet<string> = new Set()
 
   it("open (ungated) content marks its levelNr regardless of held keys", () => {
-    const { api } = run(a => a.registerFloorExploration(0, true, []))
+    const { api } = run(a => a.registerFloorExploration(REAL_ID, 0, true, []))
     expect([...api.getUnexploredLevels(REAL_ID, NO_KEYS)]).toEqual([1])
   })
 
   it("a gated key bundle lights up only once every key in it is held (the earned-later case)", () => {
-    const { api } = run(a => a.registerFloorExploration(2, false, [["junior_a_1"]]))
+    const { api } = run(a => a.registerFloorExploration(REAL_ID, 2, false, [["junior_a_1"]]))
     expect(api.getUnexploredLevels(REAL_ID, NO_KEYS).size).toBe(0) // no key yet → nothing to go back for
     expect([...api.getUnexploredLevels(REAL_ID, new Set(["junior_a_1"]))]).toEqual([1]) // key earned → lit
   })
 
   it("a multi-key bundle (ward + hieroglyphs) needs ALL its keys, not just one", () => {
-    const { api } = run(a => a.registerFloorExploration(0, false, [["ward_a_1", "hieroglyph:p10"]]))
+    const { api } = run(a => a.registerFloorExploration(REAL_ID, 0, false, [["ward_a_1", "hieroglyph:p10"]]))
     expect(api.getUnexploredLevels(REAL_ID, new Set(["ward_a_1"])).size).toBe(0) // only one held → not lit
     expect([...api.getUnexploredLevels(REAL_ID, new Set(["ward_a_1", "hieroglyph:p10"]))]).toEqual([1]) // both → lit
+  })
+
+  it("records against the passed journeyId even when the journey is no longer active", () => {
+    // Recording runs from the interior's unmount cleanup — which can happen right after
+    // completeJourney flips `active` to false. Passing journeyId explicitly (not relying on the
+    // active journey) is what lets the completed journey still get its summary.
+    const { api } = run(a => a.registerFloorExploration(REAL_ID, 0, true, []), { active: false, completionCount: 1 })
+    expect([...api.getUnexploredLevels(REAL_ID, NO_KEYS)]).toEqual([1])
   })
 
   it("tolerates a floorExploration entry from an older build shape (no crash)", () => {
@@ -346,7 +354,7 @@ describe("floor exploration tracking", () => {
   })
 
   it("re-registering a floor overwrites its summary (content cleared → cleared)", () => {
-    const { api } = run(a => a.registerFloorExploration(0, false, []), {
+    const { api } = run(a => a.registerFloorExploration(REAL_ID, 0, false, []), {
       floorExploration: { "1:0": { open: true, keySets: [] } },
     })
     expect(api.getUnexploredLevels(REAL_ID, NO_KEYS).size).toBe(0)

--- a/src/app/state/useJourneys.ts
+++ b/src/app/state/useJourneys.ts
@@ -67,7 +67,7 @@ export type JourneyAPI = {
   markCorridorFound: (sectionHash: string) => void
   getFoundHiddenCorridors: (journeyId: string) => ReadonlySet<string>
   getOutstandingHiddenCorridorCount: (journeyId: string) => number
-  registerFloorExploration: (floorIndex: number, open: boolean, keySets: string[][]) => void
+  registerFloorExploration: (journeyId: string, floorIndex: number, open: boolean, keySets: string[][]) => void
   // 1-based levelNrs of this journey's pyramids that still hold unvisited content given the passed
   // held keys — ungated content, or gated content whose full key bundle the player now holds (a ward
   // door's key, a tableau's hieroglyphs, …). Empty set = nothing to go back for. Read cheaply on the
@@ -374,11 +374,10 @@ export const createJourneysV3Api = ({
   const sig = (o: boolean | undefined, ks: string[][] | undefined) =>
     `${o ?? false}|${(ks ?? []).map(k => k.join(",")).join(";")}`
 
-  const registerFloorExploration = (floorIndex: number, open: boolean, keySets: string[][]) => {
-    if (!activeJourneyId) return
+  const registerFloorExploration = (journeyId: string, floorIndex: number, open: boolean, keySets: string[][]) => {
     setJourneys(prev =>
       prev.map(j => {
-        if (j.journeyId !== activeJourneyId) return j
+        if (j.journeyId !== journeyId) return j
         const key = `${j.levelNr}:${floorIndex}`
         const prevEntry = j.floorExploration?.[key]
         // No churn: identical summary lets React bail (the effect that calls this fires every render).


### PR DESCRIPTION
## Symptom
On v0.30.3, as the chamber with the exit was revealed, the map **flickered fast and the marker refused to move** — the pyramid couldn't be finished. Scrolling janked too.

## Cause
v0.30.3 made floor-exploration recording fire **reactively** — a `useEffect` keyed on the floor's exploration summary. But `journeys.getExploredSections()` returns a fresh object every render, so `useAssembledFloor` rebuilds the grid every render. As the exit chamber revealed, the summary write re-rendered `SiteMapScreen`, the grid recomputed, and the effect could re-fire → a `useEffect` render loop. It doesn't throw "Maximum update depth" (the writes are post-commit, not synchronous-in-render), so there's no console error — just a pegged CPU: flicker + input starvation.

This only surfaced now because #140 was the change that made recording actually *fire* (before, it bailed).

## Fix
Record the floor's summary **once, when the player leaves it** (floor switch or interior unmount) — read from a ref in the effect cleanup. That's off the render path, so it can never re-enter rendering. It captures the floor's *final* state, which is exactly what "still stuff to find" means.

`registerFloorExploration` now takes an explicit `journeyId` (instead of relying on the active journey), so it still records when the interior unmounts right after `completeJourney` flips the journey inactive.

## Testing
- tsc clean; 27 tests green, incl. a new case: records against the passed `journeyId` even when the journey is no longer active.
- The reactive write is gone, so the loop is structurally impossible.
- Note: I couldn't reproduce the exact loop headless (my injected pyramid reveals the exit on entry; the loop needs a longer walk), so please confirm on-device that the freeze is gone and the marker records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)