### PR TITLE
fix(ui): stop the hieroglyph tile's engraved shadow from doubling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - The "X/Y needed" count on a still-collecting hieroglyph in the tomb's available-symbols strip was stuck in English regardless of your chosen language.
+- A hieroglyph tile's engraved shading could show as a doubled, mismatched-color outline around the symbol, most visible on devices missing the true hieroglyph glyph.
 
 ## 0.33.1 - 2026-08-09
 

--- a/src/ui/molecules/HieroglyphTile.tsx
+++ b/src/ui/molecules/HieroglyphTile.tsx
@@ -221,8 +221,10 @@ export const HieroglyphTile: FC<HieroglyphTileProps> = ({
             style={{
               // Symbol color matches the darker tile background
               color: disabled ? "#6b7280" : difficultyMaterial[difficulty].symbol,
-              // Subtle engraved effect for the symbol
-              textShadow: disabled ? "none" : "0 1px 0 rgba(255, 255, 255, 0.8), 0 -1px 0 rgba(0, 0, 0, 0.3)",
+              // Subtle depth for the symbol — a single soft shadow, not a two-tone offset pair:
+              // those doubled visibly (a light copy above, a dark copy below) on glyphs that
+              // render as a simple box (e.g. a hieroglyph missing from the device's font).
+              textShadow: disabled ? "none" : "0 1px 1px rgba(0, 0, 0, 0.35)",
               filter: selected ? "brightness(1.1)" : "none",
             }}
           >


### PR DESCRIPTION
Reported from a real device screenshot: a hint-formula tile's symbol showed a visibly doubled outline — a light copy above, a dark copy below, in contrasting colors.

## Cause

`HieroglyphTile`'s normal (non-fragment) symbol rendering used a two-tone offset `textShadow` (`0 1px 0 white, 0 -1px 0 black`) meant as a subtle "engraved" bevel. On a glyph that renders as a simple box — e.g. a hieroglyph the device's font has no glyph for, or any solid-shape symbol — the two offset copies read as a clearly doubled icon instead of a subtle bevel.

## Change

Replaced the two offset shadows with a single soft shadow (`0 1px 1px rgba(0,0,0,0.35)`). Verified in Storybook at 3x scale: the previous version showed a distinct red/white double outline around a fallback glyph box; the new version shows one clean shape with soft depth.

## Scope

`HieroglyphTile.tsx` only — the shadow style used by every filled tile across the game (Collection, tableau formula, inventory strip, etc).

## Verification

- Full suite: 1197 tests passing, `tsc --noEmit` and `eslint` clean.
- Storybook `HieroglyphTile / LargeSize` screenshotted before/after at 3x device scale to confirm the doubling is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01BU4goDhQufw7LQAdvGzqn2)_