### PR TITLE
feat: pulsing dot marker on card + fix map pulse drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- The "still something here" marker on a completed expedition's tile is now a pulsing green dot instead of a key icon, matching the pulse on the map.
+
+### Fixed
+- The map's "still something here" pulse now pulses in place on its pyramid, instead of drifting toward the corner.
 
 ## 0.30.4 - 2026-07-19
 ### Fixed

--- a/src/ui/atoms/JourneyPathView.tsx
+++ b/src/ui/atoms/JourneyPathView.tsx
@@ -218,15 +218,20 @@ export const JourneyPathView: FC<Props> = ({
                       chest/puzzle, or a ward path/tableau a key you now hold unlocks). Only completed
                       nodes light — the pyramid you're currently in never does. */}
                   {unexploredNodes?.has(i + 1) && (
+                    // SMIL animating r + opacity, not `animate-ping`: a CSS scale() transform on an
+                    // SVG element scales about the SVG origin (0,0), so the ring would drift toward
+                    // the corner instead of pulsing in place. Growing `r` expands from the fixed centre.
                     <circle
                       cx={pos.x}
                       cy={pos.y}
-                      r="5.5"
                       fill="none"
                       stroke="rgb(16,185,129)"
                       strokeWidth="1"
-                      className="pointer-events-none animate-ping"
-                    />
+                      className="pointer-events-none"
+                    >
+                      <animate attributeName="r" values="3.5;7" dur="1.1s" repeatCount="indefinite" />
+                      <animate attributeName="opacity" values="0.8;0" dur="1.1s" repeatCount="indefinite" />
+                    </circle>
                   )}
                 </g>
               )

--- a/src/ui/organisms/JourneyCard.tsx
+++ b/src/ui/organisms/JourneyCard.tsx
@@ -126,8 +126,12 @@ export const JourneyCard: FC<PropsWithChildren<JourneyCardProps>> = ({
           {(completionCount > 0 || hasMapPiece || hasUnexploredCorridors || hasReachableUnexplored) && (
             <span className="ml-auto inline-flex items-center font-bold text-amber-800">
               {hasReachableUnexplored && (
-                <span className="mr-1 inline-flex items-center" title="Still treasure to find here">
-                  🔑
+                <span
+                  className="relative mr-2 inline-flex h-3 w-3 items-center justify-center"
+                  title="Still treasure to find here"
+                >
+                  <span className="absolute inline-flex h-3 w-3 animate-ping rounded-full bg-emerald-500 opacity-75" />
+                  <span className="relative inline-flex h-2 w-2 rounded-full bg-emerald-500" />
                 </span>
               )}
               {hasUnexploredCorridors && (


### PR DESCRIPTION
Two small marker-visual changes.

## Card: 🔑 → pulsing dot
The completed-expedition tile now shows a **pulsing green dot** instead of the 🔑 icon, matching the emerald pulse on the map node. (Verified in-browser: the tile shows the dot next to the ✔.)

## Fix: map pulse drifted instead of pulsing in place
The map's node pulse used `animate-ping` — a CSS `scale()` transform. On an SVG element, `scale()` is about the **SVG origin (0,0)**, not the element's centre, so the ring drifted toward the corner instead of pulsing on its pyramid. Replaced with SMIL animating the circle's `r` + `opacity`, which grows from the node's fixed `cx`/`cy` — pulses in place. (Verified: one emerald circle at the node's fixed centre with `r`/`opacity` animations, no transform.)

## Testing
- tsc + lint clean; `JourneyPathView` render test still green (asserts the emerald pulse on completed nodes, none on the current node).
- Verified both visuals live (dev server + injected completed journey).

🤖 Generated with [Claude Code](https://claude.com/claude-code)