### PR TITLE
Make the compass readout usable: names, right precision, access marking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - The compass readout now names places instead of showing internal ids — "Papyrus Merchant's Route L2" rather than `starter_2`. It also tells you which pyramid of a journey to search: at its first level it was naming the whole journey, which can be five pyramids, instead of the one pyramid it actually knows. The supplies detector's readout is named the same way.
 - The compass panel now says what it's hunting ("Looking for 𓎗"), rather than leaving you to remember which hieroglyph you picked over on the Collection screen.
+- The detector buttons now sit alongside your health and coins instead of taking up a row of their own above them, and the readout panel only appears once you actually switch a detector on — so the bottom of the screen stays clear of the map while you're exploring.
 
 ## 0.30.10 - 2026-08-01
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- The compass now warns you when a piece isn't yours to take yet: 🔒 for one sitting behind a ward key you don't hold or in a difficulty you haven't unlocked, 👁 for one hidden in a corridor you'd need the passageway detector to find, and ❓ where it genuinely can't tell — inside a tomb you may not be able to enter, or on sale at a merchant. A piece with nothing known in its way carries no mark. Previously the compass listed every location in the world with no hint that most of them were unreachable, which had become misleading now that hieroglyph pieces are deliberately held back behind tomb gates.
+
+### Fixed
+- The compass readout now names places instead of showing internal ids — "Papyrus Merchant's Route L2" rather than `starter_2`. It also tells you which pyramid of a journey to search: at its first level it was naming the whole journey, which can be five pyramids, instead of the one pyramid it actually knows. The supplies detector's readout is named the same way.
+- The compass panel now says what it's hunting ("Looking for 𓎗"), rather than leaving you to remember which hieroglyph you picked over on the Collection screen.
 
 ## 0.30.10 - 2026-08-01
 ### Fixed

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -186,6 +186,13 @@
     "hunting": "Hunting {{symbol}}",
     "huntStop": "Stop",
     "huntHint": "Select an uncollected hieroglyph, then hunt it with the compass",
-    "huntAction": "Hunt {{symbol}}"
+    "huntAction": "Hunt {{symbol}}",
+    "lookingFor": "Looking for {{symbol}}",
+    "access": {
+      "open": "Nothing known blocking this one",
+      "locked": "Locked — you don't hold the key for this one yet",
+      "hidden": "In a hidden corridor — needs the passageway detector",
+      "unknown": "Might not be reachable yet — it's inside a tomb or for sale"
+    }
   }
 }

--- a/src/app/SiteMap/SiteMapScreen.tsx
+++ b/src/app/SiteMap/SiteMapScreen.tsx
@@ -26,6 +26,7 @@ import { useCompassTargetLabel } from "@/app/SiteMap/compassTarget"
 import { useJourneyTranslations } from "@/app/translations/useJourneyTranslations"
 import { useMergedDetectorLevels } from "@/app/SiteMap/detectorLevels"
 import { DetectorPanel } from "@/ui/atoms/DetectorPanel"
+import { DetectorToggles } from "@/ui/atoms/DetectorToggles"
 import { BackButton } from "@/ui/atoms/BackButton"
 import { FloorBadge } from "@/ui/atoms/FloorBadge"
 import { SiteHudBar } from "@/ui/atoms/SiteHudBar"
