### PR TITLE
Fix journey progress wipe when a storage write races the initial load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Fixed a rare bug where leaving a pyramid or tomb right as it was entered — most likely while backing out of a glitching screen — could wipe every journey's progress back to the start, keeping only your hieroglyphs. Progress is now always saved on top of what's already there, never over it.
+
 ## 0.30.5 - 2026-07-19
 ### Changed
 - The "still something here" marker on a completed expedition's tile is now a pulsing green dot instead of a key icon, matching the pulse on the map.

--- a/src/app/state/useJourneys.spec.ts
+++ b/src/app/state/useJourneys.spec.ts
@@ -359,4 +359,19 @@ describe("floor exploration tracking", () => {
     })
     expect(api.getUnexploredLevels(REAL_ID, NO_KEYS).size).toBe(0)
   })
+
+  it("does not touch storage when the journey isn't loaded yet (guards the progress-wipe race)", () => {
+    // A freshly-mounted useJourneys() instance (e.g. SiteMapScreen entering a site) starts with
+    // `journeys = []` until its own storage read resolves. The interior's floor-leave/unmount
+    // cleanup calls registerFloorExploration regardless — if that write went through against this
+    // placeholder empty state, it would overwrite every other journey's persisted progress with `[]`.
+    let setJourneysCalls = 0
+    const state: StoredJourneyStateV3[] = []
+    const set = () => {
+      setJourneysCalls += 1
+    }
+    const api = createJourneysV3Api({ journeys: state, setJourneys: set, journeyData: [makeJourneyData(REAL_ID)] })
+    api.registerFloorExploration(REAL_ID, 0, true, [])
+    expect(setJourneysCalls).toBe(0)
+  })
 })

