### PR TITLE
Fix HUD swallowing map taps, and unreachable hieroglyph hunt picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Taps near the bottom of a pyramid or tomb map are no longer swallowed. An invisible strip spanning the full width of the screen behind the detector panel and the health/coins row was catching them, so rooms and corridors down there simply wouldn't respond — worst while a detector was switched on, since the panel grows taller as it lists results.
+- You can now actually pick a hieroglyph to hunt with the compass. The Collection screen only let you tap hieroglyphs you'd already completed, while the "hunt this one" button only ever appeared for ones you hadn't — so the compass could never be given a target despite the screen telling you to choose one. Partially-collected hieroglyphs (the ones showing e.g. 2/3) are now tappable, which is what the hint always meant.
 
 ## 0.30.9 - 2026-07-31
 ### Changed

--- a/src/app/SiteMap/SiteMapScreen.tsx
+++ b/src/app/SiteMap/SiteMapScreen.tsx
@@ -389,7 +389,9 @@ export const SiteMapScreen = ({ journeyId, siteConfig, seed, onSiteComplete, onC
             pyramidHiddenCorridorCount={pyramidHiddenCorridorCount}
           />
         )}
-        <div className="flex items-center gap-4">
+        {/* pointer-events-auto: opts this row back into hit-testing inside SiteHudBar's
+            non-hit-testing band (the widgets and dev buttons below are clickable). */}
+        <div className="pointer-events-auto flex items-center gap-4">
           {/* Mod-contributed HUD widgets (trap's health + consumables, shop's balance) — core names none. */}
           {hudWidgets().map(({ id, Component }) => (
             <Component key={id} />

--- a/src/mods/hieroglyph/app/HieroglyphCollectionSection.huntbar.spec.tsx
+++ b/src/mods/hieroglyph/app/HieroglyphCollectionSection.huntbar.spec.tsx
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, afterEach } from "vitest"
 import { render, screen, fireEvent, cleanup } from "@testing-library/react"
+import { type FC, useState } from "react"
 import { allItems } from "@/data/inventory"
+import type { CollectionSectionProps } from "@/app/pages/collectionSectionRegistry"
 
 afterEach(cleanup)
 
@@ -12,13 +14,15 @@ vi.mock("react-i18next", () => ({
 const setCompassTarget = vi.fn()
 let compassLevel = 0
 let compassTarget: string | null = null
+let found = 0
+let fragments: Record<string, number> = {}
 vi.mock("./useHieroglyphProgress", () => ({
   useHieroglyphProgress: () => ({
     compassLevel,
     compassTarget,
     setCompassTarget,
-    hieroglyphProgress: () => ({ found: 0, required: 3 }),
-    hieroglyphFragments: {},
+    hieroglyphProgress: () => ({ found, required: 3 }),
+    hieroglyphFragments: fragments,
   }),
 }))
 vi.mock("@/app/Inventory/useInventory", () => ({
@@ -44,6 +48,37 @@ describe("hieroglyph hunt bar (compass target picker)", () => {
     compassTarget = null
     setCompassTarget.mockClear()
     render(<HieroglyphCollectionSection selectedItem={selected} onSelect={() => {}} />)
+    const hunt = screen.getByText("detector.huntAction")
+    fireEvent.click(hunt)
+    expect(setCompassTarget).toHaveBeenCalledWith(hieroglyph.id)
+  })
+})
+
+// The cases above inject `selectedItem` as a prop, which proves HuntBar works in isolation but
+// bypasses the grid entirely — so they stayed green while the only click path into that prop was
+// dead (CollectibleSlot forwarded onClick for collected slots only, and HuntBar only offers
+// UNcollected ones). This drives the real path: tap a partial tile in the grid, and the hunt
+// affordance must appear. Mirrors Collection.tsx, which owns selectedItem as state and feeds it back.
+const CollectionHarness: FC = () => {
+  const [selectedItem, setSelectedItem] = useState<CollectionSectionProps["selectedItem"]>(null)
+  return <HieroglyphCollectionSection selectedItem={selectedItem} onSelect={setSelectedItem} />
+}
+
+describe("picking a hunt target from the Collection grid", () => {
+  it("offers to hunt a partially-collected hieroglyph after tapping its tile", () => {
+    compassLevel = 1
+    compassTarget = null
+    found = 2 // 2/3 — partially collected, so the tile renders in the "partial" state
+    fragments = { [hieroglyph.id]: 2 }
+    setCompassTarget.mockClear()
+
+    render(<CollectionHarness />)
+    // Nothing selected yet, so only the "pick a target" hint shows.
+    expect(screen.queryByText("detector.huntAction")).toBeNull()
+    expect(screen.getByText("detector.huntHint")).toBeTruthy()
+
+    fireEvent.click(screen.getByText(hieroglyph.symbol))
+
     const hunt = screen.getByText("detector.huntAction")
     fireEvent.click(hunt)
     expect(setCompassTarget).toHaveBeenCalledWith(hieroglyph.id)

--- a/src/ui/atoms/DetectorPanel.tsx
+++ b/src/ui/atoms/DetectorPanel.tsx
@@ -83,7 +83,10 @@ export const DetectorPanel: FC<Props> = ({
   const shownConsumables = uniqueBy(consumableResults, r => consumableKey(r, consumableDetectorLevel))
 
   return (
-    <div className="rounded-lg border border-stone-700 bg-stone-900/90 p-2 text-xs text-stone-300">
+    // `pointer-events-auto` re-enables hit-testing inside SiteHudBar's non-hit-testing band: needed
+    // for the mode toggles below, and it keeps taps on this opaque card from falling through to the
+    // map behind it.
+    <div className="pointer-events-auto rounded-lg border border-stone-700 bg-stone-900/90 p-2 text-xs text-stone-300">
       <div className="mb-2 flex gap-2">
         {compassLevel > 0 && (
           <button

--- a/src/ui/atoms/SiteHudBar.tsx
+++ b/src/ui/atoms/SiteHudBar.tsx
@@ -1,7 +1,12 @@
 import type { FC, PropsWithChildren } from "react"
 
+// Full-bleed (left-0 right-0) so its children stay centred over the map — which means the bar's own
+// box is a transparent band spanning the whole screen width. It must not hit-test, or it swallows
+// every map tap in that band (the band grows taller when a detector mode adds result rows). Each
+// real child opts back in with `pointer-events-auto`; they're all content-sized, so nothing dead is
+// reintroduced.
 export const SiteHudBar: FC<PropsWithChildren> = ({ children }) => (
-  <div className="absolute right-0 bottom-safe-bottom left-0 z-10 mb-4 flex flex-col items-center justify-center gap-2">
+  <div className="pointer-events-none absolute right-0 bottom-safe-bottom left-0 z-10 mb-4 flex flex-col items-center justify-center gap-2">
     {children}
   </div>
 )

--- a/src/ui/molecules/CollectibleSlot.spec.tsx
+++ b/src/ui/molecules/CollectibleSlot.spec.tsx
@@ -1,8 +1,44 @@
-import { describe, it, expect, afterEach } from "vitest"
-import { render, screen, cleanup } from "@testing-library/react"
+import { describe, it, expect, vi, afterEach } from "vitest"
+import { render, screen, fireEvent, cleanup } from "@testing-library/react"
 import { CollectibleSlot } from "./CollectibleSlot"
 
 afterEach(cleanup)
+
+// Which states accept a click. A partial slot MUST, or the Collection screen can't act as the
+// compass's target picker: HuntBar only offers an uncollected hieroglyph, so if only collected
+// slots were clickable the hunt button would be unreachable (clickable ⟹ collected ⟹ not huntable).
+// An empty slot deliberately stays inert — nothing to reveal, and nothing to hunt for a symbol you
+// haven't turned up a single piece of.
+describe("CollectibleSlot click targets", () => {
+  it("forwards a click on a partial slot (so it can be picked as a hunt target)", () => {
+    const onClick = vi.fn()
+    render(
+      <CollectibleSlot
+        state="partial"
+        symbol="𓂀"
+        difficulty="junior"
+        progress={{ found: 2, required: 5 }}
+        onClick={onClick}
+      />
+    )
+    fireEvent.click(screen.getByText("𓂀"))
+    expect(onClick).toHaveBeenCalledOnce()
+  })
+
+  it("forwards a click on a collected slot", () => {
+    const onClick = vi.fn()
+    render(<CollectibleSlot state="collected" symbol="𓂀" difficulty="junior" onClick={onClick} />)
+    fireEvent.click(screen.getByText("𓂀"))
+    expect(onClick).toHaveBeenCalledOnce()
+  })
+
+  it("ignores a click on an empty slot", () => {
+    const onClick = vi.fn()
+    render(<CollectibleSlot state="empty" onClick={onClick} />)
+    fireEvent.click(screen.getByText("?"))
+    expect(onClick).not.toHaveBeenCalled()
+  })
+})
 
 // The count badge (stackable junk): shows how many are held, and hides itself at 0 (a found-then-
 // sold-out item stays collected with no badge). Other sections pass no count → bare tile.

--- a/src/ui/molecules/CollectibleSlot.tsx
+++ b/src/ui/molecules/CollectibleSlot.tsx
@@ -4,8 +4,13 @@ import { HieroglyphTile } from "@/ui/atoms/HieroglyphTile"
 import { Badge } from "@/ui/atoms/Badge"
 
 // One cell in a Collection category grid, in one of three states:
-// - "empty"     — not found yet: recessed "?" placeholder.
+// - "empty"     — not found yet: recessed "?" placeholder. Not clickable: there's nothing to show,
+//   and nothing to hunt for a symbol you've never turned up a piece of.
 // - "partial"   — some fragments found: partial-reveal tile + an "X/required" count badge.
+//   CLICKABLE, so the Collection screen can serve as the compass's target picker — "you see Ra 3/5
+//   → tap to hunt it" (docs/mods/collection-and-detector-design.md §3C). HieroglyphCollectionSection's
+//   HuntBar only offers an UNcollected hieroglyph, so dropping onClick here (as this used to) left
+//   the hunt button permanently unreachable: clickable ⟹ collected ⟹ not huntable.
 // - "collected" — fully owned: clickable revealed tile (opens the detail panel). A stackable item
 //   (junk) can pass `count` for a "how many held" badge; the badge hides itself at 0 (sold out).
 // Wraps HieroglyphTile so the state → visual mapping lives in one place instead of being
@@ -42,6 +47,8 @@ export const CollectibleSlot: FC<CollectibleSlotProps> = ({
           symbol={symbol}
           difficulty={difficulty}
           fragmentProgress={progress}
+          selected={selected}
+          onClick={onClick}
           size={size}
           className={className}
         />


### PR DESCRIPTION
## Summary

Two independent UI defects reported from play. Neither is in the detector logic itself.

### 1. The HUD bar swallows map taps along the bottom of the screen

`SiteHudBar` is full-bleed (`left-0 right-0`) so its children stay centred over the map — which means its *own* box is a transparent band spanning the entire screen width along the bottom. At `z-10` it sits above the map SVG's cells (`z-auto`) with no `pointer-events-none`, so it ate every tap in that band. Everything lost there is map navigation (the cell handlers in `SiteMapView.tsx` → `handleCellClick`).

It read as *"the detector blocks clicks"* because the band grows taller when a detector mode is switched on and starts listing results — but the detector was only making an existing bug bigger.

Confirmed an oversight rather than intent: every other full-bleed overlay in the repo already carries the guard (`LevelCompletedOverlay.tsx`, `PyramidExpedition.tsx`, `fez/Fez.tsx`).

Fix: the bar stops hit-testing; its two children (both content-sized) opt back in with `pointer-events-auto`, so no dead space is reintroduced.

### 2. Picking a hieroglyph to hunt was impossible

The hunt feature was already wired end to end — picker → persisted `compassTarget` → `registerCompassTarget` seam → `useDetector` → `DetectorPanel` readout. It was dead because of a contradiction between two components:

- `CollectibleSlot` forwarded `onClick`/`selected` **only** for `collected` slots.
- `HuntBar` only offers a hieroglyph that is **not** collected.

So *clickable ⟹ collected ⟹ not huntable*. The hunt button could never appear from a grid selection, and the only visible state was a hint instructing the player to do something the UI didn't permit ("select an uncollected hieroglyph, then hunt it with the compass"). Since the in-panel `<select>` picker was deliberately removed in favour of the Collection screen, this was fully blocking rather than cosmetic.

`docs/mods/collection-and-detector-design.md` confirms the intent was exactly *"you see Ra 3/5 → tap to hunt it"* — the `HuntBar` half shipped, the `CollectibleSlot` half didn't.

Fix: **partial** slots (≥1 fragment found) are now clickable. Empty slots stay inert deliberately — there's nothing to reveal, and nothing to hunt for a symbol you haven't turned up a single piece of. No change was needed to `HuntBar`; its predicate works as soon as a partial item can reach `selectedItem`.

## Changes

- `src/ui/atoms/SiteHudBar.tsx` — `pointer-events-none` on the full-bleed wrapper.
- `src/ui/atoms/DetectorPanel.tsx`, `src/app/SiteMap/SiteMapScreen.tsx` — `pointer-events-auto` on the bar's two children.
- `src/ui/molecules/CollectibleSlot.tsx` — forward `onClick`/`selected` in the `partial` branch; doc comment updated to record which states are clickable and why.
- Tests + `CHANGELOG.md`.

## Test plan

- [x] `npx tsc -b` — clean
- [x] `npx vitest run` — 974 pass (was 970; 4 added)
- [x] `npx eslint` on all changed files — clean
- [x] **Both new tests confirmed to fail without the fix** (verified by temporarily reverting the `CollectibleSlot` change)
- [x] `src/ui/molecules/CollectibleSlot.spec.tsx` — which states accept a click (partial, collected) and which don't (empty)
- [x] `HieroglyphCollectionSection.huntbar.spec.tsx` — new integration case driving the real path: tap a partial tile *in the grid*, assert the hunt affordance appears and sets the target

### Known limits of this coverage — please read before trusting the green tick

**The HUD fix (bug 1) is verified manually only and is not regression-tested.** jsdom has no layout or hit-testing, and `fireEvent.click` dispatches straight at its target node, ignoring `pointer-events` and z-order entirely — so no test in this suite can catch that class of bug. I deliberately did not add a class-string assertion (`expect(...).toContain("pointer-events-none")`): there is no precedent for styling assertions anywhere in this repo's tests, and it would create the appearance of coverage while still not verifying the actual behaviour. Catching this properly needs a real browser (no Playwright/browser test setup exists here).

Worth knowing that the pre-existing hunt-bar tests passed throughout the entire time the feature was dead, because they injected `selectedItem` as a prop and never exercised the grid — the new integration case is what closes that gap.

**Suggested manual check for bug 1:** enter a pyramid or tomb, switch on a detector so the panel grows tall, then tap a reachable room low on the screen and confirm the explorer moves.

## Note on one accepted consequence

Selecting a partial hieroglyph also opens the shared `DetailPanel`, which renders the tile without `fragmentProgress` — so it shows the fully unmasked symbol plus name and description, bypassing the grid tile's partial-reveal gradient. I judged this acceptable because `HuntBar` already prints the selected item's symbol in its own button label, so revealing a *deliberately selected* hunt target is existing intended behaviour, and knowing what you're hunting is rather the point. Happy to change it if you'd rather the mask persisted — the contained fix is threading an optional `fragmentProgress` into `DetailPanel`, which the treasure/shop sections would simply omit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXmd8roFQg4TkXbJ5jE2Mn)_