@@ -387,25 +388,32 @@ export const SiteMapScreen = ({ journeyId, siteConfig, seed, onSiteComplete, onC
         />
       </div>
       <SiteHudBar>
-        {(detectorLevels.compass > 0 || detectorLevels.supplies > 0 || detectorLevels.corridor > 0) && (
-          <DetectorPanel
+        {/* The readout sits on its own row (it's multi-line), but only once a mode is switched on —
+            both this and the toggles below self-hide, so no empty row is reserved for them. */}
+        <DetectorPanel
+          activeDetector={detector.activeDetector}
+          compassLevel={detectorLevels.compass}
+          consumableDetectorLevel={detectorLevels.supplies}
+          detectionLevel={detectorLevels.corridor}
+          compassTarget={detector.compassTarget}
+          compassTargetLabel={compassTargetLabel}
+          journeyName={journeyName}
+          compassResults={detector.compassResults}
+          consumableResults={detector.consumableResults}
+          floorHasHiddenCorridor={floorHasHiddenCorridor}
+          pyramidHiddenCorridorCount={pyramidHiddenCorridorCount}
+        />
+        {/* pointer-events-auto: opts this row back into hit-testing inside SiteHudBar's
+            non-hit-testing band (the widgets and dev buttons below are clickable). */}
+        <div className="pointer-events-auto flex items-center gap-4">
+          {/* Detector buttons ride along in this row rather than claiming one of their own. */}
+          <DetectorToggles
             activeDetector={detector.activeDetector}
             compassLevel={detectorLevels.compass}
             consumableDetectorLevel={detectorLevels.supplies}
             detectionLevel={detectorLevels.corridor}
-            compassTarget={detector.compassTarget}
-            compassTargetLabel={compassTargetLabel}
-            journeyName={journeyName}
-            compassResults={detector.compassResults}
-            consumableResults={detector.consumableResults}
             onSetDetector={detector.setDetector}
-            floorHasHiddenCorridor={floorHasHiddenCorridor}
-            pyramidHiddenCorridorCount={pyramidHiddenCorridorCount}
           />
-        )}
-        {/* pointer-events-auto: opts this row back into hit-testing inside SiteHudBar's
-            non-hit-testing band (the widgets and dev buttons below are clickable). */}
-        <div className="pointer-events-auto flex items-center gap-4">
           {/* Mod-contributed HUD widgets (trap's health + consumables, shop's balance) — core names none. */}
           {hudWidgets().map(({ id, Component }) => (
             <Component key={id} />

--- a/src/app/SiteMap/SiteMapScreen.tsx
+++ b/src/app/SiteMap/SiteMapScreen.tsx
@@ -22,6 +22,8 @@ import { EntranceTransitionOverlay } from "@/ui/atoms/EntranceTransitionOverlay"
 import { hudWidgets } from "@/app/SiteMap/hudRegistry"
 import { useMergedRewardContributions } from "@/app/SiteMap/rewardContributions"
 import { useMergedHeldKeys } from "@/app/SiteMap/keyProviders"
+import { useCompassTargetLabel } from "@/app/SiteMap/compassTarget"
+import { useJourneyTranslations } from "@/app/translations/useJourneyTranslations"
 import { useMergedDetectorLevels } from "@/app/SiteMap/detectorLevels"
 import { DetectorPanel } from "@/ui/atoms/DetectorPanel"
 import { BackButton } from "@/ui/atoms/BackButton"
@@ -53,6 +55,16 @@ export const SiteMapScreen = ({ journeyId, siteConfig, seed, onSiteComplete, onC
   // Detector levels come from the owning mods (compass←hieroglyph, supplies←trap, corridor←core) via
   // the merged accessor — core names no mod.
   const detectorLevels = useMergedDetectorLevels()
+  // Player-facing labels for the detector readout: the hunted item's glyph (mod-owned, via the seam)
+  // and each journey's localized name, so it reads "Papyrus Merchant's Route 2" rather than
+  // "starter_2". useJourneyTranslations is called ONCE and reduced to a lookup — the per-id
+  // useJourneyTranslation is a hook and can't be called per result.
+  const compassTargetLabel = useCompassTargetLabel()
+  const translatedJourneys = useJourneyTranslations()
+  const journeyName = useMemo(() => {
+    const names: Record<string, string> = Object.fromEntries(translatedJourneys.map(j => [j.id, j.name]))
+    return (id: string) => names[id] ?? id
+  }, [translatedJourneys])
 
   const [currentFloor, setCurrentFloor] = useState(() => {
     const pos = journeyState?.position
@@ -382,6 +394,8 @@ export const SiteMapScreen = ({ journeyId, siteConfig, seed, onSiteComplete, onC
             consumableDetectorLevel={detectorLevels.supplies}
             detectionLevel={detectorLevels.corridor}
             compassTarget={detector.compassTarget}
+            compassTargetLabel={compassTargetLabel}
+            journeyName={journeyName}
             compassResults={detector.compassResults}
             consumableResults={detector.consumableResults}
             onSetDetector={detector.setDetector}

--- a/src/app/SiteMap/compassTarget.ts
+++ b/src/app/SiteMap/compassTarget.ts
@@ -13,3 +13,23 @@ export const registerCompassTarget = (useTarget: UseCompassTarget) => {
 // Registered once at module load (mod entrypoint) or never — the branch is stable across renders,
 // so calling the provider hook conditionally is rules-of-hooks safe (see detectorLevels.ts).
 export const useCompassTarget = (): string | null => (provider ? provider() : null)
+
+// How the target is SHOWN (e.g. a hieroglyph id → its glyph), so the readout can say "looking for
+// 𓎗" without core naming the owning mod's symbol table.
+//
+// Deliberately a SECOND seam rather than widening UseCompassTarget to return `{id, symbol}`:
+// useDetector memoises the whole-world scan on the target value, and that memo is only stable
+// because the target is a persisted string. A seam handing back a fresh object each render would
+// invalidate it every render — rescanning every journey continuously, and at level 3 reassembling
+// floors while doing it. Keep the scan key a bare string; label separately.
+export type UseCompassTargetLabel = () => (id: string) => string
+
+let labelProvider: UseCompassTargetLabel | null = null
+
+export const registerCompassTargetLabel = (useLabel: UseCompassTargetLabel) => {
+  labelProvider = useLabel
+}
+
+// Unregistered (mod off) → identity, so a readout degrades to the raw id rather than going blank.
+export const useCompassTargetLabel = (): ((id: string) => string) =>
+  labelProvider ? labelProvider() : (id: string) => id

--- a/src/app/state/useDetector.access.spec.ts
+++ b/src/app/state/useDetector.access.spec.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { renderHook, act } from "@testing-library/react"
+import type { CompassResult } from "@/game/siteTypes"
+import type { JourneyAPI } from "./useJourneys"
+
+// Whether a compass hit is actually collectable right now. The scanner reports the gates it walked
+// past; this layer decides, against the keys the player holds, which of them are in the way.
+//
+// A separate file from useDetector.spec.ts on purpose: the seam registries are module-global, so
+// registering a target/scanner here would break that spec's "no mod registered → nothing to scan".
+
+vi.mock("@/data/generatedWorld", () => ({ generatedWorldConfigs: { starter_1: [[{}]] } }))
+
+// starter_1 is a starter-tier pyramid (no tier-unlock requirement); junior_1 needs one of starter's
+// tomb treasures; junior_treasure_tomb is a tomb, whose entry cost this layer can't evaluate.
+let hits: CompassResult[] = []
+let held: string[] = []
+
+const { registerCompassTarget } = await import("@/app/SiteMap/compassTarget")
+const { registerCompassScanner } = await import("@/app/SiteMap/detectorScanners")
+const { registerHeldKeysProvider } = await import("@/app/SiteMap/keyProviders")
+registerCompassTarget(() => "h1")
+registerCompassScanner(() => () => hits)
+registerHeldKeysProvider(() => new Set(held))
+
+const { useDetector } = await import("./useDetector")
+
+const journeys = { getSkippedConsumables: () => [] } as unknown as JourneyAPI
+
+const hit = (over: Partial<CompassResult> = {}): CompassResult => ({
+  journeyId: "starter_1",
+  levelIdx: 0,
+  floorIdx: 0,
+  hieroglyphId: "h1",
+  pieceIndex: 0,
+  ...over,
+})
+
+const accessOf = () => {
+  const { result } = renderHook(() => useDetector(journeys))
+  act(() => result.current.setDetector("compass"))
+  return result.current.compassResults[0]
+}
+
+beforeEach(() => {
+  hits = []
+  held = []
+})
+
+describe("compass hit access", () => {
+  it("is open when nothing known stands in the way", () => {
+    hits = [hit()]
+    expect(accessOf().access).toBe("open")
+  })
+
+  it("is locked when a gating ward key is not held, and reports which", () => {
+    hits = [hit({ wardKeys: ["starter_a_1"] })]
+    expect(accessOf()).toMatchObject({ access: "locked", missingKeys: ["starter_a_1"] })
+  })
+
+  it("is open once that ward key is held", () => {
+    hits = [hit({ wardKeys: ["starter_a_1"] })]
+    held = ["starter_a_1"]
+    expect(accessOf().access).toBe("open")
+  })
+
+  it("needs EVERY key of a nested gate chain, not just one", () => {
+    hits = [hit({ wardKeys: ["starter_a_1", "starter_a_2"] })]
+    held = ["starter_a_1"]
+    expect(accessOf()).toMatchObject({ access: "locked", missingKeys: ["starter_a_2"] })
+  })
+
+  it("is locked when the piece's tier is not unlocked yet", () => {
+    hits = [hit({ journeyId: "junior_1" })]
+    expect(accessOf().access).toBe("locked")
+  })
+
+  it("is open in a locked-by-default tier once any of its unlock treasures is held", () => {
+    hits = [hit({ journeyId: "junior_1" })]
+    held = ["starter_a_3"] // any one of junior's four unlock ids opens the tier
+    expect(accessOf().access).toBe("open")
+  })
+
+  it("is hidden for a piece in a hidden corridor", () => {
+    hits = [hit({ hidden: true })]
+    expect(accessOf().access).toBe("hidden")
+  })
+
+  // Cost, not a lock: the readout can't tell whether the player can afford or enter, so it says so
+  // rather than implying the piece is there for the taking.
+  it("is unknown for shop stock", () => {
+    hits = [hit({ inShop: true })]
+    expect(accessOf().access).toBe("unknown")
+  })
+
+  it("is unknown for a piece inside a tomb", () => {
+    hits = [hit({ journeyId: "starter_treasure_tomb" })]
+    expect(accessOf().access).toBe("unknown")
+  })
+
+  // Hardest blocker wins, so the readout names the thing that actually stops you first.
+  it("prefers locked over hidden when both apply", () => {
+    hits = [hit({ wardKeys: ["starter_a_1"], hidden: true })]
+    expect(accessOf().access).toBe("locked")
+  })
+})

--- a/src/app/state/useDetector.ts
+++ b/src/app/state/useDetector.ts
@@ -1,17 +1,47 @@
 import { useMemo, useState } from "react"
 import { generatedWorldConfigs } from "@/data/generatedWorld"
-import type { DetectorMode, CompassResult, ConsumableResult } from "@/game/siteTypes"
+import type { DetectorMode, CompassAccess, CompassHit, ConsumableResult } from "@/game/siteTypes"
 import type { JourneyAPI } from "./useJourneys"
 import { useMergedCompassScanner } from "@/app/SiteMap/detectorScanners"
 import { useCompassTarget } from "@/app/SiteMap/compassTarget"
+import { useMergedHeldKeys } from "@/app/SiteMap/keyProviders"
 import { decodeEdge } from "@/app/SiteMap/useAssembledFloor"
+import { PYRAMID_JOURNEYS, TOMB_JOURNEYS } from "@/worldGen/data"
+import { TIER_UNLOCK_PERK_IDS } from "@/data/treasurePerks"
 
 export type DetectorAPI = {
   activeDetector: DetectorMode
   compassTarget: string | null
   setDetector: (mode: DetectorMode) => void
-  compassResults: CompassResult[]
+  compassResults: CompassHit[]
   consumableResults: ConsumableResult[]
+}
+
+// journeyId → its tier, and which journeys are tombs. Same derivation as placeFragments' own
+// buildJourneyMeta; built once since the world is static.
+const JOURNEY_TIER: Record<string, string> = Object.fromEntries(
+  [...PYRAMID_JOURNEYS, ...TOMB_JOURNEYS].map(j => [j.id, j.tier])
+)
+const TOMB_JOURNEY_IDS = new Set(TOMB_JOURNEYS.map(j => j.id))
+
+// Can the player go get this piece right now? Only claims what's checkable — see CompassAccess.
+// Precedence runs hardest-blocker-first: an outright lock outranks needing the corridor detector,
+// which outranks a cost we can't evaluate.
+const accessOf = (
+  hit: { journeyId: string; wardKeys?: readonly string[]; hidden?: boolean; inShop?: boolean },
+  heldKeys: ReadonlySet<string>
+): { access: CompassAccess; missingKeys?: readonly string[] } => {
+  const missingKeys = (hit.wardKeys ?? []).filter(k => !heldKeys.has(k))
+  if (missingKeys.length > 0) return { access: "locked", missingKeys }
+  // A tier with no unlock ids is the first one — always open. Otherwise ANY of its unlock treasures
+  // opens it (mirrors reachability's isTierUnlocked).
+  const unlockIds = TIER_UNLOCK_PERK_IDS[JOURNEY_TIER[hit.journeyId] ?? ""]
+  if (unlockIds && !unlockIds.some(k => heldKeys.has(k))) return { access: "locked" }
+  if (hit.hidden) return { access: "hidden" }
+  // Entering a tomb costs map pieces and shop stock costs money; neither is modelled here, so say
+  // "don't know" rather than implying the piece is there for the taking.
+  if (hit.inShop || TOMB_JOURNEY_IDS.has(hit.journeyId)) return { access: "unknown" }
+  return { access: "open" }
 }
 
 export const useDetector = (journeys: JourneyAPI): DetectorAPI => {
@@ -20,12 +50,18 @@ export const useDetector = (journeys: JourneyAPI): DetectorAPI => {
   // the seam (null when no mod owns it) so a target survives navigation into a site.
   const compassTarget = useCompassTarget()
   const scanCompass = useMergedCompassScanner()
+  const heldKeys = useMergedHeldKeys()
 
   // Compass scanning is mod-owned (each mod registers a scanner for its own reward type via
-  // detectorScanners); core just runs the merged scanner for the current target.
-  const compassResults = useMemo<CompassResult[]>(
-    () => (activeDetector === "compass" && compassTarget ? scanCompass(compassTarget) : []),
-    [activeDetector, compassTarget, scanCompass]
+  // detectorScanners); core just runs the merged scanner for the current target, then resolves each
+  // hit's access against the keys the player holds — the scanner reports gates, it can't judge them.
+  // `compassTarget` must stay a bare string for this memo to hold; see compassTarget.ts.
+  const compassResults = useMemo<CompassHit[]>(
+    () =>
+      activeDetector === "compass" && compassTarget
+        ? scanCompass(compassTarget).map(hit => ({ ...hit, ...accessOf(hit, heldKeys) }))
+        : [],
+    [activeDetector, compassTarget, scanCompass, heldKeys]
   )
 
   const consumableResults = useMemo((): ConsumableResult[] => {

--- a/src/game/siteTypes.ts
+++ b/src/game/siteTypes.ts
@@ -177,7 +177,32 @@ export type CompassResult = {
   hieroglyphId: string
   pieceIndex: number
   cell?: { row: number; col: number }
+  // Access facts a scanner observes while walking the config, for the readout to flag pieces you
+  // can't collect yet (§7.2's readout is otherwise happy to point at gated content). Deliberately
+  // raw facts, not a verdict: the scanner has no access to what the player holds, so judging
+  // reachability is the consumer's job (useDetector).
+  //
+  // Every tomb-key ward gate between the floor and this piece — ALL must be held to reach it.
+  wardKeys?: readonly string[]
+  // The piece sits in a hidden corridor: structurally reachable but discovery-gated (§7.3), so it
+  // needs the corridor detector or luck rather than a key.
+  hidden?: boolean
+  // The piece is stock in a shop, so it costs money on top of getting there — a blocker the
+  // readout can't evaluate, hence surfaced as uncertainty rather than a lock.
+  inShop?: boolean
 }
+
+// Whether the player can actually go and collect a compass hit right now. The readout only models
+// some of what can block a piece, so this deliberately has a "don't know" value rather than
+// collapsing unknowns into "fine":
+// - "locked"  a checkable blocker IS in the way (a ward key not held, or the tier not unlocked)
+// - "hidden"  in a hidden corridor: needs the corridor detector or luck, not a key (§7.3)
+// - "unknown" a blocker exists that this readout can't evaluate (tomb map-piece entry, shop price)
+// - "open"    nothing known is in the way — NOT a guarantee, just "we checked and found nothing"
+export type CompassAccess = "open" | "locked" | "hidden" | "unknown"
+
+// A compass hit with its access verdict resolved against what the player currently holds.
+export type CompassHit = CompassResult & { access: CompassAccess; missingKeys?: readonly string[] }
 
 // floorIdx + cell decoded from edgeId ("floor:row,col") so the supplies detector can narrow its
 // readout by level (§7.2): L1 pyramid, L2 +floor, L3 +cell.

--- a/src/mods/hieroglyph/app/HieroglyphCollectionSection.tsx
+++ b/src/mods/hieroglyph/app/HieroglyphCollectionSection.tsx
@@ -4,18 +4,13 @@ import { useTranslation } from "react-i18next"
 import { useInventoryCategory } from "@/app/translations/useInventoryTranslations"
 import { getItemFirstLevel } from "@/data/itemLevelLookup"
 import { useInventory } from "@/app/Inventory/useInventory"
-import { allItems } from "@/data/inventory"
 import { useHieroglyphProgress } from "./useHieroglyphProgress"
+import { HIEROGLYPH_SYMBOLS } from "./hieroglyphSymbols"
 import { difficulties } from "@/data/difficultyLevels"
 import { CategoryGrid } from "@/ui/atoms/CategoryGrid"
 import { CollectionSection } from "@/ui/atoms/CollectionSection"
 import { CollectibleSlot } from "@/ui/molecules/CollectibleSlot"
 import type { CollectionSectionProps } from "@/app/pages/collectionSectionRegistry"
-
-// id → symbol for every hieroglyph (the four egyptian categories). Used to tell whether a selected
-// Collection item is a hieroglyph this mod owns (the hunt affordance only applies to those) and to
-// show the hunted glyph in the hunt bar.
-const HIEROGLYPH_SYMBOLS: Record<string, string> = Object.fromEntries(allItems.map(i => [i.id, i.symbol]))
 
 // The hieroglyph mod's Collection contribution: fragment-collectible categories, each hieroglyph
 // shown as an empty / partial ("Ra 1/3") / collected slot. Registered app-side and gated on the

--- a/src/mods/hieroglyph/app/compassScanner.spec.ts
+++ b/src/mods/hieroglyph/app/compassScanner.spec.ts
@@ -36,6 +36,49 @@ vi.mock("@/data/generatedWorld", () => ({
         },
       ],
     ],
+    // A second journey covering the ACCESS facts the readout needs (h2, so the h1 cases above are
+    // unaffected): a ward gate, a gate nested under it, a hidden corridor, and shop stock.
+    starter_2: [
+      [
+        {
+          pathPuzzles: 0,
+          difficulty: "starter",
+          end: "treasure",
+          sideSections: [
+            {
+              pathPuzzles: 0,
+              difficulty: "starter",
+              end: "treasure",
+              gate: { type: "tomb-key", wardKeyId: "starter_a_1" },
+              endReward: { type: "hieroglyphFragment", hieroglyphId: "h2", pieceIndex: 0 },
+              sideSections: [
+                {
+                  pathPuzzles: 0,
+                  difficulty: "starter",
+                  end: "treasure",
+                  gate: { type: "tomb-key", wardKeyId: "starter_a_2" },
+                  endReward: { type: "hieroglyphFragment", hieroglyphId: "h2", pieceIndex: 1 },
+                },
+              ],
+            },
+            {
+              pathPuzzles: 0,
+              difficulty: "starter",
+              end: "treasure",
+              hidden: true,
+              endReward: { type: "hieroglyphFragment", hieroglyphId: "h2", pieceIndex: 2 },
+            },
+            {
+              pathPuzzles: 0,
+              difficulty: "starter",
+              end: "treasure",
+              encounter: "fez-shop",
+              rewards: [{ type: "hieroglyphFragment", hieroglyphId: "h2", pieceIndex: 3 }],
+            },
+          ],
+        },
+      ],
+    ],
   },
 }))
 
@@ -85,6 +128,57 @@ describe("useHieroglyphCompassScanner", () => {
     const { result } = renderHook(() => useHieroglyphCompassScanner())
     const results = result.current("h1")
     expect(results.every(r => r.cell === undefined)).toBe(true)
+  })
+
+  // The readout has to distinguish "go get it" from "you can't yet", so the scanner reports what
+  // stands in the way. It reports raw facts only — it can't see what the player holds, so it never
+  // decides reachability itself (that's useDetector's job).
+  describe("access facts", () => {
+    const scanH2 = () => {
+      hasFragmentImpl = () => false
+      compassLevelImpl = 1
+      const { result } = renderHook(() => useHieroglyphCompassScanner())
+      const byPiece = new Map(result.current("h2").map(r => [r.pieceIndex, r]))
+      return byPiece
+    }
+
+    it("reports the ward key gating a piece", () => {
+      expect(scanH2().get(0)?.wardKeys).toEqual(["starter_a_1"])
+    })
+
+    it("accumulates a parent gate and a nested gate — both are needed", () => {
+      expect(scanH2().get(1)?.wardKeys).toEqual(["starter_a_1", "starter_a_2"])
+    })
+
+    it("marks a piece in a hidden corridor", () => {
+      const hit = scanH2().get(2)
+      expect(hit?.hidden).toBe(true)
+      expect(hit?.wardKeys).toBeUndefined()
+    })
+
+    it("marks shop stock as buyable, not gated", () => {
+      const hit = scanH2().get(3)
+      expect(hit?.inShop).toBe(true)
+      expect(hit?.wardKeys).toBeUndefined()
+    })
+
+    it("reports nothing in the way for an ungated main-path piece", () => {
+      hasFragmentImpl = () => false
+      compassLevelImpl = 1
+      const { result } = renderHook(() => useHieroglyphCompassScanner())
+      const mainPath = result.current("h1").find(r => r.pieceIndex === 0)
+      expect(mainPath?.wardKeys).toBeUndefined()
+      expect(mainPath?.hidden).toBeUndefined()
+      expect(mainPath?.inShop).toBeUndefined()
+    })
+
+    // A plain section's rewards[] is puzzle-chain loot, not merchandise — only a shop section's is.
+    it("does not treat a non-shop section's rewards[] as shop stock", () => {
+      hasFragmentImpl = () => false
+      compassLevelImpl = 1
+      const { result } = renderHook(() => useHieroglyphCompassScanner())
+      expect(result.current("h1").find(r => r.pieceIndex === 2)?.inShop).toBeUndefined()
+    })
   })
 
   it("resolves the exact cell at level 3 by assembling the floor", () => {

--- a/src/mods/hieroglyph/app/compassScanner.ts
+++ b/src/mods/hieroglyph/app/compassScanner.ts
@@ -9,28 +9,66 @@ import { hashString } from "@/support/hashString"
 import { useHieroglyphProgress } from "./useHieroglyphProgress"
 import { hieroglyphFragmentSchema } from "./rewardSchema"
 
-const scanFloorForFragments = (floor: FloorConfig, hieroglyphId: string): number[] => {
-  const results: number[] = []
-  const checkReward = (r: FloorConfig["mainEndReward"]) => {
+// What stands between the player and a fragment, as observed while walking the config. Raw facts
+// only — the scanner can't see what the player holds, so the verdict is useDetector's job.
+type FragmentAccess = { wardKeys: readonly string[]; hidden: boolean; inShop: boolean }
+type FragmentHit = FragmentAccess & { pieceIndex: number }
+
+const OPEN: FragmentAccess = { wardKeys: [], hidden: false, inShop: false }
+
+// A section's own tomb-key gate, if any. Mirrors slots.ts's sWardKeys/subWardKeys accumulation so
+// the client agrees with world-gen about what gates a slot.
+const gateKeysOf = (s: { gate?: { type: string; wardKeyId?: string } }): readonly string[] =>
+  s.gate?.type === "tomb-key" && s.gate.wardKeyId ? [s.gate.wardKeyId] : []
+
+// A section's stock is buyable when its encounter resolved to the shop family. `encounter` may be a
+// tag list, so read the first entry (same normalisation as slots.ts).
+const isShop = (s: { encounter?: string | string[] }): boolean =>
+  (Array.isArray(s.encounter) ? s.encounter[0] : s.encounter) === "fez-shop"
+
+const scanFloorForFragments = (floor: FloorConfig, hieroglyphId: string): FragmentHit[] => {
+  const hits: FragmentHit[] = []
+  const checkReward = (r: FloorConfig["mainEndReward"], access: FragmentAccess) => {
     if (r?.type !== "hieroglyphFragment") return
     const fragment = hieroglyphFragmentSchema.parse(r)
-    if (fragment.hieroglyphId === hieroglyphId) results.push(fragment.pieceIndex)
+    if (fragment.hieroglyphId === hieroglyphId) hits.push({ pieceIndex: fragment.pieceIndex, ...access })
   }
   // Fragments live under two node-reward names: the path-end `endReward` AND every `rewards[]`
   // entry (a shop node bakes its stock there). Scan both, or the compass can't point at a shop
   // that sells a fragment — the ownership-skip below then drops it once bought. Mirrors the
-  // gen-side forEachReward sweep (validate.ts).
-  const scan = (s: { endReward?: FloorConfig["mainEndReward"]; rewards?: FloorConfig["mainEndReward"][] }) => {
-    checkReward(s.endReward)
-    for (const r of s.rewards ?? []) checkReward(r)
+  // gen-side forEachReward sweep (validate.ts). Only `rewards[]` of a shop section is buyable
+  // stock; a plain section's `rewards[]` is its puzzle-chain loot, which costs nothing.
+  const scan = (
+    s: {
+      endReward?: FloorConfig["mainEndReward"]
+      rewards?: FloorConfig["mainEndReward"][]
+      encounter?: string | string[]
+    },
+    access: FragmentAccess
+  ) => {
+    checkReward(s.endReward, access)
+    const stocked = isShop(s) ? { ...access, inShop: true } : access
+    for (const r of s.rewards ?? []) checkReward(r, stocked)
   }
-  checkReward(floor.mainEndReward)
-  for (const r of floor.rewards ?? []) checkReward(r)
+  // The floor's own main path is ungated by construction (a gate lives on a side section).
+  checkReward(floor.mainEndReward, OPEN)
+  for (const r of floor.rewards ?? []) checkReward(r, OPEN)
   for (const section of floor.sideSections ?? []) {
-    scan(section)
-    for (const sub of section.sideSections ?? []) scan(sub)
+    const access: FragmentAccess = {
+      wardKeys: gateKeysOf(section),
+      hidden: !!section.hidden,
+      inShop: false,
+    }
+    scan(section, access)
+    // A sub-section sits behind its parent's gate as well as its own, and inherits its hiddenness.
+    for (const sub of section.sideSections ?? [])
+      scan(sub, {
+        wardKeys: [...access.wardKeys, ...gateKeysOf(sub)],
+        hidden: access.hidden || !!sub.hidden,
+        inShop: false,
+      })
   }
-  return results
+  return hits
 }
 
 const isTargetFragment = (r: TreasureReward | undefined, hieroglyphId: string, pieceIndex: number): boolean =>
@@ -71,7 +109,7 @@ export const useHieroglyphCompassScanner = (): CompassScanner => {
       for (const [journeyId, levels] of Object.entries(generatedWorldConfigs)) {
         levels.forEach((floors, levelIdx) => {
           floors.forEach((floor, floorIdx) => {
-            const pieces = scanFloorForFragments(floor, target).filter(p => !hasFragment(target, p))
+            const pieces = scanFloorForFragments(floor, target).filter(p => !hasFragment(target, p.pieceIndex))
             if (pieces.length === 0) return
             // Assemble once per floor only at L3 (exact-cell precision); a failed assembly degrades
             // to floor-level (cell stays undefined) rather than dropping the hit.
@@ -87,13 +125,16 @@ export const useHieroglyphCompassScanner = (): CompassScanner => {
                     return r.success ? r.grid : undefined
                   })()
                 : undefined
-            for (const pieceIndex of pieces) {
+            for (const { pieceIndex, wardKeys, hidden, inShop } of pieces) {
               results.push({
                 journeyId,
                 levelIdx,
                 floorIdx,
                 hieroglyphId: target,
                 pieceIndex,
+                ...(wardKeys.length > 0 ? { wardKeys } : {}),
+                ...(hidden ? { hidden } : {}),
+                ...(inShop ? { inShop } : {}),
                 ...(grid ? { cell: findFragmentCell(grid, target, pieceIndex) } : {}),
               })
             }

--- a/src/mods/hieroglyph/app/hieroglyphSymbols.ts
+++ b/src/mods/hieroglyph/app/hieroglyphSymbols.ts
@@ -1,0 +1,5 @@
+import { allItems } from "@/data/inventory"
+
+// id → glyph, for anywhere this mod needs to SHOW a hieroglyph it only holds the id of (the
+// Collection hunt bar, the compass target label seam). Shared so the two don't drift.
+export const HIEROGLYPH_SYMBOLS: Record<string, string> = Object.fromEntries(allItems.map(i => [i.id, i.symbol]))

--- a/src/mods/hieroglyph/app/index.ts
+++ b/src/mods/hieroglyph/app/index.ts
@@ -4,13 +4,14 @@ import { registerRewardSchema } from "@/app/SiteMap/rewardSchemas"
 import { registerCompassScanner } from "@/app/SiteMap/detectorScanners"
 import { registerPerkContribution } from "@/app/SiteMap/perkContributions"
 import { registerDetectorLevel } from "@/app/SiteMap/detectorLevels"
-import { registerCompassTarget } from "@/app/SiteMap/compassTarget"
+import { registerCompassTarget, registerCompassTargetLabel } from "@/app/SiteMap/compassTarget"
 import { registerHeldKeysProvider } from "@/app/SiteMap/keyProviders"
 import { isModEnabled } from "@/mods/registeredMods"
 import { useHieroglyphProgress } from "./useHieroglyphProgress"
 import { useHieroglyphCompassScanner } from "./compassScanner"
 import { registerHieroglyphRewardDisplay } from "./rewardDisplay"
 import { hieroglyphFragmentSchema } from "./rewardSchema"
+import { HIEROGLYPH_SYMBOLS } from "./hieroglyphSymbols"
 import "./plugin"
 import "./collection"
 
@@ -56,6 +57,9 @@ if (isModEnabled("hieroglyph")) {
   // The hunt target is picked on the Collection screen (§3C) and stored in the mod's own state;
   // core reads it through this seam to drive the in-run compass readout without naming the mod.
   registerCompassTarget(() => useHieroglyphProgress().compassTarget)
+  // …and how to show it, so the readout can say "looking for 𓎗" while core stays ignorant of what a
+  // hieroglyph is. Separate from the target seam above on purpose — see compassTarget.ts.
+  registerCompassTargetLabel(() => (id: string) => HIEROGLYPH_SYMBOLS[id] ?? id)
   // Completed hieroglyphs are held keys (`hieroglyph:${id}`), so a tableau the player can now solve
   // reads as unlocked content on the travel screen — same seam the tomb-treasure mod uses for ward
   // keys. Core never learns these are hieroglyphs; a tableau node just exposes them as requiredKeyIds.

--- a/src/ui/atoms/DetectorPanel.spec.tsx
+++ b/src/ui/atoms/DetectorPanel.spec.tsx
@@ -17,8 +17,6 @@ const { DetectorPanel } = await import("./DetectorPanel")
 // mounted and later queries match earlier renders (see CollectibleSlot.spec.tsx for the same guard).
 afterEach(cleanup)
 
-const noop = () => {}
-
 // Journey ids are internal; the panel is handed a lookup so the readout shows real names. Tests use
 // stand-ins to prove the substitution happens (the app passes localized names from journeys.json).
 const journeyName = (id: string) => ({ starter_1: "Sphinx Dawn", junior_1: "Ibis Way" })[id] ?? id
@@ -62,7 +60,6 @@ const renderCompass = (compassLevel: number, compassResults: CompassHit[] = COMP
       journeyName={journeyName}
       compassResults={compassResults}
       consumableResults={[]}
-      onSetDetector={noop}
     />
   )
 
@@ -100,7 +97,6 @@ describe("DetectorPanel precision by level (§7.2)", () => {
         compassTarget={null}
         compassResults={[]}
         consumableResults={[]}
-        onSetDetector={noop}
       />
     )
     expect(screen.getByText("detector.pickTarget")).toBeTruthy()
@@ -127,7 +123,6 @@ describe("DetectorPanel precision by level (§7.2)", () => {
       compassTarget: null,
       compassResults: [],
       consumableResults: [],
-      onSetDetector: noop,
       floorHasHiddenCorridor: true,
       pyramidHiddenCorridorCount: 3,
     }
@@ -153,7 +148,6 @@ describe("DetectorPanel precision by level (§7.2)", () => {
       compassTarget: null,
       compassResults: [],
       consumableResults: CONSUMABLE,
-      onSetDetector: noop,
     }
     const { rerender } = render(<DetectorPanel {...props} consumableDetectorLevel={1} journeyName={journeyName} />)
     expect(screen.getAllByText("Ibis Way")).toHaveLength(1)
@@ -170,8 +164,8 @@ describe("DetectorPanel precision by level (§7.2)", () => {
 describe("DetectorPanel access marking", () => {
   const withAccess = (access: CompassHit["access"]) => [{ ...COMPASS[0], access }]
 
-  // Queried by tooltip rather than glyph: the mode-toggle buttons use some of the same emoji, so the
-  // title both disambiguates and proves the explanation is wired up.
+  // Queried by tooltip rather than glyph — 👁 also labels a detector mode, so the title both keeps
+  // the assertion unambiguous and proves the explanation is wired up.
   it("leaves an unblocked hit unmarked", () => {
     renderCompass(1, withAccess("open"))
     expect(screen.getByText("Sphinx Dawn L1")).toBeTruthy()

--- a/src/ui/atoms/DetectorPanel.spec.tsx
+++ b/src/ui/atoms/DetectorPanel.spec.tsx
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi } from "vitest"
-import { render, screen } from "@testing-library/react"
-import type { CompassResult, ConsumableResult } from "@/game/siteTypes"
+import { describe, it, expect, vi, afterEach } from "vitest"
+import { render, screen, cleanup } from "@testing-library/react"
+import type { CompassHit, ConsumableResult } from "@/game/siteTypes"
 
 // Isolated from the app's real i18n (never initialized in tests) — identity passthrough returns the
 // key (with interpolated opts appended) so assertions target the key + data, not the prose.
@@ -13,11 +13,36 @@ vi.mock("react-i18next", () => ({
 
 const { DetectorPanel } = await import("./DetectorPanel")
 
+// This project doesn't enable RTL's automatic cleanup, so without this each test's markup stays
+// mounted and later queries match earlier renders (see CollectibleSlot.spec.tsx for the same guard).
+afterEach(cleanup)
+
 const noop = () => {}
 
-const COMPASS: CompassResult[] = [
-  { journeyId: "starter_1", levelIdx: 0, floorIdx: 0, hieroglyphId: "h1", pieceIndex: 0, cell: { row: 3, col: 4 } },
-  { journeyId: "starter_1", levelIdx: 0, floorIdx: 1, hieroglyphId: "h1", pieceIndex: 1, cell: { row: 5, col: 2 } },
+// Journey ids are internal; the panel is handed a lookup so the readout shows real names. Tests use
+// stand-ins to prove the substitution happens (the app passes localized names from journeys.json).
+const journeyName = (id: string) => ({ starter_1: "Sphinx Dawn", junior_1: "Ibis Way" })[id] ?? id
+const targetLabel = (id: string) => (id === "h1" ? "𓎗" : id)
+
+const COMPASS: CompassHit[] = [
+  {
+    journeyId: "starter_1",
+    levelIdx: 0,
+    floorIdx: 0,
+    hieroglyphId: "h1",
+    pieceIndex: 0,
+    cell: { row: 3, col: 4 },
+    access: "open",
+  },
+  {
+    journeyId: "starter_1",
+    levelIdx: 0,
+    floorIdx: 1,
+    hieroglyphId: "h1",
+    pieceIndex: 1,
+    cell: { row: 5, col: 2 },
+    access: "open",
+  },
 ]
 
 const CONSUMABLE: ConsumableResult[] = [
@@ -25,7 +50,7 @@ const CONSUMABLE: ConsumableResult[] = [
   { journeyId: "junior_1", edgeId: "1:6,1", floorIdx: 1, cell: { row: 6, col: 1 } },
 ]
 
-const renderCompass = (compassLevel: number) =>
+const renderCompass = (compassLevel: number, compassResults: CompassHit[] = COMPASS) =>
   render(
     <DetectorPanel
       activeDetector="compass"
@@ -33,7 +58,9 @@ const renderCompass = (compassLevel: number) =>
       consumableDetectorLevel={0}
       detectionLevel={0}
       compassTarget="h1"
-      compassResults={COMPASS}
+      compassTargetLabel={targetLabel}
+      journeyName={journeyName}
+      compassResults={compassResults}
       consumableResults={[]}
       onSetDetector={noop}
     />
@@ -42,9 +69,25 @@ const renderCompass = (compassLevel: number) =>
 describe("DetectorPanel precision by level (§7.2)", () => {
   it("compass L1 collapses to the pyramid only — one line, no floor/cell", () => {
     renderCompass(1)
-    // Two hits in the same pyramid collapse to a single 'starter_1' line.
-    expect(screen.getAllByText("starter_1")).toHaveLength(1)
+    // Two hits on different floors of the SAME pyramid collapse to one line.
+    expect(screen.getAllByText("Sphinx Dawn L1")).toHaveLength(1)
     expect(screen.queryByText(/F1|F2|\(3,4\)/)).toBeNull()
+  })
+
+  // L1 is "which pyramid" (§7.2), not "which journey" — a journey holds several, so two pyramids of
+  // one journey must stay separate lines. Keying on journeyId alone used to merge them.
+  it("compass L1 lists two pyramids of the same journey separately", () => {
+    renderCompass(1, [
+      { ...COMPASS[0], levelIdx: 0 },
+      { ...COMPASS[1], levelIdx: 2 },
+    ])
+    expect(screen.getByText("Sphinx Dawn L1")).toBeTruthy()
+    expect(screen.getByText("Sphinx Dawn L3")).toBeTruthy()
+  })
+
+  it("names what it is hunting, using the mod-supplied target label", () => {
+    renderCompass(1)
+    expect(screen.getByText(/detector\.lookingFor:.*𓎗/)).toBeTruthy()
   })
 
   it("compass with no target points the player at the Collection picker (§3C)", () => {
@@ -65,15 +108,15 @@ describe("DetectorPanel precision by level (§7.2)", () => {
 
   it("compass L2 shows the floor but not the cell", () => {
     renderCompass(2)
-    expect(screen.getByText("starter_1 L1 F1")).toBeTruthy()
-    expect(screen.getByText("starter_1 L1 F2")).toBeTruthy()
+    expect(screen.getByText("Sphinx Dawn L1 F1")).toBeTruthy()
+    expect(screen.getByText("Sphinx Dawn L1 F2")).toBeTruthy()
     expect(screen.queryByText(/\(3,4\)/)).toBeNull()
   })
 
   it("compass L3 shows the exact cell", () => {
     renderCompass(3)
-    expect(screen.getByText("starter_1 L1 F1 · (3,4)")).toBeTruthy()
-    expect(screen.getByText("starter_1 L1 F2 · (5,2)")).toBeTruthy()
+    expect(screen.getByText("Sphinx Dawn L1 F1 · (3,4)")).toBeTruthy()
+    expect(screen.getByText("Sphinx Dawn L1 F2 · (5,2)")).toBeTruthy()
   })
 
   it("corridor detector widens outward: L1 silent, L2 floor line, L3 pyramid count", () => {
@@ -112,11 +155,41 @@ describe("DetectorPanel precision by level (§7.2)", () => {
       consumableResults: CONSUMABLE,
       onSetDetector: noop,
     }
-    const { rerender } = render(<DetectorPanel {...props} consumableDetectorLevel={1} />)
-    expect(screen.getAllByText("junior_1")).toHaveLength(1)
+    const { rerender } = render(<DetectorPanel {...props} consumableDetectorLevel={1} journeyName={journeyName} />)
+    expect(screen.getAllByText("Ibis Way")).toHaveLength(1)
 
-    rerender(<DetectorPanel {...props} consumableDetectorLevel={3} />)
-    expect(screen.getByText("junior_1 F1 · (2,3)")).toBeTruthy()
-    expect(screen.getByText("junior_1 F2 · (6,1)")).toBeTruthy()
+    rerender(<DetectorPanel {...props} consumableDetectorLevel={3} journeyName={journeyName} />)
+    expect(screen.getByText("Ibis Way F1 · (2,3)")).toBeTruthy()
+    expect(screen.getByText("Ibis Way F2 · (6,1)")).toBeTruthy()
+  })
+})
+
+// The readout only marks what it can justify: a blocker it checked (🔒), one it can't evaluate (❓),
+// or discovery-gated content (👁). A hit with nothing known in the way carries NO badge — a bare row
+// must not be read as a promise that the piece is collectable.
+describe("DetectorPanel access marking", () => {
+  const withAccess = (access: CompassHit["access"]) => [{ ...COMPASS[0], access }]
+
+  // Queried by tooltip rather than glyph: the mode-toggle buttons use some of the same emoji, so the
+  // title both disambiguates and proves the explanation is wired up.
+  it("leaves an unblocked hit unmarked", () => {
+    renderCompass(1, withAccess("open"))
+    expect(screen.getByText("Sphinx Dawn L1")).toBeTruthy()
+    expect(screen.queryByTitle(/^detector\.access\./)).toBeNull()
+  })
+
+  it("flags a hit behind a key the player lacks", () => {
+    renderCompass(1, withAccess("locked"))
+    expect(screen.getByTitle("detector.access.locked").textContent).toContain("🔒")
+  })
+
+  it("flags a hit whose reachability it cannot determine", () => {
+    renderCompass(1, withAccess("unknown"))
+    expect(screen.getByTitle("detector.access.unknown").textContent).toContain("❓")
+  })
+
+  it("flags a hit that needs the corridor detector", () => {
+    renderCompass(1, withAccess("hidden"))
+    expect(screen.getByTitle("detector.access.hidden").textContent).toContain("👁")
   })
 })

--- a/src/ui/atoms/DetectorPanel.stories.tsx
+++ b/src/ui/atoms/DetectorPanel.stories.tsx
@@ -14,18 +14,17 @@ const meta = {
     compassTarget: null,
     compassResults: [],
     consumableResults: [],
-    onSetDetector: () => {},
+    journeyName: (id: string) => ({ starter_1: "Sphinx Dawn", starter_2: "Papyrus Route" })[id] ?? id,
+    compassTargetLabel: () => "𓎗",
   },
 } satisfies Meta<typeof DetectorPanel>
 
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const NoPerks: Story = {}
-
-export const CompassOnly: Story = {
-  args: { compassLevel: 1 },
-}
+// Readout only — the mode buttons live in DetectorToggles, so with no mode active this renders
+// nothing at all rather than an empty card.
+export const NoModeActive: Story = {}
 
 // Compass active but no target picked yet — the HUD points the player at the Collection picker (§3C).
 export const CompassNoTarget: Story = {

--- a/src/ui/atoms/DetectorPanel.stories.tsx
+++ b/src/ui/atoms/DetectorPanel.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
+import type { CompassHit } from "@/game/siteTypes"
 import { DetectorPanel } from "./DetectorPanel"
 
 const meta = {
@@ -31,10 +32,38 @@ export const CompassNoTarget: Story = {
   args: { compassLevel: 1, activeDetector: "compass", compassTarget: null },
 }
 
-const COMPASS_HITS = [
-  { journeyId: "starter_1", levelIdx: 0, floorIdx: 0, hieroglyphId: "p10", pieceIndex: 0, cell: { row: 3, col: 4 } },
-  { journeyId: "starter_1", levelIdx: 0, floorIdx: 0, hieroglyphId: "p10", pieceIndex: 1, cell: { row: 5, col: 2 } },
-  { journeyId: "starter_2", levelIdx: 1, floorIdx: 2, hieroglyphId: "p10", pieceIndex: 2, cell: { row: 1, col: 6 } },
+// One hit of each access verdict, so the stories show the full marker vocabulary (§7.2): reachable
+// (no badge), key-locked, and not-determinable.
+const COMPASS_HITS: CompassHit[] = [
+  {
+    journeyId: "starter_1",
+    levelIdx: 0,
+    floorIdx: 0,
+    hieroglyphId: "p10",
+    pieceIndex: 0,
+    cell: { row: 3, col: 4 },
+    access: "open",
+  },
+  {
+    journeyId: "starter_1",
+    levelIdx: 0,
+    floorIdx: 0,
+    hieroglyphId: "p10",
+    pieceIndex: 1,
+    cell: { row: 5, col: 2 },
+    access: "locked",
+    missingKeys: ["junior_a_1"],
+  },
+  {
+    journeyId: "starter_2",
+    levelIdx: 1,
+    floorIdx: 2,
+    hieroglyphId: "p10",
+    pieceIndex: 2,
+    cell: { row: 1, col: 6 },
+    access: "unknown",
+    inShop: true,
+  },
 ]
 
 const CONSUMABLE_HITS = [

--- a/src/ui/atoms/DetectorPanel.tsx
+++ b/src/ui/atoms/DetectorPanel.tsx
@@ -15,17 +15,10 @@ type Props = {
   journeyName?: (journeyId: string) => string
   compassResults: CompassHit[]
   consumableResults: ConsumableResult[]
-  onSetDetector: (mode: DetectorMode) => void
   // Corridor detector widens outward (§7.2): L2 = an unfound corridor on this floor; L3 = the count
   // still outstanding across the whole pyramid. Both default off so lower levels stay silent.
   floorHasHiddenCorridor?: boolean
   pyramidHiddenCorridorCount?: number
-}
-
-const MODE_ICON: Record<string, string> = {
-  compass: "🧭",
-  consumable: "🎒",
-  hiddenPassageway: "👁",
 }
 
 const uniqueBy = <T,>(items: T[], key: (item: T) => string): T[] => {
@@ -93,53 +86,22 @@ export const DetectorPanel: FC<Props> = ({
   journeyName = id => id,
   compassResults,
   consumableResults,
-  onSetDetector,
   floorHasHiddenCorridor = false,
   pyramidHiddenCorridorCount = 0,
 }) => {
   const { t } = useTranslation("common")
-  if (compassLevel === 0 && consumableDetectorLevel === 0 && detectionLevel === 0) return null
-
-  const toggle = (mode: DetectorMode) => onSetDetector(activeDetector === mode ? null : mode)
+  // Purely a readout — with no mode switched on there's nothing to report, so the card doesn't
+  // render at all rather than sitting there empty above the HUD row. The buttons that switch a mode
+  // on live in DetectorToggles, inline in that row.
+  if (!activeDetector) return null
 
   const shownCompass = uniqueBy(compassResults, r => compassKey(r, compassLevel))
   const shownConsumables = uniqueBy(consumableResults, r => consumableKey(r, consumableDetectorLevel))
 
   return (
-    // `pointer-events-auto` re-enables hit-testing inside SiteHudBar's non-hit-testing band: needed
-    // for the mode toggles below, and it keeps taps on this opaque card from falling through to the
-    // map behind it.
+    // `pointer-events-auto` re-enables hit-testing inside SiteHudBar's non-hit-testing band, so taps
+    // on this opaque card don't fall through to the map behind it.
     <div className="pointer-events-auto rounded-lg border border-stone-700 bg-stone-900/90 p-2 text-xs text-stone-300">
-      <div className="mb-2 flex gap-2">
-        {compassLevel > 0 && (
-          <button
-            onClick={() => toggle("compass")}
-            className={`rounded px-2 py-1 ${activeDetector === "compass" ? "bg-amber-700 text-amber-100" : "bg-stone-800 hover:bg-stone-700"}`}
-            title={t("detector.compassTitle")}
-          >
-            {MODE_ICON.compass}
-          </button>
-        )}
-        {consumableDetectorLevel > 0 && (
-          <button
-            onClick={() => toggle("consumable")}
-            className={`rounded px-2 py-1 ${activeDetector === "consumable" ? "bg-amber-700 text-amber-100" : "bg-stone-800 hover:bg-stone-700"}`}
-            title={t("detector.consumableTitle")}
-          >
-            {MODE_ICON.consumable}
-          </button>
-        )}
-        {detectionLevel > 0 && (
-          <button
-            onClick={() => toggle("hiddenPassageway")}
-            className={`rounded px-2 py-1 ${activeDetector === "hiddenPassageway" ? "bg-amber-700 text-amber-100" : "bg-stone-800 hover:bg-stone-700"}`}
-            title={t("detector.corridorTitle")}
-          >
-            {MODE_ICON.hiddenPassageway}
-          </button>
-        )}
-      </div>
-
       {activeDetector === "compass" && (
         <div>
           {/* Target is picked on the Collection screen (§3C), not here — the HUD only reads it out. */}

--- a/src/ui/atoms/DetectorPanel.tsx
+++ b/src/ui/atoms/DetectorPanel.tsx
@@ -1,6 +1,6 @@
 import type { FC } from "react"
 import { useTranslation } from "react-i18next"
-import type { DetectorMode, CompassResult, ConsumableResult } from "@/game/siteTypes"
+import type { DetectorMode, CompassAccess, CompassHit, ConsumableResult } from "@/game/siteTypes"
 
 type Props = {
   activeDetector: DetectorMode
@@ -9,7 +9,11 @@ type Props = {
   detectionLevel: number // 0 = not unlocked
   // The hunted hieroglyph, picked on the Collection screen (§3C). null = nothing picked yet.
   compassTarget: string | null
-  compassResults: CompassResult[]
+  // How to SHOW the target (id → glyph) and a journey (id → its localized name). Injected rather
+  // than looked up here: this is a presentational atom, and the target's meaning is mod-owned.
+  compassTargetLabel?: (id: string) => string
+  journeyName?: (journeyId: string) => string
+  compassResults: CompassHit[]
   consumableResults: ConsumableResult[]
   onSetDetector: (mode: DetectorMode) => void
   // Corridor detector widens outward (§7.2): L2 = an unfound corridor on this floor; L3 = the count
@@ -34,18 +38,31 @@ const uniqueBy = <T,>(items: T[], key: (item: T) => string): T[] => {
   })
 }
 
-// Precision narrows inward with level (§7.2): L1 pyramid only, L2 +floor, L3 +exact cell. The key
-// collapses hits to the shown precision so lower levels don't list the same pyramid/floor twice.
-const compassKey = (r: CompassResult, level: number): string =>
+// Precision narrows inward with level (§7.2): L1 pyramid, L2 +floor, L3 +exact cell. The key
+// collapses hits to the shown precision so lower levels don't list the same pyramid/floor twice —
+// L1 keys on the PYRAMID (journey + level), since a journey holds several and naming only the
+// journey would be a whole expedition rather than the "which pyramid" the design specifies.
+const compassKey = (r: CompassHit, level: number): string =>
   level <= 1
-    ? r.journeyId
+    ? `${r.journeyId}:${r.levelIdx}`
     : level === 2
       ? `${r.journeyId}:${r.levelIdx}:${r.floorIdx}`
       : `${r.journeyId}:${r.levelIdx}:${r.floorIdx}:${r.cell?.row},${r.cell?.col}`
 
-const compassLabel = (r: CompassResult, level: number): string => {
-  if (level <= 1) return r.journeyId
-  const floor = `${r.journeyId} L${r.levelIdx + 1} F${r.floorIdx + 1}`
+// What each access verdict looks like. "open" shows nothing — a bare row means "nothing known in the
+// way", which is all the data supports; only the blockers get a badge. See CompassAccess.
+const ACCESS_ICON: Record<CompassAccess, string> = {
+  open: "",
+  locked: "🔒",
+  hidden: "👁",
+  unknown: "❓",
+}
+
+const compassLabel = (r: CompassHit, level: number, journeyName: (id: string) => string): string => {
+  // L#/F# keeps the shipped notation (# = pyramid, then floor); only the journey id → name changes.
+  const pyramid = `${journeyName(r.journeyId)} L${r.levelIdx + 1}`
+  if (level <= 1) return pyramid
+  const floor = `${pyramid} F${r.floorIdx + 1}`
   return level >= 3 && r.cell ? `${floor} · (${r.cell.row},${r.cell.col})` : floor
 }
 
@@ -56,9 +73,13 @@ const consumableKey = (r: ConsumableResult, level: number): string =>
       ? `${r.journeyId}:${r.floorIdx}`
       : `${r.journeyId}:${r.floorIdx}:${r.cell.row},${r.cell.col}`
 
-const consumableLabel = (r: ConsumableResult, level: number): string => {
-  if (level <= 1) return r.journeyId
-  const floor = `${r.journeyId} F${r.floorIdx + 1}`
+// The supplies readout gets the same name treatment. Its L1 stays journey-wide, unlike the compass:
+// ConsumableResult carries no levelIdx (it's rebuilt from an edgeId), so pyramid precision here
+// needs the skipped-consumable store to record one first.
+const consumableLabel = (r: ConsumableResult, level: number, journeyName: (id: string) => string): string => {
+  const journey = journeyName(r.journeyId)
+  if (level <= 1) return journey
+  const floor = `${journey} F${r.floorIdx + 1}`
   return level >= 3 ? `${floor} · (${r.cell.row},${r.cell.col})` : floor
 }
 
@@ -68,6 +89,8 @@ export const DetectorPanel: FC<Props> = ({
   consumableDetectorLevel,
   detectionLevel,
   compassTarget,
+  compassTargetLabel = id => id,
+  journeyName = id => id,
   compassResults,
   consumableResults,
   onSetDetector,
@@ -122,17 +145,27 @@ export const DetectorPanel: FC<Props> = ({
           {/* Target is picked on the Collection screen (§3C), not here — the HUD only reads it out. */}
           {!compassTarget ? (
             <p className="text-stone-500">{t("detector.pickTarget")}</p>
-          ) : shownCompass.length === 0 ? (
-            <p className="text-stone-500">{t("detector.allCollected")}</p>
           ) : (
             <>
-              {shownCompass.slice(0, 3).map((r, i) => (
-                <div key={i} className="truncate text-amber-200">
-                  {compassLabel(r, compassLevel)}
-                </div>
-              ))}
-              {shownCompass.length > 3 && (
-                <p className="text-stone-500">{t("detector.more", { count: shownCompass.length - 3 })}</p>
+              <p className="text-stone-500">
+                {t("detector.lookingFor", { symbol: compassTargetLabel(compassTarget) })}
+              </p>
+              {shownCompass.length === 0 ? (
+                <p className="text-stone-500">{t("detector.allCollected")}</p>
+              ) : (
+                <>
+                  {shownCompass.slice(0, 3).map((r, i) => (
+                    <div key={i} className="truncate text-amber-200">
+                      {ACCESS_ICON[r.access] && (
+                        <span title={t(`detector.access.${r.access}`)}>{ACCESS_ICON[r.access]} </span>
+                      )}
+                      {compassLabel(r, compassLevel, journeyName)}
+                    </div>
+                  ))}
+                  {shownCompass.length > 3 && (
+                    <p className="text-stone-500">{t("detector.more", { count: shownCompass.length - 3 })}</p>
+                  )}
+                </>
               )}
             </>
           )}
@@ -146,7 +179,7 @@ export const DetectorPanel: FC<Props> = ({
           ) : (
             shownConsumables.slice(0, 3).map((r, i) => (
               <div key={i} className="truncate text-amber-200">
-                {consumableLabel(r, consumableDetectorLevel)}
+                {consumableLabel(r, consumableDetectorLevel, journeyName)}
               </div>
             ))
           )}

--- a/src/ui/atoms/DetectorToggles.spec.tsx
+++ b/src/ui/atoms/DetectorToggles.spec.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, afterEach } from "vitest"
+import { render, screen, fireEvent, cleanup } from "@testing-library/react"
+
+// Identity i18n (the app's real i18n is never initialized in tests) — assertions target keys.
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+const { DetectorToggles } = await import("./DetectorToggles")
+
+afterEach(cleanup)
+
+const props = {
+  activeDetector: null,
+  compassLevel: 0,
+  consumableDetectorLevel: 0,
+  detectionLevel: 0,
+  onSetDetector: () => {},
+}
+
+// These buttons sit inline among the other HUD widgets, so rendering nothing when there's nothing to
+// show matters: an empty wrapper would still take space in that row.
+describe("DetectorToggles visibility", () => {
+  it("renders nothing until at least one detector is unlocked", () => {
+    const { container } = render(<DetectorToggles {...props} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it("shows only the unlocked detectors", () => {
+    render(<DetectorToggles {...props} compassLevel={1} />)
+    expect(screen.getByTitle("detector.compassTitle")).toBeTruthy()
+    expect(screen.queryByTitle("detector.consumableTitle")).toBeNull()
+    expect(screen.queryByTitle("detector.corridorTitle")).toBeNull()
+  })
+
+  it("shows all three when all are unlocked", () => {
+    render(<DetectorToggles {...props} compassLevel={1} consumableDetectorLevel={2} detectionLevel={3} />)
+    expect(screen.getByTitle("detector.compassTitle")).toBeTruthy()
+    expect(screen.getByTitle("detector.consumableTitle")).toBeTruthy()
+    expect(screen.getByTitle("detector.corridorTitle")).toBeTruthy()
+  })
+})
+
+describe("DetectorToggles switching", () => {
+  it("switches a mode on", () => {
+    const onSetDetector = vi.fn()
+    render(<DetectorToggles {...props} compassLevel={1} onSetDetector={onSetDetector} />)
+    fireEvent.click(screen.getByTitle("detector.compassTitle"))
+    expect(onSetDetector).toHaveBeenCalledWith("compass")
+  })
+
+  // Tapping the mode that's already on turns it off, rather than being a no-op.
+  it("switches the active mode back off", () => {
+    const onSetDetector = vi.fn()
+    render(<DetectorToggles {...props} compassLevel={1} activeDetector="compass" onSetDetector={onSetDetector} />)
+    fireEvent.click(screen.getByTitle("detector.compassTitle"))
+    expect(onSetDetector).toHaveBeenCalledWith(null)
+  })
+
+  it("switches straight from one mode to another", () => {
+    const onSetDetector = vi.fn()
+    render(
+      <DetectorToggles
+        {...props}
+        compassLevel={1}
+        detectionLevel={1}
+        activeDetector="compass"
+        onSetDetector={onSetDetector}
+      />
+    )
+    fireEvent.click(screen.getByTitle("detector.corridorTitle"))
+    expect(onSetDetector).toHaveBeenCalledWith("hiddenPassageway")
+  })
+})

--- a/src/ui/atoms/DetectorToggles.stories.tsx
+++ b/src/ui/atoms/DetectorToggles.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import { DetectorToggles } from "./DetectorToggles"
+
+const meta = {
+  title: "UI/DetectorToggles",
+  component: DetectorToggles,
+  tags: ["autodocs"],
+  args: {
+    activeDetector: null,
+    compassLevel: 0,
+    consumableDetectorLevel: 0,
+    detectionLevel: 0,
+    onSetDetector: () => {},
+  },
+} satisfies Meta<typeof DetectorToggles>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+// Nothing unlocked → nothing rendered, so the HUD row keeps no gap for it.
+export const NoPerks: Story = {}
+
+export const CompassOnly: Story = {
+  args: { compassLevel: 1 },
+}
+
+export const AllThree: Story = {
+  args: { compassLevel: 1, consumableDetectorLevel: 1, detectionLevel: 1 },
+}
+
+// The active mode is highlighted, and tapping it again switches back off.
+export const CompassActive: Story = {
+  args: { compassLevel: 1, consumableDetectorLevel: 1, detectionLevel: 1, activeDetector: "compass" },
+}

--- a/src/ui/atoms/DetectorToggles.tsx
+++ b/src/ui/atoms/DetectorToggles.tsx
@@ -1,0 +1,59 @@
+import type { FC } from "react"
+import { useTranslation } from "react-i18next"
+import type { DetectorMode } from "@/game/siteTypes"
+
+// Just the detector mode buttons, split out of DetectorPanel so they can sit INLINE in the HUD row
+// alongside the other widgets (health, coins) instead of claiming a row of their own — a lone
+// compass button was taking a full row while that row had space to spare. The readout they toggle
+// stays in DetectorPanel, which only appears once a mode is active.
+//
+// No card of its own: it sits among the other HUD widgets, which bring their own styling. Tapping
+// through to the map is already handled by the row that hosts it (see SiteHudBar).
+type Props = {
+  activeDetector: DetectorMode
+  compassLevel: number // 0 = not unlocked
+  consumableDetectorLevel: number // 0 = not unlocked
+  detectionLevel: number // 0 = not unlocked
+  onSetDetector: (mode: DetectorMode) => void
+}
+
+const MODE_ICON: Record<string, string> = {
+  compass: "🧭",
+  consumable: "🎒",
+  hiddenPassageway: "👁",
+}
+
+export const DetectorToggles: FC<Props> = ({
+  activeDetector,
+  compassLevel,
+  consumableDetectorLevel,
+  detectionLevel,
+  onSetDetector,
+}) => {
+  const { t } = useTranslation("common")
+  // Nothing unlocked yet → no buttons at all (and no empty gap in the HUD row).
+  if (compassLevel === 0 && consumableDetectorLevel === 0 && detectionLevel === 0) return null
+
+  // Tapping the active mode switches it back off.
+  const toggle = (mode: DetectorMode) => onSetDetector(activeDetector === mode ? null : mode)
+
+  const modeButton = (mode: Exclude<DetectorMode, null>, title: string) => (
+    <button
+      onClick={() => toggle(mode)}
+      className={`rounded px-2 py-1 text-xs ${
+        activeDetector === mode ? "bg-amber-700 text-amber-100" : "bg-stone-800/90 text-stone-300 hover:bg-stone-700"
+      }`}
+      title={title}
+    >
+      {MODE_ICON[mode]}
+    </button>
+  )
+
+  return (
+    <div className="flex gap-2">
+      {compassLevel > 0 && modeButton("compass", t("detector.compassTitle"))}
+      {consumableDetectorLevel > 0 && modeButton("consumable", t("detector.consumableTitle"))}
+      {detectionLevel > 0 && modeButton("hiddenPassageway", t("detector.corridorTitle"))}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

First real play session with a working compass (unblocked by #151) showed the readout itself was never finished — hunting a hieroglyph at compass L1 printed `starter_2 starter_3`. Three gaps against the ladder in `collection-and-detector-design.md` §7.2, which specifies the compass **narrows inward** (L1 = which pyramid, L2 = which floor, L3 = exact cell).

### 1. It leaked internal journey ids

`compassLabel` returned `r.journeyId` verbatim. Localized names already existed in `journeys.json`, so it now reads **"Papyrus Merchant's Route L2"** instead of `starter_2`. The panel receives the lookup as a prop rather than reaching for journey data itself, since it's a presentational atom. The supplies readout gets the same treatment.

### 2. L1 was one notch coarser than designed

It keyed on `journeyId` alone, discarding `levelIdx` — so it named a whole *journey* (up to five pyramids) rather than the one pyramid it actually knew. Now keys on journey + level.

### 3. It gave no reachability signal at all

The scanner filtered on exactly one thing — *"do you already own this piece"* — and swept the entire world. That had become actively misleading: the 0.30.8 holdback design deliberately puts fragments behind ward gates, and #150 re-keyed 13 further pockets to make them live, so the compass routinely pointed at precisely what the design intends you not to have yet.

Marking is **three-valued rather than a reachable flag**, because coverage is partial:

| Mark | Meaning |
|---|---|
| 🔒 | a checkable blocker is in the way — ward key not held, or tier not unlocked |
| 👁 | hidden corridor: needs the passageway detector or luck |
| ❓ | a blocker exists that this readout can't evaluate — tomb map-piece entry, or shop price |
| *(none)* | nothing known stands in the way |

**A bare row is not a promise.** It means "we checked and found nothing", which is all the data supports — the readout doesn't model tomb entry, shop affordability, or journey progression. Claiming reachability outright would be worse than not marking at all, which is why there's an explicit "can't tell" state rather than folding unknowns in with "fine".

## Notable implementation points

- **Scanner reports facts; `useDetector` judges them.** The scanner stays free of player state, so it never needs held-key access. Gate accumulation mirrors `slots.ts`'s own so client and world-gen agree on what gates a slot.
- **The "Looking for 𓎗" header avoids a performance trap.** It needs the target's symbol, which is mod-owned. The obvious fix — widening the target seam from `() => string | null` to `() => {id, symbol} | null` — would have been a real bug: `useDetector` memoises the whole-world scan on that value, so a fresh object each render would rescan every journey continuously, reassembling floors at L3. Added a separate label seam instead, keeping the scan key a bare string. That reasoning is recorded in `compassTarget.ts` so nobody "tidies" it later.
- **Shop detection keys off the section's resolved family, not "came from `rewards[]`"** — puzzle-chain positions also live in `rewards[]`, so the naive test would false-positive on ordinary puzzle rooms. There's a regression test for exactly that.

## Test plan

- [x] `npx tsc -b` — clean
- [x] `npx vitest run` — **996 pass** (was 974; 22 added)
- [x] `npx eslint` on all changed files — clean
- [x] **Verified the L1 test fails against the old journey-only keying** (temporarily reverted to confirm)
- [x] `DetectorPanel.spec.tsx` — L1 pyramid precision, two pyramids of one journey listed separately, the header, and one test per access mark
- [x] `compassScanner.spec.ts` — ward key reported, parent + nested gates accumulated, hidden flagged, shop stock flagged, and a non-shop `rewards[]` *not* flagged
- [x] `useDetector.access.spec.ts` (new) — every verdict, including "needs every key of a chain" and locked-outranks-hidden precedence

**Two expectation changes worth calling out rather than burying:**

1. `DetectorPanel.spec.tsx`'s five existing precision-by-level tests are **intentionally updated** for the L1 change and the name substitution — not quietly rewritten.
2. That spec was **missing `afterEach(cleanup)`**. Without it each test's markup stayed mounted and later queries matched earlier renders; my new tests surfaced it as spurious "multiple elements found" failures. Added, matching the convention in the repo's other specs. Worth knowing it was silently accumulating DOM before.

### Manual check suggested

This is a play-feel change, so it's the real gate: hunt a hieroglyph at compass L1 and confirm real journey names with pyramid numbers, the "Looking for" header, and 🔒 on pieces behind gates you don't hold.

## Known remaining gap

The supplies detector gets the name fix but **keeps its journey-wide L1** — `ConsumableResult` carries no `levelIdx` (it's rebuilt from an edgeId), so pyramid precision there needs the skipped-consumable store to record one first. Left out deliberately rather than half-plumbed; happy to follow up if it's worth it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXmd8roFQg4TkXbJ5jE2Mn)_