### PR TITLE
Tomb treasure popup shows its bonus; Collection details show again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Finding a tomb treasure says what it does for you — the same bonus line the Collection shows.
+
+### Fixed
+- Tapping something in the Collection shows its details again, instead of only for players holding a trinket.
 ### Fixed
 - Pinch-zooming the site map is smooth, and zooms toward your fingers instead of the middle of the screen.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Finding a tomb treasure says what it does for you — the same bonus line the Collection shows.
 
 ### Fixed
-- Tapping something in the Collection shows its details again, instead of only for players holding a trinket.
-### Fixed
 - Pinch-zooming the site map is smooth, and zooms toward your fingers instead of the middle of the screen.
+- Tapping something in the Collection shows its details again, instead of only for players holding a trinket.
 
 ## 0.32.0 - 2026-08-08
 ### Added

--- a/src/app/pages/Collection.spec.tsx
+++ b/src/app/pages/Collection.spec.tsx
@@ -1,0 +1,44 @@
+import { render, fireEvent } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import type { CollectionItem, CollectionSectionProps } from "./collectionSectionRegistry"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+// An empty inventory: everything this player has collected lives elsewhere — a finished hieroglyph
+// is fragments, a tomb treasure is a held key. That used to hide the detail panel entirely.
+vi.mock("@/app/Inventory/useInventory", () => ({
+  useInventory: () => ({ inventory: {}, addItem: () => {} }),
+}))
+
+const treasure: CollectionItem = {
+  id: "t2",
+  symbol: "𓅱",
+  name: "Papyrus Scroll",
+  description: "A merchant's record scroll.",
+  effectDescription: "Fragment compass (Lv 1)",
+}
+
+vi.mock("./collectionSectionRegistry", async importOriginal => {
+  const actual = await importOriginal<typeof import("./collectionSectionRegistry")>()
+  const Section = ({ onSelect }: CollectionSectionProps) => (
+    <button onClick={() => onSelect(treasure)}>collected treasure</button>
+  )
+  return { ...actual, collectionSections: () => [{ id: "test", Component: Section }] }
+})
+
+const { CollectionPage } = await import("./Collection")
+
+describe(CollectionPage, () => {
+  it("shows a tapped item's details even when the player holds no inventory items", () => {
+    const { getByText, queryByText } = render(<CollectionPage />)
+    expect(queryByText("collection.clickForDetails")).not.toBeNull()
+
+    fireEvent.click(getByText("collected treasure"))
+
+    expect(queryByText(treasure.name)).not.toBeNull()
+    expect(queryByText(treasure.description)).not.toBeNull()
+    expect(queryByText(treasure.effectDescription!)).not.toBeNull()
+  })
+})

