### PR TITLE
Fix pyramid interiors that could not be entered

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,5 +111,7 @@ jobs:
         run: yarn lint
       - name: Run tests
         run: yarn test
+      - name: Verify floor layouts
+        run: yarn verify-floors
       - name: yarn build
         run: yarn build # Checks if build can be produced without issues

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Seventeen pyramid interiors that couldn't be entered at all now open normally. Reaching one — the first expert pyramid among them — showed only "Site layout unavailable." with no way forward: its floor plan was being laid out on a grid too small to fit all of its side passages, and the game gave up trying. The affected floors sit in the expert, master and wizard tiers; they get a roomier floor plan, and a few of their side passages wander a little less than intended so everything fits. Every other interior keeps exactly the layout it had, so anything you'd already explored is untouched.
 
 ## 0.31.1 - 2026-08-01
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "generate-pwa-assets": "pwa-assets-generator",
     "generate-world": "tsx scripts/generateWorld.ts && yarn prettier --write src/data/generatedWorld.ts",
     "validate-world": "tsx scripts/generateWorld.ts --validate-only",
+    "verify-floors": "vitest run src/app/SiteMap/worldFloorAssembly.spec.ts",
     "world-info": "tsx scripts/worldInfo.ts",
     "release": "tsx scripts/release.ts",
     "prepare": "husky"

--- a/src/app/SiteMap/floorExploration.spec.ts
+++ b/src/app/SiteMap/floorExploration.spec.ts
@@ -2,8 +2,7 @@ import { describe, expect, it } from "vitest"
 import { assembleFloor, type ResolveKeyRequirements } from "@/game/siteAssembler"
 import { resolveEncounter, getFamilyPlugin } from "@/app/families/familyRegistry"
 import { generatedWorldConfigs } from "@/data/generatedWorld"
-import { generateNewSeed } from "@/game/random"
-import { hashString } from "@/support/hashString"
+import { floorAssemblySeed, persistentInteriorSeed } from "@/game/siteSeed"
 import { computeFloorExploration } from "./floorExploration"
 // Populate the family registry (families, their meta.rewardPriority + resolveKeyRequirements) —
 // exactly what SiteMapScreen/useAssembledFloor rely on. Without this every family resolves to
