### PR TITLE
Mark a ward door with the sign of the key that opens it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- A ward door carries the sign of the treasure that opens it, so you can see which key it wants — the same glyph that treasure shows in the Collection.
 
 ## 0.32.1 - 2026-08-08
 ### Changed

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -102,6 +102,7 @@
   "gate": {
     "title": "🔒 Locked Gate",
     "locked": "You don't have the right key yet.",
+    "markedWith": "A sign is cut into the door:",
     "unlocked": "You have the key.",
     "pass": "Pass through",
     "turnAround": "Turn around",

--- a/public/locales/nl/common.json
+++ b/public/locales/nl/common.json
@@ -102,6 +102,7 @@
   "gate": {
     "title": "🔒 Gesloten Poort",
     "locked": "Je hebt de juiste sleutel nog niet.",
+    "markedWith": "In de deur staat een teken gekerfd:",
     "unlocked": "Je hebt de sleutel.",
     "pass": "Doorgaan",
     "turnAround": "Omdraaien",

--- a/src/app/SiteMap/keyProviders.ts
+++ b/src/app/SiteMap/keyProviders.ts
@@ -15,6 +15,32 @@ export const registerHeldKeysProvider = (useKeys: UseHeldKeys) => registry.push(
 // Calls each provider hook in a fixed order (the registry is populated once at module load — each
 // mod's app entrypoint pushes exactly once — so the hooks run in the same order every render,
 // rules-of-hooks safe) and unions them into one set of held key ids.
+// How a mod says what one of its keys LOOKS like — the sign a locked door carries, so a ward gate
+// can show which key opens it without core knowing that a key id is a tomb treasure. Same
+// hook-shaped seam as the held-keys providers above; a provider returns undefined for any key it
+// doesn't own, and the merged lookup takes the first owner's answer.
+export type KeyDisplay = { symbol: string }
+export type UseKeyDisplay = () => (keyId: string) => KeyDisplay | undefined
+
+const displayRegistry: UseKeyDisplay[] = []
+
+export const registerKeyDisplay = (useDisplay: UseKeyDisplay) => displayRegistry.push(useDisplay)
+
+export const useMergedKeyDisplay = (): ((keyId: string) => KeyDisplay | undefined) => {
+  const lookups: ((keyId: string) => KeyDisplay | undefined)[] = []
+  for (const useDisplay of displayRegistry) {
+    // eslint-disable-next-line react-hooks/rules-of-hooks -- stable registry order; see above
+    lookups.push(useDisplay())
+  }
+  return keyId => {
+    for (const lookup of lookups) {
+      const display = lookup(keyId)
+      if (display) return display
+    }
+    return undefined
+  }
+}
+
 export const useMergedHeldKeys = (): ReadonlySet<string> => {
   const sets: ReadonlySet<string>[] = []
   for (const useKeys of registry) {

--- a/src/mods/core/app/keyGate/plugin.spec.tsx
+++ b/src/mods/core/app/keyGate/plugin.spec.tsx
@@ -1,0 +1,70 @@
+import { render, cleanup } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import type { FamilyContext } from "@/app/families/familyRegistry"
+import { registerKeyDisplay } from "@/app/SiteMap/keyProviders"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+// Stands in for the tomb-treasure mod: it owns the ward keys, so it is what knows a key's sign.
+const WARD_SYMBOL = "𓈖"
+registerKeyDisplay(() => keyId => (keyId === "starter_a_1" ? { symbol: WARD_SYMBOL } : undefined))
+
+const { getFamilyPlugin } = await import("@/app/families/familyRegistry")
+await import("./plugin")
+
+const plugin = getFamilyPlugin("key-gate")!
+
+const ctx = (overrides: Partial<FamilyContext>): FamilyContext =>
+  ({
+    journeyId: "starter_1",
+    edgeId: "0:1,1",
+    sectionHash: "",
+    freshArrival: true,
+    difficulty: "starter",
+    gateVariant: "tomb-key",
+    ...overrides,
+  }) as FamilyContext
+
+const renderGate = (overrides: Partial<FamilyContext>) => {
+  const context = ctx(overrides)
+  return render(
+    <plugin.Component
+      puzzle={plugin.generate(1, context)}
+      ctx={context}
+      // The gate reads none of these; it has no state of its own beyond the key precondition.
+      progression={undefined as never}
+      journeys={undefined as never}
+      inventory={undefined as never}
+      applyReward={() => {}}
+      onSolved={() => {}}
+      onCancel={() => {}}
+    />
+  )
+}
+
+afterEach(cleanup)
+
+describe("ward gate", () => {
+  it("shows the sign of the key that opens it, so a locked door says which key it wants", () => {
+    const { queryByText } = renderGate({ requiredKeyId: "starter_a_1", ownedKeys: new Set() })
+
+    expect(queryByText("gate.markedWith")).not.toBeNull()
+    expect(queryByText(WARD_SYMBOL)).not.toBeNull()
+    expect(queryByText("gate.locked")).not.toBeNull()
+  })
+
+  it("keeps showing the sign once the key is held, so the door still reads as that treasure's", () => {
+    const { queryByText } = renderGate({ requiredKeyId: "starter_a_1", ownedKeys: new Set(["starter_a_1"]) })
+
+    expect(queryByText(WARD_SYMBOL)).not.toBeNull()
+    expect(queryByText("gate.unlocked")).not.toBeNull()
+  })
+
+  it("shows no mark for a key nobody has a sign for", () => {
+    const { queryByText } = renderGate({ requiredKeyId: "floor_key_red", ownedKeys: new Set() })
+
+    expect(queryByText("gate.markedWith")).toBeNull()
+  })
+})

--- a/src/mods/core/app/keyGate/plugin.tsx
+++ b/src/mods/core/app/keyGate/plugin.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next"
 import { registerFamily, type FamilyContext, type FamilyPlugin } from "@/app/families/familyRegistry"
 import { KEY_GATE_META } from "@/mods/core/game/keyGate/meta"
 import { wardKeyDifficulty } from "@/data/difficultyLevels"
+import { useMergedKeyDisplay } from "@/app/SiteMap/keyProviders"
 
 type KeyGatePuzzle = { satisfied: boolean }
 
@@ -19,6 +20,8 @@ const KeyGateComponent: FamilyPlugin["Component"] = ({ puzzle, ctx, onSolved, on
   // A ward (tomb-key) gate carries the flavor of the tier that sealed it (merchant, noble, ...),
   // derived from its key's difficulty. Floor-key/color gates have no such theme.
   const wardDifficulty = ctx.gateVariant === "tomb-key" ? wardKeyDifficulty(ctx.requiredKeyId) : undefined
+  const keyDisplay = useMergedKeyDisplay()
+  const keySymbol = ctx.requiredKeyId ? keyDisplay(ctx.requiredKeyId)?.symbol : undefined
   return (
     <div className="fixed inset-0 z-30 flex flex-col items-center justify-center gap-6 bg-black/85">
       <p className="font-pyramid text-2xl text-amber-300">{t("gate.title")}</p>
@@ -26,6 +29,15 @@ const KeyGateComponent: FamilyPlugin["Component"] = ({ puzzle, ctx, onSolved, on
         <p className="max-w-xs text-center text-sm text-stone-400 italic">
           {t(`gate.wardDescription.${wardDifficulty}`)}
         </p>
+      )}
+      {/* The sign cut into the door: the key's own symbol, so a locked door says WHICH key it wants
+          — the same glyph that treasure wears in the Collection. Mod-supplied (see keyProviders);
+          a key whose owner has no symbol for it simply shows no mark. */}
+      {keySymbol && (
+        <div className="flex flex-col items-center gap-1">
+          <p className="text-sm text-stone-400">{t("gate.markedWith")}</p>
+          <span className="font-mono text-5xl text-amber-200">{keySymbol}</span>
+        </div>
       )}
       <p className="text-sm text-stone-300">{satisfied ? t("gate.unlocked") : t("gate.locked")}</p>
       <div className="flex flex-col items-center gap-3">

--- a/src/mods/tombTreasure/app/index.ts
+++ b/src/mods/tombTreasure/app/index.ts
@@ -1,10 +1,11 @@
 import { registerRewardContribution } from "@/app/SiteMap/rewardContributions"
 import { registerRewardSchema } from "@/app/SiteMap/rewardSchemas"
-import { registerHeldKeysProvider } from "@/app/SiteMap/keyProviders"
+import { registerHeldKeysProvider, registerKeyDisplay } from "@/app/SiteMap/keyProviders"
 import { useMergedPerkContributions } from "@/app/SiteMap/perkContributions"
 import { registerCollectionSection } from "@/app/pages/collectionSectionRegistry"
 import { isModEnabled } from "@/mods/registeredMods"
 import { TREASURE_PERKS } from "../game/treasurePerks"
+import { treasureDisplayByKeyId } from "../game/treasures"
 import { useTombTreasureProgress } from "./useTombTreasureProgress"
 import { registerTombTreasureRewardDisplay } from "./rewardDisplay"
 import { TombTreasureCollectionSection } from "./TombTreasureCollectionSection"
@@ -42,6 +43,12 @@ if (isModEnabled("tomb-treasure")) {
     }
   })
   registerHeldKeysProvider(() => useTombTreasureProgress().tombKeyIds)
+  // A ward key IS a treasure, so a door sealed with one carries that treasure's sign — the same
+  // glyph its Collection slot shows, which is how the player recognizes what they're missing.
+  registerKeyDisplay(() => keyId => {
+    const treasure = treasureDisplayByKeyId[keyId]
+    return treasure ? { symbol: treasure.symbol } : undefined
+  })
   // The 5 per-difficulty treasure groups. Ordered first (before hieroglyph=20 / shop=30) — ward
   // treasures are the most valuable collectibles (ward keys + their perks). "Collected" = own the
   // tombKey; drops out of the Collection screen when the mod is off.


### PR DESCRIPTION
A ward door only told you whether you held the right key — never *which* key. It now carries the key's own symbol, the same glyph that treasure wears in its Collection slot, so an unfamiliar door is something you can go and look up.

```
🔒 Locked Gate
A merchant's seal bars this passage — only their ward key will part it.

A sign is cut into the door:
            𓈖

You don't have the right key yet.
```

The mark stays once you hold the key, so the door keeps reading as that treasure's.

## The seam

Core must not know that a key id is a tomb treasure, so the symbol is mod-supplied: `registerKeyDisplay` in `keyProviders.ts`, shaped like the held-keys providers already beside it (hook, first owner answers, `undefined` for keys a mod doesn't own). The tomb-treasure mod answers for its own keys off its catalog.

Consequences that fall out of that: a floor-key/colour gate shows no mark (nobody claims those ids), and with the tomb-treasure mod toggled off the registry is empty and the door renders exactly as before.

## Testing

`yarn test` 1185 pass, `yarn check-types` and `yarn lint` clean. New `plugin.spec.tsx` covers the three cases: locked door shows the sign, held key keeps it, unclaimed key id shows no mark. New string in `en` and `nl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CtdWuKt2JHUqZT9XaCiVbC