### PR TITLE
Merge CHANGELOG entries instead of conflicting on them

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Two branches almost always add their entries to the same spot — the top of ## Unreleased — which
+# git reads as a conflict on every second PR. `union` keeps both sides' lines instead of stopping:
+# git's own built-in driver, no local setup, and GitHub applies it to PR merges too.
+#
+# The cost is that a merged Unreleased can end up with a heading twice (two `### Fixed` blocks) or
+# entries interleaved out of order. Both are harmless to read and a one-line tidy at release time —
+# strictly better than hand-resolving conflict markers on a file where both sides are always right.
+CHANGELOG.md merge=union


### PR DESCRIPTION
Every second PR conflicts on `CHANGELOG.md`, always for the same reason: both branches add their entry at the top of `## Unreleased`. Nothing is actually in dispute — both sides are right.

```
CHANGELOG.md merge=union
```

`union` is git's own built-in merge driver: on a conflicting hunk it keeps **both** sides' lines rather than writing conflict markers. No local setup for anyone (unlike a custom driver, which needs a `git config merge.<name>.driver` on every machine), and GitHub applies it to PR merges as well.

Verified locally: two branches each adding an entry under `## Unreleased`, merged clean with both entries present.

## The mess it leaves is cleaned up by the release we already run

A union merge can leave `## Unreleased` with a heading twice (two `### Fixed` blocks — exactly what we hand-fixed on #167) or with sections interleaved out of order. `scripts/release.ts` parses the file with `keep-a-changelog`, which groups entries into a map by type and re-renders one heading per type in canonical order. Checked against the real dependency: a section with two separate `### Fixed` blocks parses to `fixed count: 2` and comes back out as a single ordered `### Fixed`.

So the untidiness lives only in `## Unreleased` between releases, and `yarn release` normalizes it without any change to the script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CtdWuKt2JHUqZT9XaCiVbC