@@ -16,8 +15,10 @@ const resolveKeyRequirements: ResolveKeyRequirements = (familyId, ctx) =>
 
 const assemble = (journeyId: string, pyramid: number, floor: number) => {
   const cfg = generatedWorldConfigs[journeyId][pyramid][floor]
-  const seed = generateNewSeed(hashString(journeyId), 1)
-  const result = assembleFloor(journeyId, cfg, seed + floor, resolveEncounter, {
+  // The real seed the runtime hands this floor — `pyramid` is a 0-based index here, so the
+  // level number it stands for is one higher (see floorAssemblySeed).
+  const seed = floorAssemblySeed(persistentInteriorSeed(journeyId), pyramid + 1, floor)
+  const result = assembleFloor(journeyId, cfg, seed, resolveEncounter, {
     resolveKeyRequirements,
     floorRef: { journeyId, floorIndex: floor },
   })

--- a/src/app/SiteMap/worldFloorAssembly.spec.ts
+++ b/src/app/SiteMap/worldFloorAssembly.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest"
+import { assembleFloor, type ResolveKeyRequirements } from "@/game/siteAssembler"
+import { resolveEncounter, getFamilyPlugin } from "@/app/families/familyRegistry"
+import { journeys } from "@/data/journeys"
+import { floorAssemblySeed, persistentInteriorSeed } from "@/game/siteSeed"
+import type { FloorConfig } from "@/game/siteTypes"
+// Populate the family registry, exactly as the app does — resolveEncounter's tags (trap in
+// particular) steer the carve, so an unregistered registry would assemble different floors
+// than players get.
+import "@/mods/registerModApps"
+
+// Mirror useAssembledFloor's own resolver, so this walks the identical code path.
+const resolveKeyRequirements: ResolveKeyRequirements = (familyId, ctx) =>
+  getFamilyPlugin(familyId)?.meta.resolveKeyRequirements?.(ctx)
+
+type Floor = { label: string; config: FloorConfig; seed: number; floorIndex: number; journeyId: string }
+
+// Every floor a player can be sent into, at the exact seed the runtime will use.
+// Mirrors PyramidExpedition: one site per level number (1-based), falling back to the first
+// site config when a journey has more levels than site configs, and SiteMapScreen's own
+// per-floor seed offset.
+const allFloors = (): Floor[] => {
+  const floors: Floor[] = []
+  for (const journey of journeys) {
+    const siteConfigs = journey.siteConfigs
+    if (!siteConfigs?.length) continue
+    const siteSeed = persistentInteriorSeed(journey.id)
+    for (let levelNr = 1; levelNr <= journey.levelCount; levelNr++) {
+      const site = siteConfigs[levelNr - 1] ?? siteConfigs[0]
+      site.forEach((config, floorIndex) => {
+        floors.push({
+          label: `${journey.id} level ${levelNr} floor ${floorIndex}`,
+          config,
+          seed: floorAssemblySeed(siteSeed, levelNr, floorIndex),
+          floorIndex,
+          journeyId: journey.id,
+        })
+      })
+    }
+  }
+  return floors
+}
+
+// The guard that was missing when 17 authored floors (expert_1, expert_4, master_1/2/4, and ten
+// wizard floors) shipped unenterable: their layout could not be carved at the one seed the
+// runtime ever hands them, so the interior rendered "Site layout unavailable." for every player,
+// permanently. Nothing else covers this — worldGen/reachability.ts assembles with its own seeds,
+// and no other spec walks the whole baked world. Run standalone via `yarn verify-floors`.
+describe("every authored floor assembles at its runtime seed", () => {
+  it("has floors to check at all (a silent empty sweep would prove nothing)", () => {
+    expect(allFloors().length).toBeGreaterThan(100)
+  })
+
+  // Assembling the whole world is a few hundred maze carves — well past the default 5s budget.
+  it("assembles all of them", () => {
+    const failures = allFloors()
+      .map(floor => {
+        const result = assembleFloor(floor.journeyId, floor.config, floor.seed, resolveEncounter, {
+          resolveKeyRequirements,
+          floorRef: { journeyId: floor.journeyId, floorIndex: floor.floorIndex },
+        })
+        return result.success ? null : `${floor.label} (seed ${floor.seed}): ${JSON.stringify(result.reasons)}`
+      })
+      .filter((f): f is string => f !== null)
+
+    expect(failures, `${failures.length} floor(s) cannot be assembled:\n${failures.join("\n")}`).toEqual([])
+  }, 60_000)
+})

--- a/src/app/state/useJourneys.ts
+++ b/src/app/state/useJourneys.ts
@@ -2,6 +2,7 @@ import { useEffect, useMemo } from "react"
 import { useGameStorage } from "@/support/useGameStorage"
 import { journeys as journeyData, type Journey } from "@/data/journeys"
 import { generateNewSeed } from "@/game/random"
+import { persistentInteriorSeed } from "@/game/siteSeed"
 import { useJourneyTranslations, type TranslatedJourney } from "@/app/translations/useJourneyTranslations"
 import { hashString } from "@/support/hashString"
 import { difficultyCompare, type Difficulty } from "@/data/difficultyLevels"
@@ -138,7 +139,7 @@ export const createJourneysV3Api = ({
     // Persistent interiors (pyramids and tombs) are revisitable sites — their seed must never
     // move, or a completed run's exploredSections stop matching the (now different) layout.
     const randomSeed = isPersistentInterior(journeyInfo)
-      ? generateNewSeed(hashString(journeyId), 1)
+      ? persistentInteriorSeed(journeyId)
       : generateNewSeed(hashString(journeyId), journeyState.completionCount + 1)
     return {
       ...journeyState,

--- a/src/game/siteAssembler.spec.ts
+++ b/src/game/siteAssembler.spec.ts
@@ -833,6 +833,57 @@ describe(assembleFloor, () => {
     }
   })
 
+  // An expert-shaped floor: a handful of main-path puzzles plus eight side sections, each of
+  // which is carved at `paddedChainLength` (6× its content at the default packing). The grid
+  // size used to be derived from the bare content count, so floors like this were sized for a
+  // fraction of what the carve consumes and only assembled when the retry shuffle got lucky —
+  // roughly 40% of seeds failed outright, and 17 real authored floors (expert_1's first pyramid
+  // among them) fell on the wrong side of that coin flip at the one seed the runtime ever gives
+  // them, rendering "Site layout unavailable." forever.
+  const manySideSections = (): FloorConfig => ({
+    pathPuzzles: 3,
+    difficulty: "expert",
+    end: "treasure",
+    exitOrStaircase: "exit",
+    sideSections: Array.from({ length: 8 }, () => ({
+      pathPuzzles: 2,
+      difficulty: "expert" as const,
+      end: "treasure" as const,
+    })),
+  })
+
+  it("property: 100 seeds × a side-section-heavy expert floor all pass validation", () => {
+    for (let seed = 0; seed < 100; seed++) {
+      const result = assembleFloor(`site-${seed}`, manySideSections(), seed)
+      expect(result.success, `seed ${seed} failed assembly`).toBe(true)
+      if (result.success) {
+        const v = validateSite(result.grid)
+        expect(v.valid, `seed ${seed} failed validation: ${JSON.stringify(v)}`).toBe(true)
+      }
+    }
+  }, 30_000)
+
+  it("keeps the layout of floors that already assembled within the original attempt budget", () => {
+    // The recovery re-size must stay invisible to any floor that never needed it. Interiors are
+    // persistent places whose stored exploration is keyed to the layout (see the retry loop's
+    // comment), so a change in grid size or entrance here means someone's saved progress moved.
+    const basic = assembleFloor("site-1", basicConfig(), 42)
+    const pyramid = assembleFloor("site-1", firstPyramid(), 7)
+    if (!basic.success || !pyramid.success) throw new Error("assembly failed")
+    expect([basic.grid.rows, basic.grid.cols, basic.grid.entrancePos, basic.grid.exitPos]).toEqual([
+      13,
+      13,
+      [0, 2],
+      [2, 4],
+    ])
+    expect([pyramid.grid.rows, pyramid.grid.cols, pyramid.grid.entrancePos, pyramid.grid.exitPos]).toEqual([
+      15,
+      15,
+      [12, 0],
+      [8, 8],
+    ])
+  })
+
   it("places every puzzle in a multi-puzzle sub-section at a distinct, valid room", () => {
     // Regression guard: sub-section content used to be indexed as `(contentStart + pi) * 2`
     // instead of `contentStart + pi` — harmless for a single-puzzle sub-section (index 0

--- a/src/game/siteAssembler.ts
+++ b/src/game/siteAssembler.ts
@@ -133,6 +133,15 @@ const DEFAULT_STRAIGHT_BIAS = 0.65
 // FloorConfig.packing.
 const DEFAULT_PACKING = 1
 
+// Maze carving is a per-attempt gamble (each attempt reshuffles branch points and section
+// order), so assembleFloor retries. The first RECOVERY_ATTEMPT attempts run at the original
+// sizing; the rest re-size the grid to what the carve actually needs and wind the side chains
+// down. Measured over every authored floor × 30 seeds each: all of them assemble, the slowest
+// at attempt 37, so the tail of the budget is headroom rather than something floors rely on.
+// See the retry loop in assembleFloor for why the first stretch is deliberately frozen.
+const RECOVERY_ATTEMPT = 30
+const ASSEMBLY_ATTEMPTS = 60
+
 // Generate a perfect DFS maze on an N×N grid starting from (entR, entC).
 // Returns adjacency function, BFS path from entrance to the chosen main-path endpoint, and
 // passages set. `targetDistance` picks the main path's length: the *true* farthest node in
@@ -334,7 +343,7 @@ export const assembleFloor = (
   // The auto-injection above guarantees a free host whenever one's needed — this is a
   // structural safety net, not an expected path: if a floor-key gate still has nowhere to
   // put its key, that's an unsolvable floor, not a per-seed maze fluke, so it fails
-  // immediately rather than burning 30 retry attempts on something a different seed can't fix.
+  // immediately rather than burning every retry attempt on something a different seed can't fix.
   if (gatedFloorKeyIdxs.length > 0 && ungatedIdxs.length === 0) {
     return { success: false, reasons: [{ type: "noUngatedSectionForKey" }] }
   }
@@ -388,8 +397,32 @@ export const assembleFloor = (
   // `corridorStraightness`, however spacious or winding the rest of the floor got. Reusing
   // the identical formula (not a separate, lighter-touch one) keeps one mental model for
   // "how long is a walk" everywhere in the DSL, main path or side path alike.
+  //
+  // `chainPacking` is `packing` for every ordinary attempt; the recovery phase in the retry
+  // loop below winds it down, trading a side path's cosmetic wandering for a layout that fits
+  // at all. Nothing outside that loop should change it.
+  let chainPacking = packing
   const paddedChainLength = (contentCellsCount: number): number =>
-    Math.max(contentCellsCount, Math.round(contentCellsCount * (1 + 5 * packing)))
+    Math.max(contentCellsCount, Math.round(contentCellsCount * (1 + 5 * chainPacking)))
+
+  // What the carve *actually* consumes, as opposed to `minCells`'s bare content count: every
+  // side-section and sub-section chain is carved at its `paddedChainLength`, which is 6× its
+  // content at packing=1 and 11× at packing=2. Sizing the grid off `minCells` therefore
+  // undershoots badly on floors with many side sections (expert and up), and the retry loop
+  // below has to rescue them by growing N on shuffle luck — for 17 authored floors it never
+  // did, and they failed outright with `layoutNotFound`. This is the honest figure, and it
+  // moves with `chainPacking`, so the recovery phase re-sizes the grid to whatever it has
+  // wound the chains down to rather than leaving a shrunken floor rattling around a huge grid.
+  const carvedCells = (): number =>
+    mainPathCells +
+    sideSections.reduce((sum, sec) => {
+      const secCells = paddedChainLength(sec.pathPuzzles + 1 + (sec.gate ? 1 : 0))
+      const subCells = (sec.sideSections ?? []).reduce(
+        (s2, sub) => s2 + paddedChainLength(sub.pathPuzzles + 1 + (sub.gate ? 1 : 0)),
+        0
+      )
+      return sum + secCells + subCells
+    }, 0)
 
   // Derive odd grid size. Only even/even positions can hold a real node (see NODE_STEP
   // above), so usable node capacity is ((N+1)/2)^2, not N^2 — the grid needs to be
@@ -401,22 +434,46 @@ export const assembleFloor = (
   // `targetDistance` hops (a DFS-maze's diameter is typically a large fraction of its
   // total node count, so `targetDistance * 2` is a generous safety margin — if it's still
   // not enough, the retry loop below grows N further; buildMaze never fails outright).
-  let N = 3
-  while (
-    Math.pow((N + 1) / 2, 2) <
-    Math.max(
-      minCells +
-        packing *
-          (minCells * 3 + (N + 1) / 2 + sideSections.length + expectedFootprintRooms * FOOTPRINT_SLACK_PER_ROOM),
-      targetDistance * 2
+  const deriveN = (contentCells: number): number => {
+    let n = 3
+    while (
+      Math.pow((n + 1) / 2, 2) <
+      Math.max(
+        contentCells +
+          packing *
+            (contentCells * 3 + (n + 1) / 2 + sideSections.length + expectedFootprintRooms * FOOTPRINT_SLACK_PER_ROOM),
+        targetDistance * 2
+      )
     )
-  )
-    N += 2
+      n += 2
+    return n
+  }
+  const startingN = deriveN(minCells)
+  let N = startingN
 
   const nid = (r: number, c: number) => `${siteId}-${r}-${c}`
 
-  for (let attempt = 0; attempt < 30; attempt++) {
-    if (attempt > 0 && attempt % 4 === 0) N += 2
+  // Attempts 0..RECOVERY_ATTEMPT-1 are FROZEN: same starting N, same growth cadence, same
+  // chain lengths, same per-attempt seed as before the recovery phase existed. A pyramid/tomb
+  // interior is a persistent, revisitable place whose stored exploredSections and position are
+  // keyed to its layout (useJourneys' isPersistentInterior), so re-sizing a floor that already
+  // assembles would silently invalidate a player's progress on it.
+  //
+  // Only a floor that has exhausted the original budget — one nobody can currently enter at
+  // all, so there is no progress to protect — enters recovery. There, each attempt sizes the
+  // grid to what the carve genuinely needs (`carvedCells`, the figure the original sizing
+  // should always have used) while winding `chainPacking` down from `packing` to 0, so the
+  // floor is retried across the whole spectrum from "every side path as windy as authored" to
+  // "every side path at its bare content length". The last attempt is therefore the most
+  // permissive shape this config can take, which is what makes the phase converge instead of
+  // just rerolling the same too-tight puzzle. Cosmetically shorter side paths on a floor that
+  // was previously unreachable is a plain win.
+  for (let attempt = 0; attempt < ASSEMBLY_ATTEMPTS; attempt++) {
+    if (attempt >= RECOVERY_ATTEMPT) {
+      const steps = Math.max(1, ASSEMBLY_ATTEMPTS - RECOVERY_ATTEMPT - 1)
+      chainPacking = (packing * (steps - (attempt - RECOVERY_ATTEMPT))) / steps
+      N = Math.max(startingN, deriveN(carvedCells()))
+    } else if (attempt > 0 && attempt % 4 === 0) N += 2
 
     const rand = mulberry32(seed + attempt * 7919)
     const pkey = makePkey(N)
@@ -680,10 +737,21 @@ export const assembleFloor = (
         return { success: false, reasons: [{ type: "noUngatedSectionForKey" }] }
       }
 
-      // Branch candidates: parent section cells (excluding end cell)
+      // Branch candidates: parent section cells (excluding end cell). In recovery a cell whose
+      // only opening has to be carved (see the fallback below) counts too — pre-filtering it out
+      // here would put it out of that fallback's reach.
+      const hasCarveableNeighbor = (pr: number, pc: number) =>
+        DIRS2.some(
+          ([dr, dc]) =>
+            pr + dr >= 0 && pr + dr < N && pc + dc >= 0 && pc + dc < N && !usedCells.has(`${pr + dr},${pc + dc}`)
+        )
       const subBranchCandidates = group.cells
         .slice(0, -1)
-        .filter(([pr, pc]) => neighbors(pr, pc).some(([ar, ac]) => !usedCells.has(`${ar},${ac}`)))
+        .filter(
+          ([pr, pc]) =>
+            neighbors(pr, pc).some(([ar, ac]) => !usedCells.has(`${ar},${ac}`)) ||
+            (attempt >= RECOVERY_ATTEMPT && hasCarveableNeighbor(pr, pc))
+        )
         .sort(() => rand() - 0.5)
 
       const placedSubs: Array<{
@@ -698,9 +766,34 @@ export const assembleFloor = (
         let placed = false
 
         for (const [pcr, pcc] of subBranchCandidates) {
-          const freeAdj = neighbors(pcr, pcc)
+          let freeAdj = neighbors(pcr, pcc)
             .filter(([ar, ac]) => !usedCells.has(`${ar},${ac}`))
             .sort(() => rand() - 0.5)
+
+          // In recovery, carve a brand-new passage out of the parent chain rather than give up
+          // on this candidate — the same departure from "perfect maze" the top-level branch loop
+          // above already makes, and for the same reason. Sub-sections not having it is what left
+          // the recovery phase stuck: by the time they're placed, earlier chains have boxed the
+          // parent in, and a sub-section needing a single free cell would fail the whole attempt
+          // with plenty of grid still empty one wall away. Kept to recovery so the frozen
+          // attempts stay byte-identical.
+          if (freeAdj.length === 0 && attempt >= RECOVERY_ATTEMPT) {
+            const carveCandidates = DIRS2.map(([dr, dc]): [number, number] => [pcr + dr, pcc + dc])
+              .filter(
+                ([nr, nc]) =>
+                  nr >= 0 &&
+                  nr < N &&
+                  nc >= 0 &&
+                  nc < N &&
+                  !usedCells.has(`${nr},${nc}`) &&
+                  !passages.has(pkey(pcr, pcc, nr, nc))
+              )
+              .sort(() => rand() - 0.5)
+            if (carveCandidates.length > 0) {
+              passages.add(pkey(pcr, pcc, carveCandidates[0][0], carveCandidates[0][1]))
+              freeAdj = [carveCandidates[0]]
+            }
+          }
           if (freeAdj.length === 0) continue
           for (const [startR, startC] of freeAdj) {
             usedCells.add(`${startR},${startC}`)

--- a/src/game/siteSeed.ts
+++ b/src/game/siteSeed.ts
@@ -1,0 +1,21 @@
+import { generateNewSeed } from "./random"
+import { hashString } from "@/support/hashString"
+
+// The seed a site's layout is assembled from, in one place. It used to be spread over three
+// files — useJourneys derived the per-journey seed, PyramidExpedition added the level number,
+// useAssembledFloor added the floor index — which is exactly how the one spec that assembled
+// real floors drifted out of sync with the runtime (it omitted the level number and so never
+// exercised the seeds players actually get). Anything that wants to check a real floor's layout
+// must go through here.
+
+// Persistent interiors (pyramids and tombs with a site config) are revisitable places: their
+// seed must never move, or a run's stored exploredSections stop matching the (now different)
+// layout. So it's derived from the journey id alone, at a fixed index — NOT from
+// completionCount, which is what a replayable exterior-only journey uses.
+export const persistentInteriorSeed = (journeyId: string): number => generateNewSeed(hashString(journeyId), 1)
+
+// One floor's assembly seed within a site. `levelNr` is 1-based (it's the journey's level
+// counter, not an array index) and separates the sites of a multi-pyramid journey; `floorIndex`
+// separates the floors within one site.
+export const floorAssemblySeed = (siteSeed: number, levelNr: number, floorIndex: number): number =>
+  siteSeed + levelNr + floorIndex

--- a/src/worldGen/configBuilder.integration.spec.ts
+++ b/src/worldGen/configBuilder.integration.spec.ts
@@ -89,6 +89,11 @@ const countRewards = (configs: Record<string, SiteConfig[]>) => {
   return { mapPieces, mosaicPieces }
 }
 
+// A full world build assembles every reachable floor, so these budgets are seconds, not
+// milliseconds — and they have to hold on a CI runner well slower than a dev machine. They were
+// already within 40% of the old 20s ceiling before the assembler's recovery phase (which resolves
+// floors reachability used to silently skip) made a build ~30% dearer, so this leaves real headroom
+// rather than something to shave again the next time the world grows.
 describe("buildConfigs golden guard", () => {
   it("hits reward targets exactly (map + mosaic from their mods)", () => {
     const configs = buildRealConfigs()
@@ -96,13 +101,13 @@ describe("buildConfigs golden guard", () => {
       mapPieces: WORLD_TARGETS.mapPieceRewards,
       mosaicPieces: MOSAIC_TOTAL,
     })
-  }, 20000)
+  }, 90_000)
 
   it("is deterministic across runs", () => {
     const first = buildRealConfigs()
     const second = buildRealConfigs()
     expect(second).toEqual(first)
-  }, 20000)
+  }, 90_000)
 })
 
 describe("tomb floor linking — ward-path shortcuts", () => {
@@ -111,7 +116,7 @@ describe("tomb floor linking — ward-path shortcuts", () => {
   let floors: FloorConfig[]
   beforeAll(() => {
     floors = buildRealConfigs().junior_treasure_tomb[0]
-  })
+  }, 90_000)
 
   it("every floor's main path ends in a real exit, not an auto-chained stairhead", () => {
     for (const floor of floors) expect(floor.exitOrStaircase).toBe("exit")

--- a/src/worldGen/reachability.ts
+++ b/src/worldGen/reachability.ts
@@ -143,7 +143,19 @@ export const reachableFloorsInSite = (
       })
       cache?.set(cacheKey, result)
     }
-    if (!result.success) continue
+    // A floor that won't assemble used to be skipped silently, which quietly reclassified it as
+    // unreachable: generation then placed no content behind it and reported nothing, so
+    // unenterable floors shipped unnoticed. It's a data bug, so say so and stop. Note this
+    // assembles at `defaultSeedFor`, NOT the seed the runtime uses (game/siteSeed.ts) — a floor
+    // passing here says nothing about what players get, which is what worldFloorAssembly.spec.ts
+    // (`yarn verify-floors`) is for.
+    if (!result.success) {
+      throw new Error(
+        `Floor ${floorKey({ ...ref, floorIndex: i })} cannot be assembled (seed ${seed + i}): ${JSON.stringify(
+          result.reasons
+        )}`
+      )
+    }
 
     const {
       keys: expandedKeys,


### PR DESCRIPTION
Reported from play: reaching expert and tapping into the first pyramid showed a bare red `Site layout unavailable.` and nothing else.

Rebased onto current `main` (`bca2e81`, v0.31.1), so this PR is now only the two commits below — the branch previously also carried #147 and #153, both of which are already merged.

## The bug

That string is `SiteMapScreen.tsx`'s null-grid guard, which fires only when `assembleFloor()` returns `success: false`. For a persistent interior the seed is fixed — `generateNewSeed(hashString(journeyId), 1) + levelNr + floorIndex` — so this was never an unlucky roll: the floor was unenterable for every player, permanently.

Sweeping all 206 baked floors at their exact runtime seeds found **17 failures**: `expert_1` #1/#3, `expert_4` #4, `master_1` #3, `master_2` #3, `master_4` #1/#3, and ten wizard floors. All `layoutNotFound`, all dying in side-section chain placement rather than validation.

**Root cause:** the grid size is derived from `minCells`, which counts each side section's bare content cells — but the carve consumes `paddedChainLength`, i.e. `cells × (1 + 5 × packing)`: 6× at the default packing, 9× at `packing: 1.6`, 11× at `packing: 2`. Floors with many side sections (expert and up) were sized for a fraction of what they need. Only 115 of 189 floors assembled on attempt 0; the rest survived on retry-shuffle luck, and for these 17 the 30-attempt budget ran out.

Nothing caught it. `worldGen/reachability.ts` did `if (!result.success) continue`, silently reclassifying an unassemblable floor as unreachable, and it assembles at its own seeds anyway. The one spec that assembled real floors omitted the `+ levelNr` the runtime adds and only covered `starter_1`.

## The fix

Correcting the sizing outright would move layouts that already work — and an interior is a persistent, revisitable place whose stored `exploredSections` and `position` are keyed to its layout, so that would quietly invalidate saved progress. Instead:

- **Attempts 0–29 are frozen** — same starting size, growth cadence, chain lengths and per-attempt seed as before. Verified by assembling every floor with the old and new code and hashing the grids: **189 identical, 0 changed, 17 recovered.**
- **A recovery phase past attempt 30**, which only a floor nobody can currently enter ever reaches. Each attempt sizes the grid to what the carve genuinely needs (`carvedCells` — the figure the original sizing should always have used) while winding side-chain padding down from `packing` to 0, so the config is retried across the whole spectrum from "as windy as authored" to "bare content length". That is what makes the phase converge instead of rerolling the same too-tight puzzle.
- **Sub-sections get the carve-a-new-passage fallback** top-level sections already had. Without it, a sub-section needing a single free cell could fail a whole attempt with the grid empty one wall away — the remaining blocker once sizing was fixed.

All 17 floors now assemble, the slowest at attempt 37 of 60, grids up to N=95, ≤270 ms per floor. Across every authored floor × 20 seeds each (4120 combinations) there are now **zero** failures, down from 24.

## Guard rails

- `yarn verify-floors` (new `src/app/SiteMap/worldFloorAssembly.spec.ts`) sweeps every baked floor at its real runtime seed, using the same family registry the app does. Wired into CI as its own step so a regression names itself.
- The seed formula now lives in `src/game/siteSeed.ts` instead of being spread over three files — which is exactly how `floorExploration.spec.ts` had drifted out of sync with the runtime.
- `worldGen/reachability.ts` throws instead of silently skipping a floor it cannot assemble.

## The second commit

CI first failed on `configBuilder.integration.spec.ts` **timing out**, not on an assertion. A full world build is ~30% dearer now (24s → 31s locally) because floors reachability used to skip silently now assemble and their content takes part in placement; those tests were already at 12s against a 20s ceiling on a machine faster than the runner, and the `beforeAll` had only the default 10s while doing a whole build of its own. That commit raises those three budgets to 90s and changes nothing else. The per-floor assembly cache a build already threads through means each floor is still assembled once, so there is no repeated work to remove.

## Verification

- `yarn verify-floors` — 206/206 floors assemble.
- Old-vs-new grid hash comparison against current `main`'s assembler — 189 identical, 0 changed, 17 recovered.
- Full suite (1017 tests), `check-types`, `build`, `validate-world`, prettier at the lockfile's pinned version.
- Ran the app: the JourneyInspector story at `expert_1`'s real seed draws a real, connected map for pyramid 1 and pyramid 3 instead of failing.

## Flagged, not fixed here

- `SiteMapScreen.tsx`'s staircase teleport still does `if (!result.success) continue`, so it would silently no-op rather than report a problem.
- `Site layout unavailable.` is still a bare dead end with no explanation.
- `generateNewSeed` returns values past `Number.MAX_SAFE_INTEGER`, so `seed + levelNr + floorIndex` loses precision and adjacent sites can share an effective seed. Harmless today; fixing it would reshuffle every layout.
- 26 baked floors carry `packing: 1.6` and 2 carry `packing: 2` on top of 8–16 side sections — that pressure is what pushes recovered grids to N≈95. Toning it down in `worldGen/spec` would give tighter maps, at the cost of a world regen.