### PR TITLE
Open a difficulty tier on its unlock treasure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- A tomb treasure opens the next difficulty: hold any one of a tomb's four unlock treasures and that tier's first expedition is yours, without finishing the tomb run first.
 
 ## 0.32.1 - 2026-08-08
 ### Changed

--- a/src/app/PyramidExpedition.tsx
+++ b/src/app/PyramidExpedition.tsx
@@ -5,6 +5,7 @@ import { LevelCompletionHandler } from "@/app/PyramidLevel/LevelCompletionHandle
 import { ExpeditionCompletionOverlay } from "@/app/PyramidExpedition/ExpeditionCompletionOverlay"
 import { getNextUnlockedPyramidJourneyId } from "@/app/PyramidExpedition/utils"
 import { SiteMapScreen } from "@/app/SiteMap/SiteMapScreen"
+import { useMergedHeldKeys } from "@/app/SiteMap/keyProviders"
 import { clsx } from "clsx"
 import { DesertBackdrop } from "@/ui/atoms/DesertBackdrop"
 import { getLevelWidth } from "@/game/state"
@@ -73,6 +74,8 @@ export const PyramidExpedition: FC<{
   const { t } = useTranslation("common")
   const { isDevelopMode } = use(DevelopContext)
   const { setInteriorLevel } = useJourneys()
+  // Ward/tomb keys held right now — what decides whether the next tier is open (journeyAvailability).
+  const heldKeys = useMergedHeldKeys()
   const [transitionToLevel, setTransitionToLevel] = useState(activeJourney.levelNr)
   const [levelCompleted, setLevelCompleted] = useState(false)
   // Restore interior if player backed out mid-interior on a previous visit
@@ -248,7 +251,7 @@ export const PyramidExpedition: FC<{
 
   // Check if a new pyramid journey is unlocked (first time completing this journey)
   const nextPyramidJourneyId =
-    activeJourney.completionCount === 0 ? getNextUnlockedPyramidJourneyId(activeJourney.journeyId) : undefined
+    activeJourney.completionCount === 0 ? getNextUnlockedPyramidJourneyId(activeJourney.journeyId, heldKeys) : undefined
   const dayTime = dayNightCycleDayTime(
     activeJourney.levelNr,
     pyramidJourney.background.time,

--- a/src/app/PyramidExpedition/utils.ts
+++ b/src/app/PyramidExpedition/utils.ts
@@ -1,9 +1,9 @@
 import { journeys } from "@/data/journeys"
+import { nextPyramidJourneyId } from "@/app/pages/journeyAvailability"
 
-export function getNextUnlockedPyramidJourneyId(journeyId: string): string | undefined {
-  const idx = journeys.findIndex(j => j.id === journeyId)
-  if (idx === -1) return undefined
-  const journey = journeys[idx + 1]
-  if (!journey || journey.type !== "pyramid") return undefined
-  return journey.id
+// The expedition the completion screen offers next. Gated on the same rule the Travel screen picks
+// from (journeyAvailability), so it never announces one the player can't start: crossing into a
+// tier needs that tier's unlock treasure, which the next tomb — not this pyramid — holds.
+export function getNextUnlockedPyramidJourneyId(journeyId: string, heldKeys: ReadonlySet<string>): string | undefined {
+  return nextPyramidJourneyId(journeys, journeyId, heldKeys)
 }

--- a/src/app/pages/Travel.tsx
+++ b/src/app/pages/Travel.tsx
@@ -15,6 +15,7 @@ import { DevelopContext } from "@/contexts/DevelopMode"
 import { DeveloperButton } from "@/ui/atoms/DeveloperButton"
 
 import { TableauInventory } from "./TableauInventory"
+import { availablePyramidJourneyIds } from "./journeyAvailability"
 import { useTombTreasureProgress } from "@/mods/tombTreasure/app/useTombTreasureProgress"
 
 export const TravelPage: FC<{
@@ -118,14 +119,17 @@ export const TravelPage: FC<{
     setShowInterruptModal(false)
   }
 
-  const unlocked = useMemo(() => {
-    return journeys.findIndex((_j, journeyIndex) => {
-      if (journeyIndex === 0) return false // Always unlock the first journey
-      const previousJourneyId = journeys[journeyIndex - 1]?.id
-      const hasPreviousCompleted = (getJourney(previousJourneyId)?.completionCount ?? 0) > 0
-      return !hasPreviousCompleted
-    })
-  }, [journeys, getJourney])
+  // Which pyramid expeditions are pickable: a tier is entered on holding one of its unlock
+  // treasures, and inside a tier they still open one at a time (see journeyAvailability).
+  const availableJourneyIds = useMemo(
+    () => availablePyramidJourneyIds(journeys, heldKeys, id => (getJourney(id)?.completionCount ?? 0) > 0),
+    [journeys, heldKeys, getJourney]
+  )
+  // The newest one open to the player — the card that shows its details expanded.
+  const newestAvailableId = useMemo(
+    () => journeys.filter(j => availableJourneyIds.has(j.id)).at(-1)?.id,
+    [journeys, availableJourneyIds]
+  )
 
   const hasPendingMapPieceProgress = useMemo(() => {
     return journeys
@@ -256,8 +260,8 @@ export const TravelPage: FC<{
             </div>
             <div className="grid grid-cols-1 gap-4 px-6 pb-safe-bottom xl:grid-cols-2">
               {journeys.map((journey, index) => {
-                if (journey.type === "pyramid" && index >= unlocked) {
-                  // Skip pyramid journeys that are not yet unlocked
+                if (journey.type === "pyramid" && !availableJourneyIds.has(journey.id)) {
+                  // Skip pyramid journeys the player cannot pick yet
                   return null
                 }
                 if (
@@ -295,7 +299,7 @@ export const TravelPage: FC<{
                 return (
                   <JourneyCard
                     key={journey.id}
-                    showDetails={index === unlocked - 1}
+                    showDetails={journey.id === newestAvailableId}
                     journey={journey}
                     disabled={false}
                     completionCount={completionCount}

--- a/src/app/pages/journeyAvailability.spec.ts
+++ b/src/app/pages/journeyAvailability.spec.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest"
+import { journeys } from "@/data/journeys"
+import { TIER_UNLOCK_PERK_IDS } from "@/data/treasurePerks"
+import { availablePyramidJourneyIds, isTierUnlocked, nextPyramidJourneyId } from "./journeyAvailability"
+
+const noKeys: ReadonlySet<string> = new Set()
+const keys = (...ids: string[]): ReadonlySet<string> => new Set(ids)
+const completed =
+  (...ids: string[]) =>
+  (id: string) =>
+    ids.includes(id)
+
+const starterPyramids = journeys.filter(j => j.type === "pyramid" && j.difficulty === "starter").map(j => j.id)
+const juniorPyramids = journeys.filter(j => j.type === "pyramid" && j.difficulty === "junior").map(j => j.id)
+
+describe(isTierUnlocked, () => {
+  it("lets the player start the game — the first tier has no entry key", () => {
+    expect(isTierUnlocked("starter", noKeys)).toBe(true)
+  })
+
+  it("opens a tier on any one of its four unlock treasures, not a specific one", () => {
+    for (const keyId of TIER_UNLOCK_PERK_IDS.junior!) {
+      expect(isTierUnlocked("junior", keys(keyId))).toBe(true)
+    }
+  })
+
+  it("stays shut for a key belonging to another tier", () => {
+    expect(isTierUnlocked("junior", keys(...TIER_UNLOCK_PERK_IDS.expert!))).toBe(false)
+  })
+})
+
+describe(availablePyramidJourneyIds, () => {
+  it("offers the first expedition on a fresh game", () => {
+    const available = availablePyramidJourneyIds(journeys, noKeys, completed())
+    expect([...available]).toEqual([starterPyramids[0]])
+  })
+
+  it("opens the next expedition of a tier as the one before it is completed", () => {
+    const available = availablePyramidJourneyIds(journeys, noKeys, completed(starterPyramids[0]))
+    expect([...available]).toEqual(starterPyramids.slice(0, 2))
+  })
+
+  it("keeps the next tier shut until one of its unlock treasures is held, however much is completed", () => {
+    const available = availablePyramidJourneyIds(journeys, noKeys, completed(...starterPyramids))
+    expect(available.has(juniorPyramids[0])).toBe(false)
+    expect([...available]).toEqual(starterPyramids)
+  })
+
+  it("admits the player to the tier's first expedition once the treasure is held", () => {
+    const available = availablePyramidJourneyIds(journeys, keys("starter_a_1"), completed(...starterPyramids))
+    expect(available.has(juniorPyramids[0])).toBe(true)
+    // Entry only — the rest of the tier still opens one at a time.
+    expect(available.has(juniorPyramids[1])).toBe(false)
+  })
+
+  it("does not need the tier's own expeditions completed first, only the previous one inside it", () => {
+    const available = availablePyramidJourneyIds(
+      journeys,
+      keys("starter_a_1"),
+      completed(...starterPyramids, juniorPyramids[0])
+    )
+    expect(available.has(juniorPyramids[1])).toBe(true)
+    expect(available.has(juniorPyramids[2])).toBe(false)
+  })
+})
+
+describe(nextPyramidJourneyId, () => {
+  it("announces the next expedition inside the tier", () => {
+    expect(nextPyramidJourneyId(journeys, juniorPyramids[0], keys("starter_a_1"))).toBe(juniorPyramids[1])
+  })
+
+  it("announces nothing at a tier's last expedition — a tomb comes next, not a pyramid", () => {
+    expect(nextPyramidJourneyId(journeys, starterPyramids.at(-1)!, noKeys)).toBeUndefined()
+  })
+
+  it("announces nothing the player couldn't start", () => {
+    expect(nextPyramidJourneyId(journeys, juniorPyramids[0], noKeys)).toBeUndefined()
+  })
+})

--- a/src/app/pages/journeyAvailability.ts
+++ b/src/app/pages/journeyAvailability.ts
@@ -1,0 +1,52 @@
+import type { Difficulty } from "@/data/difficultyLevels"
+import { TIER_UNLOCK_PERK_IDS } from "@/data/treasurePerks"
+import type { Journey } from "@/data/journeys"
+
+// Which expeditions the player may pick, and why.
+//
+// Crossing into a difficulty tier is a possession check, not a completion count: holding ANY ONE of
+// that tier's unlock treasures admits you (docs/game-design/keys-and-locks-solver.md, "Global-scoped
+// — the next difficulty tier unlocks"). World-gen's solver guarantees the world is finishable along
+// exactly that ladder (`isTierUnlocked` in worldGen/reachability.ts), so the screen has to gate on
+// the same fact — a second, different rule here is what let the two drift apart.
+//
+// Within a tier, journeys still open one at a time: the tier's first is available as soon as the
+// tier is, each later one when the pyramid before it has been completed.
+
+export const isTierUnlocked = (difficulty: Difficulty, heldKeys: ReadonlySet<string>): boolean => {
+  // The first tier has no entry key — nothing gates the start of the game.
+  const keys = TIER_UNLOCK_PERK_IDS[difficulty]
+  if (!keys) return true
+  return keys.some(keyId => heldKeys.has(keyId))
+}
+
+export const availablePyramidJourneyIds = (
+  journeys: readonly Journey[],
+  heldKeys: ReadonlySet<string>,
+  isCompleted: (journeyId: string) => boolean
+): ReadonlySet<string> => {
+  const available = new Set<string>()
+  const previousInTier = new Map<Difficulty, Journey>()
+  for (const journey of journeys) {
+    if (journey.type !== "pyramid") continue
+    const previous = previousInTier.get(journey.difficulty)
+    previousInTier.set(journey.difficulty, journey)
+    if (!isTierUnlocked(journey.difficulty, heldKeys)) continue
+    if (!previous || isCompleted(previous.id)) available.add(journey.id)
+  }
+  return available
+}
+
+// The expedition the completion screen offers next: the pyramid journey following this one, and
+// only if the player may actually pick it — announcing a locked tier would be a dead end.
+export const nextPyramidJourneyId = (
+  journeys: readonly Journey[],
+  journeyId: string,
+  heldKeys: ReadonlySet<string>
+): string | undefined => {
+  const index = journeys.findIndex(j => j.id === journeyId)
+  if (index === -1) return undefined
+  const next = journeys[index + 1]
+  if (!next || next.type !== "pyramid") return undefined
+  return isTierUnlocked(next.difficulty, heldKeys) ? next.id : undefined
+}


### PR DESCRIPTION
## What was wrong

Travel decided what you may pick from **list order alone**: a journey appeared once the entry before it had `completionCount > 0` (`Travel.tsx:121`). The starter tomb sits between `starter_4` and `junior_1`, so junior needed the *tomb journey* completed — leave the tomb and confirm on the completion overlay — even while already holding the treasure that is supposed to admit you.

Reported from play: "I got the Deben as treasure, but cannot choose a junior expedition." The Deben is `starter_a_1`, whose perk is literally `tier-unlock: junior`, and the loot popup now says so.

## What the design says

> **Global-scoped** — the next difficulty tier unlocks.
> Collecting ANY ONE of a tomb's 4 designated tier-unlock treasures (`TIER_UNLOCK_PERK_IDS`) unlocks the next tier.

— `docs/game-design/keys-and-locks-solver.md`

World-gen's solver already implements exactly that (`isTierUnlocked`, `worldGen/reachability.ts`) and **guarantees the world is finishable along that ladder**. Nothing in the app ever called it. So the screen enforced a second, unrelated rule, and the two were free to drift — which is what happened.

## The change

`src/app/pages/journeyAvailability.ts` is the app-side rule, stating the same fact the solver does:

- crossing into a tier is a **possession check** on that tier's four unlock keys;
- inside a tier, journeys still open **one at a time** by completion;
- list order no longer carries a tier boundary, so finishing the tomb is not a prerequisite for the next tier (it stays worth doing for its later floors).

The completion overlay's "new expedition unlocked" reads the same function, so it can't announce a journey the player is unable to start.

Per the decisions taken while diagnosing: the key admits you to the tier's **first** expedition (not all four at once), and the key is the **only** way across a tier boundary (no list-order fallback).

## On the regression-test question

There was no coverage of journey availability anywhere — no spec touched the rule, which is precisely why the app could disagree with the solver it depends on. `journeyAvailability.spec.ts` now pins it against the real journey data: fresh game, in-tier progression, next tier shut without a key however much is completed, opened by any one of the four, and the overlay's announcement.

`yarn test` 1193 pass, `yarn check-types` and `yarn lint` clean.

## Save note

Existing saves gain rather than lose: a player holding a tier-unlock treasure sees that tier open immediately. A save that somehow crossed a tier without holding any of its four keys would find that tier gated — the tomb is re-enterable, so it is recoverable, and no such state should exist since the tomb is the only source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CtdWuKt2JHUqZT9XaCiVbC