--- a/src/app/state/useJourneys.ts
+++ b/src/app/state/useJourneys.ts
@@ -375,6 +375,11 @@ export const createJourneysV3Api = ({
     `${o ?? false}|${(ks ?? []).map(k => k.join(",")).join(";")}`
 
   const registerFloorExploration = (journeyId: string, floorIndex: number, open: boolean, keySets: string[][]) => {
+    // Bail if the journey isn't in `journeys` yet, same as every other mutator here — most
+    // commonly because this instance's storage load hasn't landed yet (`journeys` still `[]`
+    // on mount). Without this check, a `.map` over that placeholder state silently no-ops the
+    // update but still fires setJourneys, overwriting the real persisted data with `[]`.
+    if (!journeys.some(j => j.journeyId === journeyId)) return
     setJourneys(prev =>
       prev.map(j => {
         if (j.journeyId !== journeyId) return j

--- a/src/support/useOfflineStorage.spec.ts
+++ b/src/support/useOfflineStorage.spec.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest"
+import { renderHook, act } from "@testing-library/react"
+import { useOfflineStorage } from "./useOfflineStorage"
+
+// Regression for the journey-progress wipe bug: a component that mounts a fresh
+// useOfflineStorage instance (e.g. SiteMapScreen re-mounting a useJourneys() call on every
+// pyramid/tomb entry) must not clobber data another instance already persisted, even if it
+// writes before its own initial read of the key has resolved.
+describe("useOfflineStorage — concurrent instances", () => {
+  it("a write from a freshly-mounted instance is applied on top of already-persisted data, not the pre-load default", async () => {
+    const storeName = `race-test-${Math.random()}`
+    const key = "items"
+
+    const owner = renderHook(() => useOfflineStorage<string[]>(key, [], storeName))
+    await act(async () => {
+      await owner.result.current[1](["a", "b", "c"])
+    })
+
+    // Mount a second instance sharing the same persisted key — its local state starts at the
+    // default `[]` and its own load promise hasn't resolved yet at this point.
+    const fresh = renderHook(() => useOfflineStorage<string[]>(key, [], storeName))
+    let writePromise!: Promise<string[]>
+    act(() => {
+      writePromise = fresh.result.current[1](prev => [...prev, "d"])
+    })
+    await act(async () => {
+      await writePromise
+    })
+
+    expect(fresh.result.current[0]).toEqual(["a", "b", "c", "d"])
+
+    // The persisted store itself must reflect the merge, not just this instance's local state.
+    const verify = renderHook(() => useOfflineStorage<string[]>(key, [], storeName))
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(verify.result.current[0]).toEqual(["a", "b", "c", "d"])
+  })
+})

--- a/src/support/useOfflineStorage.ts
+++ b/src/support/useOfflineStorage.ts
@@ -81,12 +81,17 @@ export const useOfflineStorage = <T>(
   // calls chain correctly without waiting for a re-render or async DB read.
   const localStateRef = useRef(localState)
   localStateRef.current = localState
+  // Resolves once this instance's own initial read of `key` has landed (or been seeded).
+  // setValue awaits it first so a write that races the load never computes its next value
+  // from the pre-load default and clobbers whatever another instance already persisted.
+  const loadPromiseRef = useRef<Promise<void> | null>(null)
 
   useEffect(() => {
-    store
+    loadPromiseRef.current = store
       .getItem<T>(key)
       .then(value => {
         if (value !== null) {
+          localStateRef.current = value
           setLocalState(current => {
             if (JSON.stringify(current) === JSON.stringify(value)) {
               return current // No change needed
@@ -95,18 +100,24 @@ export const useOfflineStorage = <T>(
           })
         } else {
           if (initialValue !== null) {
-            store.setItem<T>(key, typeof initialValue === "function" ? (initialValue as () => T)() : initialValue)
+            const resolvedInitial = typeof initialValue === "function" ? (initialValue as () => T)() : initialValue
+            localStateRef.current = resolvedInitial
+            store.setItem<T>(key, resolvedInitial)
           }
         }
       })
       .then(() => {
         setLoaded(true)
       })
-    return store.subscribe<T>(key, setLocalState)
+    return store.subscribe<T>(key, value => {
+      localStateRef.current = value
+      setLocalState(value)
+    })
   }, [initialValue, key, store])
 
   const setValue = useCallback(
     async (value: SetStateAction<T>) => {
+      if (loadPromiseRef.current) await loadPromiseRef.current
       if (isSetFunction(value)) {
         // Compute next value from the ref (always up-to-date) and update the
         // ref synchronously so chained calls each see the previous result.


### PR DESCRIPTION
## Summary

Fixes a reported bug: after finishing the starter and junior journeys, a player found a "missing map piece" marker on junior_3's level 3 (the pyramid uniquely combining a map-piece side branch with a ward gate), revisited it, hit a rendering glitch, and pressing the back button wiped almost all journey progress — only hieroglyphs (stored separately) survived.

**Root cause:** `useJourneys()` is called independently at several component mount points (`App`, `Travel`, `PyramidExpedition`, `SiteMapScreen`), each backed by its own `useOfflineStorage` instance. Every instance starts from the default empty state (`[]` for the `journeys` key) until its own async read from storage resolves. `SiteMapScreen` — the pyramid/tomb interior — mounts a **fresh** instance on every site entry, and its floor-leave/unmount cleanup effect calls `registerFloorExploration(...)` unconditionally on exit (unlike every other mutator in `useJourneys.ts`, it had no guard for "journey record not found/loaded yet"). If that write landed before the fresh instance's own storage read resolved, it computed its next value against the empty placeholder and wrote it back — clobbering every journey's persisted progress in one shot. Normally the read resolves in a few ms, well before a player could react, but a rendering glitch forcing a fast unmount right as the site was entered is exactly the kind of disruption that widens that race window enough for a quick back-button press to lose.

## Changes

- `src/support/useOfflineStorage.ts`: `setValue` now awaits the instance's own initial load before computing/writing its next value, so a write can never be based on the pre-load placeholder state. Closes the race at its source for every current and future call site.
- `src/app/state/useJourneys.ts`: `registerFloorExploration` now bails out when the journey record isn't present yet, matching the guard pattern every other mutator in this file already follows.
- Added regression tests for both: `src/support/useOfflineStorage.spec.ts` (reproduces a second instance's write clobbering already-persisted data before its own load resolves) and a new case in `src/app/state/useJourneys.spec.ts` (`registerFloorExploration` no-ops instead of writing when the journey array is still empty).
- `CHANGELOG.md`: added a `Fixed` entry under `Unreleased`.

## Test plan

- [x] `yarn test` (via `npx vitest run`) — all 861 tests pass, including the two new regression tests
- [x] Confirmed both new tests fail without their respective fix (verified via temporary `git stash` of each fix)
- [x] `yarn check-types` (via `npx tsc -b`) — clean
- [x] `yarn lint` (via `npx eslint`) — clean

Note: the pre-commit hook (`yarn lint-staged`) couldn't run directly in this sandbox because `corepack` was blocked by network policy from fetching yarn 4.17.0; I ran the equivalent `npx lint-staged`, `eslint`, `tsc -b`, and full `vitest` suite manually instead, all clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UXmd8roFQg4TkXbJ5jE2Mn)_