### PR TITLE
Give each mosaic register its own glass colour in the loot popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The first stall you ever reach, he owns up to it being his and pitches what's on the counter. Later stalls get the short greeting.
 - Fez greets a shop as his own stall instead of as a customer.
 - What you sell at the stall is "trinkets", not "junk" — his offer, the sell section, the Collection category.
+- A mosaic piece you find shows its scene's own colour of glass, so you can tell which of the five it belongs to — on Fez's counter too.
 
 ## 0.31.5 - 2026-08-02
 ### Changed

--- a/src/mods/mosaic/app/rewardDisplay.spec.ts
+++ b/src/mods/mosaic/app/rewardDisplay.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 import { registerMosaicRewardDisplay } from "./rewardDisplay"
 import { getRewardHandler } from "@/app/SiteMap/rewardHandlerRegistry"
+import { MOSAIC_TIERS } from "../game/mosaicCurrency"
 
 describe("mosaic reward display", () => {
   it("builds popup text from (reward, t) — first arg is the reward, not the translator", () => {
@@ -11,10 +12,26 @@ describe("mosaic reward display", () => {
     // Call it exactly as rewardText/RewardFlow does: (reward, t). A lone-`t` handler would bind the
     // reward object to its first param and call it as a function here — the black-screen crash.
     const t = (key: string) => `t:${key}`
-    const text = handler!.text({ type: "mosaicPiece" }, t)
+    const text = handler!.text({ type: "mosaicPiece", tier: "starter" }, t)
 
     expect(text.itemName).toBe("t:chest.mosaicPiece")
     expect(text.itemDescription).toBe("t:chest.mosaicPieceDescription")
-    expect(text.icon).toBe("🟦")
+  })
+
+  it("gives every register its own glass colour, so a popup says which panel it fills", () => {
+    registerMosaicRewardDisplay()
+    const handler = getRewardHandler("mosaicPiece")
+    const t = (key: string) => `t:${key}`
+
+    const icons = MOSAIC_TIERS.map(tier => handler!.text({ type: "mosaicPiece", tier }, t).icon)
+    expect(new Set(icons).size).toBe(MOSAIC_TIERS.length)
+  })
+
+  it("falls back to the generic icon for a piece with no tier", () => {
+    registerMosaicRewardDisplay()
+    const handler = getRewardHandler("mosaicPiece")
+    const t = (key: string) => `t:${key}`
+
+    expect(handler!.text({ type: "mosaicPiece" }, t).icon).toBe("🔷")
   })
 })

--- a/src/mods/mosaic/app/rewardDisplay.ts
+++ b/src/mods/mosaic/app/rewardDisplay.ts
@@ -1,4 +1,21 @@
 import { registerRewardHandler } from "@/app/SiteMap/rewardHandlerRegistry"
+import { MOSAIC_TIERS, type MosaicTier } from "../game/mosaicCurrency"
+
+// One glass colour per register, echoing its scene: lapis at the guardian's door, ochre for the
+// scribe's first lesson, sunlight in the temple hall, green for the king, a cut facet for the
+// heart weighed against a feather. Cosmetic — the piece's own tier picks the icon, so a popup
+// says at a glance which of the five panels just came closer.
+const ICON_BY_TIER: Record<MosaicTier, string> = {
+  starter: "🔵",
+  junior: "🔶",
+  expert: "🟡",
+  master: "🟢",
+  wizard: "💠",
+}
+
+const GENERIC_ICON = "🔷"
+
+const isMosaicTier = (tier: unknown): tier is MosaicTier => MOSAIC_TIERS.includes(tier as MosaicTier)
 
 // The mosaicPiece reward's synchronous popup text/emoji (generic RewardFlow fallback). It uses the
 // generic icon path — no rich display registration needed. The claim EFFECT is mosaic's reward
@@ -6,14 +23,17 @@ import { registerRewardHandler } from "@/app/SiteMap/rewardHandlerRegistry"
 export const registerMosaicRewardDisplay = () => {
   registerRewardHandler({
     type: "mosaicPiece",
-    emoji: "🔷", // no dedicated icon; text().icon below is the real one
+    emoji: GENERIC_ICON, // no dedicated icon; text().icon below is the real one
     // Signature is (reward, t) — the first arg is the reward, `t` is the translator. Taking a lone
     // `t =>` param bound it to the reward object, so t("chest.mosaicPiece") called the reward as a
     // function and crashed the reward popup (black screen) on the first mosaic a player ever opened.
-    text: (_reward, t) => ({
-      itemName: t("chest.mosaicPiece"),
-      itemDescription: t("chest.mosaicPieceDescription"),
-      icon: "🟦",
-    }),
+    text: (reward, t) => {
+      const tier: unknown = reward.tier
+      return {
+        itemName: t("chest.mosaicPiece"),
+        itemDescription: t("chest.mosaicPieceDescription"),
+        icon: isMosaicTier(tier) ? ICON_BY_TIER[tier] : GENERIC_ICON,
+      }
+    },
   })
 }


### PR DESCRIPTION
## Why

Every mosaic piece popped the same 🟦 with the same name and description, so finding one told you nothing about which of the five scenes it filled. The reward already carries its tier — `toReward: () => ({ type: "mosaicPiece", tier })` — but the display handler ignored it, taking the reward as `_reward`.

## What changed

One icon per register, echoing its scene:

| register | panel | glass |
|---|---|---|
| starter | The Guardian at the Door | 🔵 lapis |
| junior | The First Lesson | 🔶 ochre |
| expert | Letting the Sun In | 🟡 sunlight |
| master | The Green King | 🟢 green |
| wizard | The Feather and the Heart | 💠 cut facet |

The colours are arbitrary-but-suggestive; what matters is that they read as five distinct pieces at popup size.

A piece with no tier falls back to the generic 🔷 — defensive only, every generated piece carries one.

**Fez's counter picks this up for free.** Shop stock renders through the same `rewardText` handler (`fezShop/plugin.tsx:71`), so a mosaic tile for sale now shows its panel's colour too.

## Not changed

Name and description are still shared ("Mosaic Piece"). The panel names exist (`mosaic.panel.*`) and the popup could say *"Glass for The Green King"*, but that's a copy decision, not a colour one — say the word and it's a small follow-up.

`MOSAIC_CURRENCY_METAS` still carries one shared `icon: "🟦"`. Left alone deliberately: `getCurrencyMeta` has no call sites outside its own spec, so `CurrencyMeta.icon` and `displayName` are currently unrendered. (That also explains why `displayName: currency.mosaicPiece.${tier}` points at a locale key that doesn't exist — no `currency.*` block is defined in `common.json` for any mod. Worth its own look sometime.)

## Testing

`yarn vitest run` — 1153 passed, lint + types clean. Two specs added: all five registers get distinct icons, and the untiered fallback.

Worth an eyeball in the app: the icons at real popup size, and a shop carrying a mosaic tile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012x8hXvnGXsRVbxCV38m3dp