### PR TITLE
Map zoom: anchor on the pinch, drop the per-frame re-render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Pinch-zooming the site map is smooth, and zooms toward your fingers instead of the middle of the screen.
 
 ## 0.32.0 - 2026-08-08
 ### Added

--- a/src/app/SiteMap/SiteMapView.spec.tsx
+++ b/src/app/SiteMap/SiteMapView.spec.tsx
@@ -368,11 +368,17 @@ describe("SiteMapView — long corridor click target", () => {
 describe("SiteMapView — zoom", () => {
   Element.prototype.scrollTo = vi.fn()
 
-  const svgSize = (container: HTMLElement) => {
-    const svg = container.querySelector("svg")!
-    return { width: Number(svg.getAttribute("width")), height: Number(svg.getAttribute("height")) }
+  // The zoom is applied to the DOM directly (see useMapZoom): the map scales by transform, and the
+  // sizer box around it carries the scaled footprint that the scroll area measures.
+  const mapScale = (container: HTMLElement) => {
+    const transform = container.querySelector("svg")!.style.transform
+    return Number(/scale\(([\d.]+)\)/.exec(transform)?.[1])
   }
-  const scrollArea = (container: HTMLElement) => container.querySelector("div")!
+  const sizerSize = (container: HTMLElement) => {
+    const sizer = container.querySelector("svg")!.parentElement!
+    return { width: parseFloat(sizer.style.width), height: parseFloat(sizer.style.height) }
+  }
+  const scrollArea = (container: HTMLElement) => container.firstElementChild as HTMLElement
 
   const wheel = (container: HTMLElement, deltaY: number, times = 1) => {
     for (let i = 0; i < times; i++) {
@@ -386,43 +392,55 @@ describe("SiteMapView — zoom", () => {
       [room("reachable"), room("reachable")],
     ])
 
-  it("scales the map up on a ctrl + wheel zoom-in, keeping its proportions", () => {
+  it("scales the map up on a ctrl + wheel zoom-in, and grows its footprint to match", () => {
     const { container } = render(<SiteMapView grid={twoByTwo()} />)
-    const before = svgSize(container)
+    const before = sizerSize(container)
+    expect(mapScale(container)).toBe(1)
 
     wheel(container, -100)
 
-    const after = svgSize(container)
-    expect(after.width).toBeGreaterThan(before.width)
-    expect(after.width / after.height).toBeCloseTo(before.width / before.height)
+    const scale = mapScale(container)
+    expect(scale).toBeGreaterThan(1)
+    expect(sizerSize(container).width).toBeCloseTo(before.width * scale)
+    expect(sizerSize(container).height).toBeCloseTo(before.height * scale)
   })
 
   it("leaves a plain wheel to scroll the map instead of zooming it", () => {
     const { container } = render(<SiteMapView grid={twoByTwo()} />)
-    const before = svgSize(container)
 
     fireEvent.wheel(scrollArea(container), { deltaY: -100, clientX: 0, clientY: 0 })
 
-    expect(svgSize(container)).toEqual(before)
+    expect(mapScale(container)).toBe(1)
   })
 
   it("stops zooming at the limits, so the map can't be lost off either end", () => {
     const { container } = render(<SiteMapView grid={twoByTwo()} />)
-    const unzoomed = svgSize(container)
 
     wheel(container, -400, 20)
-    expect(svgSize(container).width).toBeCloseTo(unzoomed.width * MAX_ZOOM)
+    expect(mapScale(container)).toBeCloseTo(MAX_ZOOM)
 
     wheel(container, 400, 40)
-    expect(svgSize(container).width).toBeCloseTo(unzoomed.width * MIN_ZOOM)
+    expect(mapScale(container)).toBeCloseTo(MIN_ZOOM)
+  })
+
+  it("keeps the zoom across a re-render, which would otherwise reset the footprint it wrote", () => {
+    const { container, rerender } = render(<SiteMapView grid={twoByTwo()} />)
+    wheel(container, -100)
+    const zoomed = { scale: mapScale(container), sizer: sizerSize(container) }
+
+    rerender(<SiteMapView grid={twoByTwo()} explorerPos={[0, 0]} />)
+
+    expect(mapScale(container)).toBe(zoomed.scale)
+    expect(sizerSize(container)).toEqual(zoomed.sizer)
   })
 })
 
 describe("SiteMapView — pinch zoom", () => {
   Element.prototype.scrollTo = vi.fn()
 
-  const svgWidth = (container: HTMLElement) => Number(container.querySelector("svg")!.getAttribute("width"))
-  const scrollArea = (container: HTMLElement) => container.querySelector("div")!
+  const mapScale = (container: HTMLElement) =>
+    Number(/scale\(([\d.]+)\)/.exec(container.querySelector("svg")!.style.transform)?.[1])
+  const scrollArea = (container: HTMLElement) => container.firstElementChild as HTMLElement
   const fingers = (spread: number) => [
     { clientX: 100 - spread, clientY: 100 },
     { clientX: 100 + spread, clientY: 100 },
@@ -430,40 +448,38 @@ describe("SiteMapView — pinch zoom", () => {
 
   it("grows the map as two fingers spread apart", () => {
     const { container } = render(<SiteMapView grid={makeGrid([[room("reachable"), room("reachable")]])} />)
-    const before = svgWidth(container)
 
     fireEvent.touchStart(scrollArea(container), { touches: fingers(50) })
     fireEvent.touchMove(scrollArea(container), { touches: fingers(100) })
 
-    expect(svgWidth(container)).toBeCloseTo(before * 2)
+    expect(mapScale(container)).toBeCloseTo(2)
   })
 
   it("ignores a one-finger drag, which still scrolls the map", () => {
     const { container } = render(<SiteMapView grid={makeGrid([[room("reachable"), room("reachable")]])} />)
-    const before = svgWidth(container)
 
     fireEvent.touchStart(scrollArea(container), { touches: [{ clientX: 100, clientY: 100 }] })
     fireEvent.touchMove(scrollArea(container), { touches: [{ clientX: 140, clientY: 100 }] })
 
-    expect(svgWidth(container)).toBe(before)
+    expect(mapScale(container)).toBe(1)
   })
 })
 
 describe("SiteMapView — zoom reset", () => {
   Element.prototype.scrollTo = vi.fn()
 
-  const svgWidth = (container: HTMLElement) => Number(container.querySelector("svg")!.getAttribute("width"))
-  const scrollArea = (container: HTMLElement) => container.querySelector("div")!
+  const mapScale = (container: HTMLElement) =>
+    Number(/scale\(([\d.]+)\)/.exec(container.querySelector("svg")!.style.transform)?.[1])
+  const scrollArea = (container: HTMLElement) => container.firstElementChild as HTMLElement
 
   it("returns to the default zoom on a double-click, however far the map was zoomed", () => {
     const { container } = render(<SiteMapView grid={makeGrid([[room("reachable"), room("reachable")]])} />)
-    const unzoomed = svgWidth(container)
 
     fireEvent.wheel(scrollArea(container), { deltaY: -300, ctrlKey: true, clientX: 0, clientY: 0 })
-    expect(svgWidth(container)).toBeGreaterThan(unzoomed)
+    expect(mapScale(container)).toBeGreaterThan(1)
 
     fireEvent.dblClick(scrollArea(container), { clientX: 0, clientY: 0 })
 
-    expect(svgWidth(container)).toBe(unzoomed)
+    expect(mapScale(container)).toBe(1)
   })
 })

--- a/src/app/SiteMap/SiteMapView.tsx
+++ b/src/app/SiteMap/SiteMapView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import type {
   CellState,
   DecorationKind,
@@ -964,8 +964,6 @@ export const SiteMapView = ({
   className,
 }: Props) => {
   const grid = revealAllCells ? revealAll(gridProp) : gridProp
-  const scrollRef = useRef<HTMLDivElement>(null)
-  const svgRef = useRef<SVGSVGElement>(null)
   const claims = useMemo(() => buildRoomClaims(grid), [grid])
   // Corridor-run markers track the explorer dot's visual position, not the logical one:
   // hide them the instant a run target is clicked (the player has committed to a
@@ -987,17 +985,18 @@ export const SiteMapView = ({
   const svgWidth = grid.cols * CELL + PAD * 2
   const svgHeight = grid.rows * CELL + PAD * 2
 
-  const { zoom, zoomHandlers } = useMapZoom(scrollRef)
+  const { scrollRef, sizerRef, mapRef, zoomRef, scrollHandlers } = useMapZoom(svgWidth, svgHeight)
 
   useEffect(() => {
-    if (!explorerPos || !scrollRef.current || !svgRef.current) return
+    if (!explorerPos || !scrollRef.current || !sizerRef.current) return
     const el = scrollRef.current
     const elRect = el.getBoundingClientRect()
-    const svgRect = svgRef.current.getBoundingClientRect()
-    // Origin accounts for the svg's own offset within the scroll area (e.g. safe-area padding, centering margin)
-    const originX = svgRect.left - elRect.left + el.scrollLeft
-    const originY = svgRect.top - elRect.top + el.scrollTop
+    const mapRect = sizerRef.current.getBoundingClientRect()
+    // Origin accounts for the map's own offset within the scroll area (e.g. safe-area padding, centering margin)
+    const originX = mapRect.left - elRect.left + el.scrollLeft
+    const originY = mapRect.top - elRect.top + el.scrollTop
     // Cell coordinates are in unzoomed SVG units; the rendered map is `zoom` times that size.
+    const zoom = zoomRef.current
     const x = originX + (PAD + explorerPos[1] * CELL + CELL / 2) * zoom
     const y = originY + (PAD + explorerPos[0] * CELL + CELL / 2) * zoom
     el.scrollTo({ left: x - el.clientWidth / 2, top: y - el.clientHeight / 2, behavior: "smooth" })
@@ -1007,180 +1006,185 @@ export const SiteMapView = ({
   return (
     <div
       ref={scrollRef}
-      {...zoomHandlers}
+      {...scrollHandlers}
       className={`flex overflow-auto pt-safe-top pr-safe-right pb-safe-bottom pl-safe-left${className ? ` ${className}` : ""}`}
     >
-      <svg
-        ref={svgRef}
-        width={svgWidth * zoom}
-        height={svgHeight * zoom}
-        viewBox={`0 0 ${svgWidth} ${svgHeight}`}
-        role="img"
-        aria-label="site map"
-        className="m-auto shrink-0"
-        style={{ background: "#110d08" }}
-      >
-        <defs>
-          <pattern id="stone" width={20} height={20} patternUnits="userSpaceOnUse">
-            <rect width={20} height={20} fill="#110d08" />
-            <rect x={0} y={0} width={10} height={10} fill="#130f09" />
-            <rect x={10} y={10} width={10} height={10} fill="#130f09" />
-          </pattern>
-        </defs>
-        <rect width={svgWidth} height={svgHeight} fill="url(#stone)" />
+      {/* Sizer: carries the zoomed footprint so the scroll extents are real, while the map itself
+          scales by transform — see useMapZoom. Its size is written there, never by React. */}
+      <div ref={sizerRef} className="m-auto shrink-0">
+        <svg
+          ref={mapRef}
+          width={svgWidth}
+          height={svgHeight}
+          viewBox={`0 0 ${svgWidth} ${svgHeight}`}
+          role="img"
+          aria-label="site map"
+          className="block"
+          style={{ background: "#110d08" }}
+        >
+          <defs>
+            <pattern id="stone" width={20} height={20} patternUnits="userSpaceOnUse">
+              <rect width={20} height={20} fill="#110d08" />
+              <rect x={0} y={0} width={10} height={10} fill="#130f09" />
+              <rect x={10} y={10} width={10} height={10} fill="#130f09" />
+            </pattern>
+          </defs>
+          <rect width={svgWidth} height={svgHeight} fill="url(#stone)" />
 
-        {Array.from({ length: grid.rows + 2 }, (_, ri) => {
-          const r = ri - 1
-          return Array.from({ length: grid.cols + 2 }, (_, ci) => {
-            const c = ci - 1
-            const cell = cellAt(grid, r, c)
-            const cx = PAD + c * CELL + CELL / 2
-            const cy = PAD + r * CELL + CELL / 2
-            const cellKey = `${r},${c}`
-            const claimOwnerKey = claims.claimedBy.get(cellKey)
+          {Array.from({ length: grid.rows + 2 }, (_, ri) => {
+            const r = ri - 1
+            return Array.from({ length: grid.cols + 2 }, (_, ci) => {
+              const c = ci - 1
+              const cell = cellAt(grid, r, c)
+              const cx = PAD + c * CELL + CELL / 2
+              const cy = PAD + r * CELL + CELL / 2
+              const cellKey = `${r},${c}`
+              const claimOwnerKey = claims.claimedBy.get(cellKey)
 
-            // A cell claimed by a neighboring room — genuine void (including one step
-            // outside the grid), or a corridor absorbed as a gate's approach or a
-            // diagonal's flank anchor (see buildRoomClaims) — renders as part of that
-            // room, always, using the OWNER's state for the floor tint. The claim shape
-            // is a static function of the finished grid (independent of exploration
-            // progress), so the whole blob must render as a single visual unit — hiding
-            // a claimed corridor while its own fog state lags behind the owner's is what
-            // punched the "spotty" holes in an otherwise-explored room. Click/interaction
-            // still uses the corridor's own state, since it's a real, independently
-            // progressed passage for gameplay purposes even though it looks unified.
-            if (claimOwnerKey && (cell.type === "empty" || cell.type === "corridor")) {
-              const [ownerRow, ownerCol] = claimOwnerKey.split(",").map(Number)
-              const owner = grid.cells[ownerRow]?.[ownerCol]
-              if (!owner || owner.type !== "room" || owner.state === "fogged") return null
-              const state = owner.state
+              // A cell claimed by a neighboring room — genuine void (including one step
+              // outside the grid), or a corridor absorbed as a gate's approach or a
+              // diagonal's flank anchor (see buildRoomClaims) — renders as part of that
+              // room, always, using the OWNER's state for the floor tint. The claim shape
+              // is a static function of the finished grid (independent of exploration
+              // progress), so the whole blob must render as a single visual unit — hiding
+              // a claimed corridor while its own fog state lags behind the owner's is what
+              // punched the "spotty" holes in an otherwise-explored room. Click/interaction
+              // still uses the corridor's own state, since it's a real, independently
+              // progressed passage for gameplay purposes even though it looks unified.
+              if (claimOwnerKey && (cell.type === "empty" || cell.type === "corridor")) {
+                const [ownerRow, ownerCol] = claimOwnerKey.split(",").map(Number)
+                const owner = grid.cells[ownerRow]?.[ownerCol]
+                if (!owner || owner.type !== "room" || owner.state === "fogged") return null
+                const state = owner.state
+                const open = Object.fromEntries(ALL_DIRS.map(d => [d, isOpenSide(grid, claims, r, c, d)])) as Record<
+                  Direction,
+                  boolean
+                >
+                const decoration = claims.decorationAt.get(cellKey)
+                const isCorner = cell.type === "corridor" && isCorridorCorner(cell.dirs)
+                const runTarget = cell.type === "corridor" ? corridorRunTargets.get(cellKey) : undefined
+                const corridorClickable =
+                  cell.type === "corridor" &&
+                  onCellClick &&
+                  ((cell.state === "reachable" || cell.state === "completed") && isCorner ? true : !!runTarget)
+                const clickTarget = runTarget ? [runTarget.row, runTarget.col] : [r, c]
+                return (
+                  <g
+                    key={cellKey}
+                    transform={`translate(${cx}, ${cy})`}
+                    onClick={corridorClickable ? () => onCellClick(clickTarget[0], clickTarget[1]) : undefined}
+                    style={{ cursor: corridorClickable ? "pointer" : "default" }}
+                  >
+                    <FloorTile state={state} open={open} kind="room" />
+                    {cell.type === "corridor" &&
+                      (runTarget ? (
+                        <RunTargetArrow dir={runTarget.dir} />
+                      ) : (
+                        cell.state === "reachable" && isCorner && <ReachableDot />
+                      ))}
+                    {decoration && <DecorationGlyph kind={decoration} />}
+                  </g>
+                )
+              }
+
+              if (cell.type === "empty") return null
+              if (cell.state === "fogged") return null
+
               const open = Object.fromEntries(ALL_DIRS.map(d => [d, isOpenSide(grid, claims, r, c, d)])) as Record<
                 Direction,
                 boolean
               >
-              const decoration = claims.decorationAt.get(cellKey)
-              const isCorner = cell.type === "corridor" && isCorridorCorner(cell.dirs)
-              const runTarget = cell.type === "corridor" ? corridorRunTargets.get(cellKey) : undefined
-              const corridorClickable =
-                cell.type === "corridor" &&
-                onCellClick &&
-                ((cell.state === "reachable" || cell.state === "completed") && isCorner ? true : !!runTarget)
-              const clickTarget = runTarget ? [runTarget.row, runTarget.col] : [r, c]
-              return (
-                <g
-                  key={cellKey}
-                  transform={`translate(${cx}, ${cy})`}
-                  onClick={corridorClickable ? () => onCellClick(clickTarget[0], clickTarget[1]) : undefined}
-                  style={{ cursor: corridorClickable ? "pointer" : "default" }}
-                >
-                  <FloorTile state={state} open={open} kind="room" />
-                  {cell.type === "corridor" &&
-                    (runTarget ? (
+
+              if (cell.type === "corridor") {
+                const isCorner = isCorridorCorner(cell.dirs)
+                const runTarget = corridorRunTargets.get(cellKey)
+                // A visible run's near end has no corner of its own to click — it borrows the
+                // far corner's click target (see findCorridorRunTarget) so a long corridor
+                // that scrolls off screen still has something to tap right next to the player.
+                const corridorClickable =
+                  onCellClick &&
+                  (((cell.state === "reachable" || cell.state === "completed") && isCorner) || !!runTarget)
+                const clickTarget = runTarget ? [runTarget.row, runTarget.col] : [r, c]
+                return (
+                  <g
+                    key={`${r},${c}`}
+                    transform={`translate(${cx}, ${cy})`}
+                    onClick={corridorClickable ? () => onCellClick(clickTarget[0], clickTarget[1]) : undefined}
+                    style={{ cursor: corridorClickable ? "pointer" : "default" }}
+                  >
+                    <FloorTile state={cell.state} open={open} kind="corridor" />
+                    {runTarget ? (
                       <RunTargetArrow dir={runTarget.dir} />
                     ) : (
                       cell.state === "reachable" && isCorner && <ReachableDot />
-                    ))}
-                  {decoration && <DecorationGlyph kind={decoration} />}
-                </g>
-              )
-            }
+                    )}
+                  </g>
+                )
+              }
 
-            if (cell.type === "empty") return null
-            if (cell.state === "fogged") return null
+              // room cell
+              const state = cell.state
+              const isCompleted = state === "completed"
+              // Only ever a pending-loot marker for a treasure room with a consumable reward — this
+              // guards against stale coordinates in pendingCells (e.g. left over from before a site
+              // was regenerated) painting the badge onto whatever room now occupies that cell.
+              const shapeKind = shapeKindFor(grid, r, c, cell.roomType, cell.tags, cell.stairId)
+              // Portals (entrance/stairhead/exit) are transitions, not tasks — they can't be
+              // "completed", so they never get the completed dim or the ✓ badge even though the
+              // entrance is always marked explored (useAssembledFloor) and used staircases complete.
+              const isPortal = shapeKind === "entrance" || shapeKind === "stairhead" || shapeKind === "exit"
+              const isPending =
+                isCompleted &&
+                shapeKind === "treasure" &&
+                cell.reward?.type === "consumable" &&
+                (pendingCells?.has(`${r},${c}`) ?? false)
+              const clickable = onCellClick && (state === "reachable" || state === "completed")
+              const roomR = nodeRadius[shapeKind]
+              // Gating is soft: a locked gate is still "reachable" (clickable), so `state`
+              // doesn't distinguish locked from unlocked. Recover that purely cosmetic
+              // distinction here, independent of `state` —
+              // `displayState` feeds the floor tint and icon only, never clickability/badges.
+              const locked =
+                shapeKind === "gate" && !!cell.requiredKeyId && !(ownedKeys?.has(cell.requiredKeyId) ?? false)
+              const displayState: CellState = locked && state === "reachable" ? "visible" : state
 
-            const open = Object.fromEntries(ALL_DIRS.map(d => [d, isOpenSide(grid, claims, r, c, d)])) as Record<
-              Direction,
-              boolean
-            >
-
-            if (cell.type === "corridor") {
-              const isCorner = isCorridorCorner(cell.dirs)
-              const runTarget = corridorRunTargets.get(cellKey)
-              // A visible run's near end has no corner of its own to click — it borrows the
-              // far corner's click target (see findCorridorRunTarget) so a long corridor
-              // that scrolls off screen still has something to tap right next to the player.
-              const corridorClickable =
-                onCellClick && (((cell.state === "reachable" || cell.state === "completed") && isCorner) || !!runTarget)
-              const clickTarget = runTarget ? [runTarget.row, runTarget.col] : [r, c]
               return (
                 <g
                   key={`${r},${c}`}
                   transform={`translate(${cx}, ${cy})`}
-                  onClick={corridorClickable ? () => onCellClick(clickTarget[0], clickTarget[1]) : undefined}
-                  style={{ cursor: corridorClickable ? "pointer" : "default" }}
+                  onClick={clickable ? () => onCellClick(r, c) : undefined}
+                  style={{ cursor: clickable ? "pointer" : "default" }}
                 >
-                  <FloorTile state={cell.state} open={open} kind="corridor" />
-                  {runTarget ? (
-                    <RunTargetArrow dir={runTarget.dir} />
-                  ) : (
-                    cell.state === "reachable" && isCorner && <ReachableDot />
-                  )}
+                  <FloorTile state={displayState} open={open} kind="room" />
+                  <g opacity={isCompleted && !isPending && !isPortal ? 0.45 : 1}>
+                    <NodeShape
+                      type={shapeKind}
+                      state={displayState}
+                      gateVariant={cell.gateVariant}
+                      keyColor={cell.keyColor}
+                      keyColors={cell.keyColors}
+                      difficulty={wardKeyDifficulty(cell.requiredKeyId)}
+                    />
+                  </g>
+                  {isCompleted &&
+                    !isPortal &&
+                    shapeKind !== "fork" &&
+                    (isPending ? <PendingLootBadge r={roomR} /> : <CompletedBadge r={roomR} />)}
                 </g>
               )
-            }
+            })
+          })}
 
-            // room cell
-            const state = cell.state
-            const isCompleted = state === "completed"
-            // Only ever a pending-loot marker for a treasure room with a consumable reward — this
-            // guards against stale coordinates in pendingCells (e.g. left over from before a site
-            // was regenerated) painting the badge onto whatever room now occupies that cell.
-            const shapeKind = shapeKindFor(grid, r, c, cell.roomType, cell.tags, cell.stairId)
-            // Portals (entrance/stairhead/exit) are transitions, not tasks — they can't be
-            // "completed", so they never get the completed dim or the ✓ badge even though the
-            // entrance is always marked explored (useAssembledFloor) and used staircases complete.
-            const isPortal = shapeKind === "entrance" || shapeKind === "stairhead" || shapeKind === "exit"
-            const isPending =
-              isCompleted &&
-              shapeKind === "treasure" &&
-              cell.reward?.type === "consumable" &&
-              (pendingCells?.has(`${r},${c}`) ?? false)
-            const clickable = onCellClick && (state === "reachable" || state === "completed")
-            const roomR = nodeRadius[shapeKind]
-            // Gating is soft: a locked gate is still "reachable" (clickable), so `state`
-            // doesn't distinguish locked from unlocked. Recover that purely cosmetic
-            // distinction here, independent of `state` —
-            // `displayState` feeds the floor tint and icon only, never clickability/badges.
-            const locked =
-              shapeKind === "gate" && !!cell.requiredKeyId && !(ownedKeys?.has(cell.requiredKeyId) ?? false)
-            const displayState: CellState = locked && state === "reachable" ? "visible" : state
-
-            return (
-              <g
-                key={`${r},${c}`}
-                transform={`translate(${cx}, ${cy})`}
-                onClick={clickable ? () => onCellClick(r, c) : undefined}
-                style={{ cursor: clickable ? "pointer" : "default" }}
-              >
-                <FloorTile state={displayState} open={open} kind="room" />
-                <g opacity={isCompleted && !isPending && !isPortal ? 0.45 : 1}>
-                  <NodeShape
-                    type={shapeKind}
-                    state={displayState}
-                    gateVariant={cell.gateVariant}
-                    keyColor={cell.keyColor}
-                    keyColors={cell.keyColors}
-                    difficulty={wardKeyDifficulty(cell.requiredKeyId)}
-                  />
-                </g>
-                {isCompleted &&
-                  !isPortal &&
-                  shapeKind !== "fork" &&
-                  (isPending ? <PendingLootBadge r={roomR} /> : <CompletedBadge r={roomR} />)}
-              </g>
-            )
-          })
-        })}
-
-        {explorerPos && (
-          <ExplorerDot
-            key={currentFloor}
-            grid={grid}
-            pos={explorerPos}
-            onArrive={() => setSettledExplorerPos(explorerPos)}
-          />
-        )}
-      </svg>
+          {explorerPos && (
+            <ExplorerDot
+              key={currentFloor}
+              grid={grid}
+              pos={explorerPos}
+              onArrive={() => setSettledExplorerPos(explorerPos)}
+            />
+          )}
+        </svg>
+      </div>
     </div>
   )
 }

--- a/src/app/SiteMap/useMapZoom.ts
+++ b/src/app/SiteMap/useMapZoom.ts
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useState, type RefObject } from "react"
+import { useEffect, useLayoutEffect, useRef } from "react"
 
 export const MIN_ZOOM = 0.5
 // Room to lean in on a single room's artwork, not just to read the layout.
@@ -16,41 +16,66 @@ const touchMidpoint = (touches: TouchList): { x: number; y: number } => ({
 
 // Scales the map inside its own scroll area: pinch on touch, ctrl/⌘ + wheel on desktop (which is
 // also what a trackpad pinch sends). Plain wheel is left alone so it still pans the map.
+// Double-click / double-tap goes back to 1×.
+//
+// The zoom level is NOT React state: a pinch fires a move event per frame, and re-rendering a
+// floor's worth of cells that often is what made it stutter on a phone. Instead the gesture writes
+// the DOM directly — the sizer box takes the scaled footprint (so the scroll extents are real),
+// and the map itself is a `scale()` transform, which the browser can composite. Nothing in the
+// React tree depends on the zoom, so nothing re-renders while pinching.
 //
 // The listeners are attached by hand rather than as JSX props because React registers wheel and
 // touch handlers passively — a passive handler can't preventDefault, and without that the browser
 // runs its own page zoom on top of this one.
-export const useMapZoom = (scrollRef: RefObject<HTMLDivElement | null>) => {
-  const [zoom, setZoom] = useState(1)
+export const useMapZoom = (baseWidth: number, baseHeight: number) => {
+  const scrollRef = useRef<HTMLDivElement>(null)
+  // The box holding the map's scaled footprint. Sized here, never by React — a re-render would
+  // otherwise reset it to the unzoomed size mid-gesture.
+  const sizerRef = useRef<HTMLDivElement>(null)
+  const mapRef = useRef<SVGSVGElement>(null)
   const zoomRef = useRef(1)
-  // Where the gesture is anchored, in scroll-area coordinates, plus the scale step it asks for.
-  // Applied after the map has re-laid-out at the new size (below), so the point under the fingers
-  // — or the cursor — stays put instead of the map sliding away from under the gesture.
-  const focal = useRef<{ x: number; y: number; ratio: number } | null>(null)
-  const pinch = useRef<{ distance: number; zoom: number } | null>(null)
 
-  useLayoutEffect(() => {
-    const el = scrollRef.current
-    const f = focal.current
-    if (!el || !f) return
-    focal.current = null
-    el.scrollLeft = (el.scrollLeft + f.x) * f.ratio - f.x
-    el.scrollTop = (el.scrollTop + f.y) * f.ratio - f.y
-  }, [zoom, scrollRef])
+  const render = () => {
+    const sizer = sizerRef.current
+    const map = mapRef.current
+    if (!sizer || !map) return
+    const zoom = zoomRef.current
+    sizer.style.width = `${baseWidth * zoom}px`
+    sizer.style.height = `${baseHeight * zoom}px`
+    map.style.transformOrigin = "0 0"
+    map.style.transform = `scale(${zoom})`
+  }
+
+  useLayoutEffect(render)
 
   useEffect(() => {
     const el = scrollRef.current
     if (!el) return
 
+    // Keeps the point under the gesture under the gesture. Measured rather than derived: the map
+    // is auto-centered while it's smaller than the viewport, so its offset within the scroll area
+    // moves as the zoom changes, and computing the new scroll from the old one silently zooms
+    // toward the middle of the screen instead.
     const zoomTo = (target: number, clientX: number, clientY: number) => {
+      const sizer = sizerRef.current
+      if (!sizer) return
       const next = clampZoom(target)
       const previous = zoomRef.current
       if (next === previous) return
-      const rect = el.getBoundingClientRect()
-      focal.current = { x: clientX - rect.left, y: clientY - rect.top, ratio: next / previous }
+
+      const before = sizer.getBoundingClientRect()
+      const mapX = (clientX - before.left) / previous
+      const mapY = (clientY - before.top) / previous
+
       zoomRef.current = next
-      setZoom(next)
+      render()
+
+      const after = sizer.getBoundingClientRect()
+      el.scrollLeft += after.left + mapX * next - clientX
+      el.scrollTop += after.top + mapY * next - clientY
     }
+
+    let pinch: { distance: number; zoom: number } | null = null
 
     const onWheel = (e: WheelEvent) => {
       if (!e.ctrlKey && !e.metaKey) return
@@ -59,23 +84,18 @@ export const useMapZoom = (scrollRef: RefObject<HTMLDivElement | null>) => {
       zoomTo(zoomRef.current * Math.exp(-e.deltaY / 300), e.clientX, e.clientY)
     }
     const onTouchStart = (e: TouchEvent) => {
-      if (e.touches.length === 2) pinch.current = { distance: touchDistance(e.touches), zoom: zoomRef.current }
+      if (e.touches.length === 2) pinch = { distance: touchDistance(e.touches), zoom: zoomRef.current }
     }
     const onTouchMove = (e: TouchEvent) => {
-      const start = pinch.current
-      if (!start || e.touches.length !== 2) return
+      if (!pinch || e.touches.length !== 2) return
       e.preventDefault()
       const { x, y } = touchMidpoint(e.touches)
-      zoomTo((start.zoom * touchDistance(e.touches)) / start.distance, x, y)
+      zoomTo((pinch.zoom * touchDistance(e.touches)) / pinch.distance, x, y)
     }
     const endPinch = () => {
-      pinch.current = null
+      pinch = null
     }
-    // Double-click / double-tap goes back to 1×, anchored where it was aimed — the way out of a
-    // zoom you pinched too far, without a control sitting on top of the map.
-    const onDoubleClick = (e: MouseEvent) => {
-      if (zoomRef.current !== 1) zoomTo(1, e.clientX, e.clientY)
-    }
+    const onDoubleClick = (e: MouseEvent) => zoomTo(1, e.clientX, e.clientY)
 
     el.addEventListener("wheel", onWheel, { passive: false })
     el.addEventListener("touchstart", onTouchStart, { passive: true })
@@ -84,15 +104,23 @@ export const useMapZoom = (scrollRef: RefObject<HTMLDivElement | null>) => {
     el.addEventListener("touchcancel", endPinch)
     el.addEventListener("dblclick", onDoubleClick)
     return () => {
-      el.removeEventListener("dblclick", onDoubleClick)
       el.removeEventListener("wheel", onWheel)
       el.removeEventListener("touchstart", onTouchStart)
       el.removeEventListener("touchmove", onTouchMove)
       el.removeEventListener("touchend", endPinch)
       el.removeEventListener("touchcancel", endPinch)
+      el.removeEventListener("dblclick", onDoubleClick)
     }
-  }, [scrollRef])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [baseWidth, baseHeight])
 
-  // One-finger drag still scrolls the map; the browser's own pinch-zoom is off, since this handles it.
-  return { zoom, zoomHandlers: { style: { touchAction: "pan-x pan-y" } as const } }
+  // One-finger drag still scrolls the map; the browser's own pinch-zoom is off, since this
+  // handles it. `zoomRef` is for readers that need the current scale (the explorer centering).
+  return {
+    scrollRef,
+    sizerRef,
+    mapRef,
+    zoomRef,
+    scrollHandlers: { style: { touchAction: "pan-x pan-y" } as const },
+  }
 }


### PR DESCRIPTION
Follow-up to #165 from mobile testing: zooming stuttered, and it zoomed toward the middle of the screen rather than toward the pinch.

## Stutter

The zoom level was React state. A pinch fires a move event per frame, so every frame re-rendered a floor's worth of cells — hundreds of `<g>`s with several shapes each.

The zoom is no longer state. The gesture writes the DOM directly: a sizer box carries the scaled footprint (so the scroll extents stay real) and the map is a `scale()` transform, which the browser can composite. Nothing in the React tree depends on the zoom, so nothing re-renders while pinching. The sizer's size is written only by the hook — a spec covers the case where a re-render would otherwise reset it mid-gesture.

## Zoomed toward the centre

The new scroll offset was derived from the old one, which assumes the map's top-left sits at the scroll origin. It doesn't: the map is auto-centred (`m-auto`) while it's smaller than the viewport — the default-zoom state on a phone — and that margin shrinks as the map grows, so the point under your fingers slid toward the middle.

The focal point is now measured instead of derived: the map point under the gesture is read off the sizer's rect before the resize, and put back under the same screen point after it, whatever the margins are doing.

Checked in a real browser (jsdom has no layout) across zoom in, zoom in again, and zoom out, with off-centre focal points:

| case | drift with this change | drift with the old formula |
| --- | --- | --- |
| auto-centred start, zoom to 2.5x | 0px | 375px |
| scrollable both axes, zoom to 4x | 0px | — |
| zoom back out to 1.5x | 0px | — |

The only residual offset is where the scroll range genuinely clamps at an edge, which is unavoidable.

## Testing

`yarn test` 1172 pass, `yarn check-types` and `yarn lint` clean. The zoom specs now assert the map's transform scale and the sizer's footprint instead of the old width attribute, plus a new case for keeping the zoom across a re-render.

Worth a phone pass: pinch around a corner of the map and check it grows toward your fingers, and that it no longer stutters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CtdWuKt2JHUqZT9XaCiVbC