--- a/src/app/pages/Collection.tsx
+++ b/src/app/pages/Collection.tsx
@@ -27,8 +27,15 @@ const DetailPanel: FC<{
       {item ? (
         <div className="flex flex-col items-start gap-4">
           <div className="flex flex-row items-start gap-3">
+            {/* A tile needs a difficulty to pick its stone; an item whose section carries none and
+                whose id isn't a hieroglyph shows its plain symbol rather than taking the page down
+                with it — HieroglyphTile throws on a symbol with no difficulty. */}
             <div className="flex-shrink-0">
-              <HieroglyphTile symbol={item.symbol} difficulty={difficulty ?? undefined} size="lg" disabled={false} />
+              {difficulty ? (
+                <HieroglyphTile symbol={item.symbol} difficulty={difficulty} size="lg" disabled={false} />
+              ) : (
+                <span className="font-mono text-4xl">{item.symbol}</span>
+              )}
             </div>
             <div className="flex flex-col">
               <h3 className="font-pyramid text-xl font-bold text-gray-900">{item.name}</h3>
@@ -77,8 +84,6 @@ export const CollectionPage: FC = () => {
     setSelectedItem(item)
   }
 
-  const hasCollectedItems = Object.values(inventory).some(value => value !== undefined)
-
   return (
     <Page className="flex bg-gradient-to-b from-blue-100 to-blue-300" snap="center">
       <div className="relative flex-1 overflow-y-auto p-6">
@@ -93,13 +98,14 @@ export const CollectionPage: FC = () => {
             <section.Component key={section.id} selectedItem={selectedItem} onSelect={handleItemClick} />
           ))}
         </div>
-        {hasCollectedItems && (
-          <DetailPanel
-            item={selectedItem}
-            debug={isDevelopMode}
-            onAdd={() => selectedItem && addItem(selectedItem?.id, 1)}
-          />
-        )}
+        {/* Always present: most of what the Collection shows isn't an inventory item at all — a
+            finished hieroglyph is fragments, a tomb treasure is a held key, mosaic glass is a
+            ledger count — so gating this panel on the inventory left those tapping into silence. */}
+        <DetailPanel
+          item={selectedItem}
+          debug={isDevelopMode}
+          onAdd={() => selectedItem && addItem(selectedItem?.id, 1)}
+        />
       </div>
     </Page>
   )

--- a/src/mods/tombTreasure/app/TombTreasureCollectionSection.tsx
+++ b/src/mods/tombTreasure/app/TombTreasureCollectionSection.tsx
@@ -1,14 +1,13 @@
 import type { FC } from "react"
 import { useTranslation } from "react-i18next"
 import { difficulties } from "@/data/difficultyLevels"
-import { useMergedPerkContributions } from "@/app/SiteMap/perkContributions"
 import { CategoryGrid } from "@/ui/atoms/CategoryGrid"
 import { CollectionSection } from "@/ui/atoms/CollectionSection"
 import { CollectibleSlot } from "@/ui/molecules/CollectibleSlot"
 import type { CollectionSectionProps } from "@/app/pages/collectionSectionRegistry"
 import { CATEGORY_BY_DIFFICULTY, difficultyTreasures, keyIdByTreasureId } from "../game/treasures"
-import { TREASURE_PERKS } from "../game/treasurePerks"
 import { useTombTreasureProgress } from "./useTombTreasureProgress"
+import { useTreasurePerkLabel } from "./useTreasurePerkLabel"
 
 // The tomb-treasure mod's Collection contribution: the 40 tomb treasures in 5 per-difficulty
 // groups. "Collected" = owning that treasure's tombKey (no inventory item). Each collected slot
@@ -19,20 +18,7 @@ import { useTombTreasureProgress } from "./useTombTreasureProgress"
 export const TombTreasureCollectionSection: FC<CollectionSectionProps> = ({ selectedItem, onSelect }) => {
   const { t } = useTranslation(["common", "treasures"])
   const { tombKeyIds } = useTombTreasureProgress()
-  const { describe } = useMergedPerkContributions()
-
-  // The treasure's perk bonus line: an owned stat/detector perk speaks for itself via the merged
-  // describe; tier-unlock/location-key are described here (no perk owner); `none`/unknown blank.
-  const bonusFor = (keyId: string): string | undefined => {
-    const perk = TREASURE_PERKS[keyId]
-    if (!perk) return undefined
-    const owned = describe(perk)
-    if (owned) return owned.label
-    if (perk.type === "tier-unlock")
-      return t("perks.tier-unlock", { ns: "treasures", tier: t(`difficulty.${perk.tier}`, { ns: "common" }) })
-    if (perk.type === "location-key") return t("perks.location-key", { ns: "treasures" })
-    return undefined
-  }
+  const bonusFor = useTreasurePerkLabel()
 
   return (
     <>

--- a/src/mods/tombTreasure/app/rewardDisplay.spec.tsx
+++ b/src/mods/tombTreasure/app/rewardDisplay.spec.tsx
@@ -13,6 +13,11 @@ vi.mock("./useTombTreasureProgress", () => ({
   useTombTreasureProgress: () => ({ mapPieceProgress: () => progress }),
 }))
 
+// Stands in for the perk line; its own wording is covered in useTreasurePerkLabel.spec.
+vi.mock("./useTreasurePerkLabel", () => ({
+  useTreasurePerkLabel: () => (keyId: string) => (keyId === "junior_a_2" ? undefined : "perk:" + keyId),
+}))
+
 // Identity `t`, with the interpolation payload appended so the assertions can see which tomb string
 // was asked for and with what values.
 const t = (key: string, opts?: Record<string, unknown>) => {
@@ -110,5 +115,36 @@ describe("map-piece reward display", () => {
     const text = rewardText({ type: "mapPiece", tombId: "expert_treasure_tomb_b" }, t)
     expect(text.itemName).toBe("chest.mapPiece")
     expect(text.itemDescription).toBe("chest.mapPieceDescription")
+  })
+})
+
+// The perk line's own wording is covered in useTreasurePerkLabel.spec; here it stands in for
+// "whatever that treasure's perk reads as", so these cases are about what the popup does with it.
+describe("tomb-treasure reward display", () => {
+  const tombKeyDisplay = (keyId: string, translate = t): RewardDisplay => {
+    const { result } = renderHook(() => useMergedRewardDisplays())
+    const build = result.current.tombKey
+    if (!build) throw new Error("no tombKey display registered")
+    return build({ type: "tombKey", keyId }, translate)
+  }
+
+  it("says what the treasure does for you, alongside what it is", () => {
+    const display = tombKeyDisplay("starter_a_2")
+    expect(display.itemName).toBe("merchantCache.t2.name")
+    expect(display.itemDescription).toBe("merchantCache.t2.description")
+    expect(display.itemEffectDescription).toBe("perk:starter_a_2")
+  })
+
+  it("marks a treasure that opens a tier or another tomb as legendary", () => {
+    expect(tombKeyDisplay("starter_a_1").rarity).toBe("legendary") // tier-unlock
+    expect(tombKeyDisplay("expert_a_2").rarity).toBe("legendary") // location-key
+  })
+
+  it("keeps a plain perk treasure at epic", () => {
+    expect(tombKeyDisplay("starter_a_3").rarity).toBe("epic")
+  })
+
+  it("falls back to the generic key label for a keyId with no catalog treasure", () => {
+    expect(tombKeyDisplay("not_a_treasure").itemName).toBe("chest.tombKey")
   })
 })

--- a/src/mods/tombTreasure/app/rewardDisplay.tsx
+++ b/src/mods/tombTreasure/app/rewardDisplay.tsx
@@ -3,7 +3,9 @@ import { registerRewardDisplays, type RewardDisplayFn } from "@/app/SiteMap/rewa
 import { journeys } from "@/data/journeys"
 import { MapPieceIcon } from "@/ui/molecules/MapPieceIcon"
 import { treasureDisplayByKeyId } from "../game/treasures"
+import { TREASURE_PERKS } from "../game/treasurePerks"
 import { useTombTreasureProgress } from "./useTombTreasureProgress"
+import { useTreasurePerkLabel } from "./useTreasurePerkLabel"
 import { mapPieceSchema, tombKeySchema } from "./rewardSchemas"
 
 // The map-piece / tomb-key rewards' synchronous popup text/emoji (used by the generic RewardFlow
@@ -46,7 +48,32 @@ const tombName = (tombId: string) => journeys.find(j => j.id === tombId)?.name
 
 const useTombTreasureRewardDisplays = (): Partial<Record<string, RewardDisplayFn>> => {
   const { mapPieceProgress } = useTombTreasureProgress()
+  const perkLabel = useTreasurePerkLabel()
   return {
+    // A tomb treasure's whole point is what it does for you, and that used to be readable only
+    // later, in the Collection. The popup now carries the same perk line, worded identically.
+    tombKey: (reward, t) => {
+      const { keyId } = tombKeySchema.parse(reward)
+      const perk = TREASURE_PERKS[keyId]
+      const info = treasureDisplayByKeyId[keyId]
+      // Opening a tier or another tomb changes where you can go next, which outranks a stat bump.
+      const rarity = perk?.type === "tier-unlock" || perk?.type === "location-key" ? "legendary" : "epic"
+      if (!info) {
+        return {
+          rarity,
+          itemName: t("chest.tombKey"),
+          itemEffectDescription: perkLabel(keyId),
+          ItemVisual: <span className="text-6xl">🗝</span>,
+        }
+      }
+      return {
+        rarity,
+        itemName: t(`${info.category}.${info.treasureId}.name`, { ns: "treasures" }),
+        itemDescription: t(`${info.category}.${info.treasureId}.description`, { ns: "treasures" }),
+        itemEffectDescription: perkLabel(keyId),
+        ItemVisual: <span className="text-6xl">{info.symbol}</span>,
+      }
+    },
     mapPiece: (reward, t) => {
       const { tombId } = mapPieceSchema.parse(reward)
       const progress = mapPieceProgress(tombId)

--- a/src/mods/tombTreasure/app/useTreasurePerkLabel.spec.tsx
+++ b/src/mods/tombTreasure/app/useTreasurePerkLabel.spec.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from "vitest"
+import { renderHook } from "@testing-library/react"
+
+// A perk with an owning mod describes itself through that mod's i18n; the merged describe is that
+// seam. Only `compass` has an owner here, so the other branches are exercised for real.
+vi.mock("@/app/SiteMap/perkContributions", () => ({
+  useMergedPerkContributions: () => ({
+    grant: () => {},
+    describe: (perk: { type: string; level?: number }) =>
+      perk.type === "compass" ? { label: `owned compass ${perk.level}` } : undefined,
+  }),
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      const { ns, ...values } = opts ?? {}
+      void ns
+      return Object.keys(values).length > 0 ? `${key}:${JSON.stringify(values)}` : key
+    },
+  }),
+}))
+
+const { useTreasurePerkLabel } = await import("./useTreasurePerkLabel")
+
+const labelFor = (keyId: string) => renderHook(() => useTreasurePerkLabel()).result.current(keyId)
+
+describe(useTreasurePerkLabel, () => {
+  it("lets the owning mod word its own perk", () => {
+    expect(labelFor("starter_a_2")).toBe("owned compass 1") // starter_a_2 = compass level 1
+  })
+
+  it("names the tier a tier-unlock treasure opens", () => {
+    expect(labelFor("starter_a_1")).toBe('perks.tier-unlock:{"tier":"difficulty.junior"}')
+  })
+
+  it("describes a location-key treasure as revealing another tomb", () => {
+    expect(labelFor("expert_a_2")).toBe("perks.location-key")
+  })
+
+  it("has nothing to say about a treasure that is a pure ward key", () => {
+    expect(labelFor("junior_a_2")).toBeUndefined() // perk: none
+  })
+
+  it("has nothing to say about a keyId that isn't a treasure", () => {
+    expect(labelFor("not_a_treasure")).toBeUndefined()
+  })
+})

--- a/src/mods/tombTreasure/app/useTreasurePerkLabel.ts
+++ b/src/mods/tombTreasure/app/useTreasurePerkLabel.ts
@@ -1,0 +1,23 @@
+import { useTranslation } from "react-i18next"
+import { useMergedPerkContributions } from "@/app/SiteMap/perkContributions"
+import { TREASURE_PERKS } from "../game/treasurePerks"
+
+// What a tomb treasure does for you, in one line: an owned stat/detector perk speaks for itself
+// through the merged `describe` (the owning mod's own i18n), while tier-unlock and location-key
+// have no perk owner and are described here. A `none` perk (a pure ward/location key) has no line.
+// Shared by the Collection slot and the loot popup, so a treasure reads the same in both places.
+export const useTreasurePerkLabel = () => {
+  const { t } = useTranslation(["common", "treasures"])
+  const { describe } = useMergedPerkContributions()
+
+  return (keyId: string): string | undefined => {
+    const perk = TREASURE_PERKS[keyId]
+    if (!perk) return undefined
+    const owned = describe(perk)
+    if (owned) return owned.label
+    if (perk.type === "tier-unlock")
+      return t("perks.tier-unlock", { ns: "treasures", tier: t(`difficulty.${perk.tier}`, { ns: "common" }) })
+    if (perk.type === "location-key") return t("perks.location-key", { ns: "treasures" })
+    return undefined
+  }
+}


### PR DESCRIPTION
Two fixes around what a treasure tells you.

## 1. The loot popup says what a tomb treasure does

A tomb treasure's whole point is the perk it grants — the compass, the pack mule, the tier it opens — and that was readable only later, in the Collection. The `tombKey` reward now has a rich display: the treasure's name, description and symbol as before, plus the bonus line.

Both places call the same new `useTreasurePerkLabel`, so the wording matches: the owning mod describes its own perk through the perk `describe` seam (its own i18n), while tier-unlock and location-key — which have no perk owner — are described by the tomb-treasure mod. No new strings.

Rarity follows the perk: legendary when the treasure opens a tier or reveals another tomb, epic otherwise.

## 2. Tapping something in the Collection showed nothing

Reported during testing. The detail panel was gated on the player holding at least one **inventory** item — but most of what the Collection shows isn't one:

- a finished hieroglyph is fragment counts (mod state)
- a tomb treasure is a held key (progression)
- mosaic glass is a ledger count

The only writer left to the inventory is the shop mod's `sellable` reward, so a player who has never picked up a trinket tapped a slot and got silence. The panel is always rendered now; it already had its own "tap for details" empty state.

While there: the panel threw on an item with no derivable difficulty (a section that carries none, an id that isn't a hieroglyph), which takes the page down rather than showing nothing. Such an item now shows its plain symbol instead of the stone tile. No shipped item hits that path today — it's a crash-on-render guard, not a behaviour change.

## Testing

`yarn test` 1182 pass, `yarn check-types` and `yarn lint` clean. New specs: `useTreasurePerkLabel.spec.tsx` (perk wording per branch), tomb-key cases in `rewardDisplay.spec.tsx`, and `Collection.spec.tsx` (details shown with an empty inventory).

Manual: claim a tomb treasure and check the popup's italic line matches its Collection entry; open the Collection on a save with no trinkets and tap a hieroglyph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CtdWuKt2JHUqZT9XaCiVbC