### PR TITLE
feat(keys): make floor keys legible and drop the interior cheat buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- A locked floor door now names the coloured key it wants, and draws it.
+- Finding a floor key names its colour in the loot popup instead of calling it a tomb key.
+- The interior HUD carries this floor's key ring: coloured keys in hand, plus the colours of doors seen here and still shut.
+
+### Removed
+
+- The interior HUD's developer cheat buttons (+Junk, +Hieroglyphs, +1000 Coins).
+
 ## 0.33.3 - 2026-08-10
 
 ### Changed

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -113,7 +113,9 @@
       "expert": "A high priest's temple ward guards this door — its sacred key must open it.",
       "master": "A pharaoh's royal seal binds this passage — only the sovereign's key breaks it.",
       "wizard": "A ward of the gods holds this gate — nothing but its divine key will pass."
-    }
+    },
+    "needsKey": "The door is marked for one key:",
+    "lockedColor": "You haven't found that key on this floor yet."
   },
   "chest": {
     "tapToOpen": "Tap to open",
@@ -213,5 +215,16 @@
       "hidden": "In a hidden corridor — needs the passageway detector",
       "unknown": "Might not be reachable yet — it's inside a tomb or for sale"
     }
+  },
+  "keys": {
+    "blue": "Blue key",
+    "red": "Red key",
+    "green": "Green key",
+    "yellow": "Yellow key",
+    "purple": "Purple key",
+    "bundle": "A ring of keys",
+    "foundDescription": "It opens the doors marked in this colour, on this floor.",
+    "heldTitle": "{{key}} — in hand",
+    "neededTitle": "{{key}} — still needed"
   }
 }

--- a/public/locales/nl/common.json
+++ b/public/locales/nl/common.json
@@ -113,7 +113,9 @@
       "expert": "De tempelban van een hogepriester bewaakt deze deur — enkel de heilige sleutel opent hem.",
       "master": "Het koninklijke zegel van een farao bindt deze doorgang — enkel de sleutel van de vorst verbreekt het.",
       "wizard": "Een ban van de goden houdt deze poort — niets dan de goddelijke sleutel komt erlangs."
-    }
+    },
+    "needsKey": "De deur is gemarkeerd voor één sleutel:",
+    "lockedColor": "Die sleutel heb je op deze verdieping nog niet gevonden."
   },
   "chest": {
     "tapToOpen": "Tik om te openen",
@@ -206,5 +208,16 @@
     "huntStop": "Stop",
     "huntHint": "Selecteer een niet-verzamelde hiëroglief en jaag erop met het kompas",
     "huntAction": "Jaag op {{symbol}}"
+  },
+  "keys": {
+    "blue": "Blauwe sleutel",
+    "red": "Rode sleutel",
+    "green": "Groene sleutel",
+    "yellow": "Gele sleutel",
+    "purple": "Paarse sleutel",
+    "bundle": "Een bos sleutels",
+    "foundDescription": "Hij opent de deuren met deze kleur, op deze verdieping.",
+    "heldTitle": "{{key}} — in bezit",
+    "neededTitle": "{{key}} — nog nodig"
   }
 }

--- a/src/app/SiteMap/RewardFlow.render.spec.tsx
+++ b/src/app/SiteMap/RewardFlow.render.spec.tsx
@@ -75,6 +75,54 @@ describe("RewardFlow — money and sellable rewards", () => {
     expect(container.textContent).toContain("sell_divine_1.name")
   })
 
+  // A floor key is claimed as a `tombKey` whose id is a grid position, so the tomb-treasure display
+  // can only call it "Tomb Key". The chest's own colour is what makes the reveal useful.
+  it("names the colour of a found floor key instead of the generic tomb-key label", () => {
+    const { container } = render(
+      <RewardFlow
+        pendingReward={{
+          reward: { type: "tombKey", keyId: "starter_1-3-4" },
+          keyColors: ["green"],
+          onCollect: vi.fn(),
+        }}
+        onDismiss={() => {}}
+      />
+    )
+    advanceThroughReveal()
+    expect(container.textContent).toContain("keys.green")
+    expect(container.textContent).toContain("keys.foundDescription")
+    expect(container.textContent).not.toContain("chest.tombKey")
+  })
+
+  it("shows one key per colour when a chest holds several floor keys", () => {
+    const { container } = render(
+      <RewardFlow
+        pendingReward={{
+          reward: { type: "tombKey", keyId: "starter_1-3-4" },
+          keyColors: ["blue", "red"],
+          onCollect: vi.fn(),
+        }}
+        onDismiss={() => {}}
+      />
+    )
+    advanceThroughReveal()
+    expect(container.textContent).toContain("keys.bundle")
+    expect(container.querySelectorAll("svg[role='img']")).toHaveLength(2)
+  })
+
+  // A real tomb treasure also travels as a tombKey, but its chest wears no colour — it must keep the
+  // mod's rich display (treasure name + perk line), not become a "floor key".
+  it("leaves a colourless tomb treasure to the tomb-treasure display", () => {
+    const { container } = render(
+      <RewardFlow
+        pendingReward={{ reward: { type: "tombKey", keyId: "starter_a_1" }, onCollect: vi.fn() }}
+        onDismiss={() => {}}
+      />
+    )
+    advanceThroughReveal()
+    expect(container.textContent).not.toContain("keys.foundDescription")
+  })
+
   it("falls back to the raw itemId if the sellable id is unknown", () => {
     const onCollect = vi.fn()
     const { container } = render(

--- a/src/app/SiteMap/RewardFlow.tsx
+++ b/src/app/SiteMap/RewardFlow.tsx
@@ -1,16 +1,41 @@
 import { useEffect, useState, type FC } from "react"
 import { useTranslation } from "react-i18next"
 
-import type { TreasureReward } from "@/game/siteTypes"
+import type { KeyColor, TreasureReward } from "@/game/siteTypes"
 import { LootPopup } from "@/ui/atoms/LootPopup"
+import { KeyIcon } from "@/ui/atoms/KeyIcon"
 import { useTimeout } from "@/support/useTimeout"
 import { rewardText } from "./rewardDisplay"
 import { useMergedRewardDisplays, type RewardDisplay } from "./rewardDisplayRegistry"
+import type { TFn } from "./rewardHandlerRegistry"
 
 type Props = {
-  pendingReward: { reward: TreasureReward; consumableFull?: boolean; onCollect: () => void } | null
+  pendingReward: {
+    reward: TreasureReward
+    consumableFull?: boolean
+    /** Set when the chest held this floor's key(s) — core chrome, see floorKeyDisplay below. */
+    keyColors?: readonly KeyColor[]
+    onCollect: () => void
+  } | null
   onDismiss: () => void
 }
+
+// A floor key is a structural, floor-local thing core itself places (siteAssembler), and its colour
+// lives on the chest cell rather than in the reward payload — so core owns this popup content, the
+// same way it owns the pack-full chrome below. Without it a found floor key read as a generic "Tomb
+// Key" with no hint of which door it opens.
+const floorKeyDisplay = (colors: readonly KeyColor[], t: TFn): RewardDisplay => ({
+  rarity: "rare",
+  itemName: colors.length === 1 ? t(`keys.${colors[0]}`) : t("keys.bundle"),
+  itemDescription: t("keys.foundDescription"),
+  ItemVisual: (
+    <span className="flex items-center justify-center gap-2">
+      {colors.map(color => (
+        <KeyIcon key={color} color={color} size={64} title={t(`keys.${color}`)} />
+      ))}
+    </span>
+  ),
+})
 
 export const RewardFlow: FC<Props> = ({ pendingReward, onDismiss }) => {
   const { t } = useTranslation(["common", "inventory", "sellables", "treasures", "journeys"])
@@ -29,7 +54,7 @@ export const RewardFlow: FC<Props> = ({ pendingReward, onDismiss }) => {
 
   if (!pendingReward) return null
 
-  const { reward, consumableFull } = pendingReward
+  const { reward, consumableFull, keyColors } = pendingReward
 
   const handleDismiss = () => {
     setShowLoot(false)
@@ -41,11 +66,13 @@ export const RewardFlow: FC<Props> = ({ pendingReward, onDismiss }) => {
   // from the synchronous reward handler. Core owns the shell (LootPopup) and names no mod.
   const build = displays[reward.type]
   const display: RewardDisplay =
-    build?.(reward, t) ??
-    (() => {
-      const { itemName, itemDescription, icon } = rewardText(reward, t)
-      return { itemName, itemDescription, ItemVisual: <span className="text-6xl">{icon}</span> }
-    })()
+    keyColors && keyColors.length > 0
+      ? floorKeyDisplay(keyColors, t)
+      : (build?.(reward, t) ??
+        (() => {
+          const { itemName, itemDescription, icon } = rewardText(reward, t)
+          return { itemName, itemDescription, ItemVisual: <span className="text-6xl">{icon}</span> }
+        })())
 
   return (
     <>

--- a/src/app/SiteMap/SiteMapScreen.spec.tsx
+++ b/src/app/SiteMap/SiteMapScreen.spec.tsx
@@ -4,9 +4,13 @@ import type { FloorConfig, FloorGrid, GridCell } from "@/game/siteTypes"
 import { CELL } from "./mapScale"
 import { clearGameData } from "@/support/useGameStorage"
 
-// Keys are enough to tell the buttons apart; none of these assertions read copy.
+// Keys are enough to tell the buttons apart; none of these assertions read copy. Interpolated data
+// is appended so a label built from a nested lookup (the key ring's "<colour> key — in hand") still
+// says which colour it stands for.
 vi.mock("react-i18next", () => ({
-  useTranslation: () => ({ t: (key: string) => key }),
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => (opts ? `${key}:${JSON.stringify(opts)}` : key),
+  }),
 }))
 
 // The screen's own click handling is what's under test, so the floor comes from here rather than
@@ -15,15 +19,19 @@ const entrance: GridCell = { type: "room", roomType: "portal", dirs: new Set(["e
 const corridor: GridCell = { type: "corridor", dirs: new Set(["w", "e"]), state: "completed" }
 const exitRoom: GridCell = { type: "room", roomType: "portal", dirs: new Set(["w"]), state: "reachable" }
 
-const grid: FloorGrid = {
-  cells: [[entrance, corridor, exitRoom]],
+const gridOf = (cells: GridCell[]): FloorGrid => ({
+  cells: [cells],
   rows: 1,
-  cols: 3,
+  cols: cells.length,
   entrancePos: [0, 0],
-  exitPos: [0, 2],
+  exitPos: [0, cells.length - 1],
   siteId: "test-site",
   staircases: {},
-}
+})
+
+const walkableFloor = gridOf([entrance, corridor, exitRoom])
+// Swapped per test (the mock below reads it lazily), so a floor-key test can supply its own layout.
+let grid: FloorGrid = walkableFloor
 
 vi.mock("./useAssembledFloor", async importOriginal => {
   const actual = await importOriginal<typeof import("./useAssembledFloor")>()
@@ -61,6 +69,7 @@ const exitNode = (container: HTMLElement) =>
 
 describe(SiteMapScreen, () => {
   beforeEach(async () => {
+    grid = walkableFloor
     // jsdom doesn't implement scrollTo; SiteMapView calls it to center on explorerPos.
     Element.prototype.scrollTo = vi.fn()
     await clearGameData()
@@ -122,5 +131,39 @@ describe(SiteMapScreen, () => {
     // Confirming hands over to the exit transition, which completes the site when it finishes.
     expect(queryByText("ui.leaveSiteConfirm")).toBeNull()
     expect(container.querySelector(".animate-entrance-zoom")).not.toBeNull()
+  })
+
+  describe("the floor key ring", () => {
+    const keyChest: GridCell = {
+      type: "room",
+      roomType: "encounter",
+      dirs: new Set(["e"]),
+      state: "completed",
+      reward: { type: "tombKey", keyId: "test-site-0-0" },
+      keyColor: "blue",
+    }
+    const redDoor: GridCell = {
+      type: "room",
+      roomType: "encounter",
+      dirs: new Set(["w"]),
+      state: "reachable",
+      gateVariant: "floor-key",
+      keyColor: "red",
+      requiredKeyId: "test-site-0-9",
+    }
+
+    it("shows the colour of a key picked up on this floor, and of a door still shut", async () => {
+      grid = gridOf([keyChest, redDoor])
+      const { getByTitle } = await renderScreen()
+
+      expect(getByTitle(/keys\.heldTitle.*keys\.blue/)).toBeTruthy()
+      expect(getByTitle(/keys\.neededTitle.*keys\.red/)).toBeTruthy()
+    })
+
+    it("shows nothing on a floor with no keys and no doors", async () => {
+      const { queryByTitle } = await renderScreen()
+
+      expect(queryByTitle(/keys\./)).toBeNull()
+    })
   })
 })

--- a/src/app/SiteMap/SiteMapScreen.tsx
+++ b/src/app/SiteMap/SiteMapScreen.tsx
@@ -1,10 +1,11 @@
-import { use, useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { findPath, getCell, getOwnedKeys } from "@/game/gridNavigation"
+import { floorKeyRing } from "@/game/floorKeys"
 import { getFamilyPlugin, type FamilyContext } from "@/app/families/familyRegistry"
 import { hashString } from "@/support/hashString"
 import { useTimeout } from "@/support/useTimeout"
-import type { SiteConfig, TreasureReward } from "@/game/siteTypes"
+import type { KeyColor, SiteConfig, TreasureReward } from "@/game/siteTypes"
 import { SiteMapView } from "./SiteMapView"
 import { useAssembledFloor, encodeEdge } from "./useAssembledFloor"
 import { floorOfPosition, stairPeerPosition } from "./stairTravel"
@@ -15,9 +16,6 @@ import { useJourneys } from "@/app/state/useJourneys"
 import { useProgression } from "@/app/state/useProgression"
 import { useDetector } from "@/app/state/useDetector"
 import { useInventory } from "@/app/Inventory/useInventory"
-import { DevelopContext } from "@/contexts/DevelopMode"
-import { allItems } from "@/data/inventory"
-import { ALL_SELLABLES } from "@/data/sellables"
 import { EntranceTransitionOverlay } from "@/ui/atoms/EntranceTransitionOverlay"
 import { hudWidgets } from "@/app/SiteMap/hudRegistry"
 import { useMergedRewardContributions } from "@/app/SiteMap/rewardContributions"
@@ -31,7 +29,7 @@ import { BackButton } from "@/ui/atoms/BackButton"
 import { ConfirmModal } from "@/ui/atoms/ConfirmModal"
 import { FloorBadge } from "@/ui/atoms/FloorBadge"
 import { SiteHudBar } from "@/ui/atoms/SiteHudBar"
-import { DeveloperButton } from "@/ui/atoms/DeveloperButton"
+import { FloorKeyRing } from "@/ui/molecules/FloorKeyRing"
 // Side-effect: registers every mod's app contributions (families, HUD, reward effects, …)
 import "@/mods/registerModApps"
 
@@ -45,7 +43,6 @@ type Props = {
 
 export const SiteMapScreen = ({ journeyId, siteConfig, seed, onSiteComplete, onCancel }: Props) => {
   const { t } = useTranslation(["common", "inventory", "sellables"])
-  const { isDevelopMode } = use(DevelopContext)
   const journeys = useJourneys()
   const progression = useProgression()
   const rewardContributions = useMergedRewardContributions()
@@ -119,6 +116,10 @@ export const SiteMapScreen = ({ journeyId, siteConfig, seed, onSiteComplete, onC
   // gate coloring.
   const ownedKeys = useMemo(() => (grid ? new Set([...getOwnedKeys(grid), ...wardKeys]) : wardKeys), [grid, wardKeys])
 
+  // What the HUD key ring shows: this floor's coloured keys in hand, and the colours of doors the
+  // player has already seen here and can't open yet (fogged ones stay secret — see floorKeys.ts).
+  const keyRing = useMemo(() => (grid ? floorKeyRing(grid, ownedKeys) : { held: [], needed: [] }), [grid, ownedKeys])
+
   // Per-floor "still stuff to find here" summary for the Travel marker. The pure classification
   // (loot nodes / key-gated nodes / fogged corridors, keys-and-gates only, no mod names) lives in
   // floorExploration.ts and is unit-tested there.
@@ -163,6 +164,7 @@ export const SiteMapScreen = ({ journeyId, siteConfig, seed, onSiteComplete, onC
   const [pendingReward, setPendingReward] = useState<{
     reward: TreasureReward
     consumableFull?: boolean
+    keyColors?: readonly KeyColor[]
     onCollect: () => void
   } | null>(null)
   const [exiting, setExiting] = useState(false)
@@ -222,6 +224,10 @@ export const SiteMapScreen = ({ journeyId, siteConfig, seed, onSiteComplete, onC
 
       const reward = cell?.type === "room" ? cell.reward : undefined
       if (!reward) return
+      // A key-host chest wears the colour(s) of the doors its key opens; carry that into the popup so
+      // the reveal says WHICH key this was, not just "a key".
+      const keyColors =
+        cell?.type === "room" ? (cell.keyColors ?? (cell.keyColor ? [cell.keyColor] : undefined)) : undefined
       // A mod may silently ignore a reward (nothing to do — e.g. an already-collected hieroglyph
       // fragment): no popup, no side effect, not remembered. Distinct from a refusal below.
       if (rewardContributions.skip(reward)) return
@@ -233,7 +239,7 @@ export const SiteMapScreen = ({ journeyId, siteConfig, seed, onSiteComplete, onC
         setPendingReward({ reward, consumableFull: true, onCollect: () => {} })
         return
       }
-      setPendingReward({ reward, onCollect: () => applyReward(reward) })
+      setPendingReward({ reward, keyColors, onCollect: () => applyReward(reward) })
     },
     [grid, journeys, currentFloor, rewardContributions, applyReward]
   )
@@ -384,7 +390,7 @@ export const SiteMapScreen = ({ journeyId, siteConfig, seed, onSiteComplete, onC
           currentFloor={currentFloor}
           pendingCells={pendingConsumableCells}
           ownedKeys={ownedKeys}
-          className="h-full w-full"
+          className="size-full"
         />
       </div>
       <SiteHudBar>
@@ -420,7 +426,7 @@ export const SiteMapScreen = ({ journeyId, siteConfig, seed, onSiteComplete, onC
           pyramidHiddenCorridorCount={pyramidHiddenCorridorCount}
         />
         {/* pointer-events-auto: opts this row back into hit-testing inside SiteHudBar's
-            non-hit-testing band (the widgets and dev buttons below are clickable). */}
+            non-hit-testing band (the detector toggles and mod widgets below are clickable). */}
         <div className="pointer-events-auto flex items-center gap-4">
           {/* Detector buttons ride along in this row rather than claiming one of their own. */}
           <DetectorToggles
@@ -435,25 +441,18 @@ export const SiteMapScreen = ({ journeyId, siteConfig, seed, onSiteComplete, onC
             }}
             onSetDetector={detector.setDetector}
           />
+          {/* This floor's key ring: coloured keys already in hand, plus the colours of doors seen
+              here and still shut. Floor-local, so it resets with the floor. */}
+          <FloorKeyRing
+            held={keyRing.held}
+            needed={keyRing.needed}
+            heldLabel={color => t("common:keys.heldTitle", { key: t(`common:keys.${color}`) })}
+            neededLabel={color => t("common:keys.neededTitle", { key: t(`common:keys.${color}`) })}
+          />
           {/* Mod-contributed HUD widgets (trap's health + consumables, shop's balance) — core names none. */}
           {hudWidgets().map(({ id, Component }) => (
             <Component key={id} />
           ))}
-          {isDevelopMode && (
-            <DeveloperButton
-              onClick={() => {
-                ALL_SELLABLES.slice(0, 5).forEach(item => inventory.addItem(item.id, 1))
-                inventory.addItem(ALL_SELLABLES[0].id, 1) // second copy, to see the ×N badge
-              }}
-              label="+Junk"
-            />
-          )}
-          {isDevelopMode && (
-            <DeveloperButton
-              onClick={() => allItems.forEach(item => inventory.addItem(item.id, 20))}
-              label="+Hieroglyphs"
-            />
-          )}
         </div>
       </SiteHudBar>
       {/* ponytail: plain confirm dialog for now — the exit chamber's own artwork (daylight through

--- a/src/app/SiteMap/SiteMapView.tsx
+++ b/src/app/SiteMap/SiteMapView.tsx
@@ -12,6 +12,7 @@ import type {
 } from "../../game/siteTypes"
 import { wardKeyDifficulty } from "../../data/difficultyLevels"
 import { revealAll } from "../../game/gridNavigation"
+import { keyColorHex } from "@/ui/tokens/keyColors"
 import { ExplorerDot } from "./ExplorerDot"
 import { useMapZoom } from "./useMapZoom"
 import {
@@ -102,14 +103,6 @@ type ShapeProps = {
   keyColors?: KeyColor[]
   // A ward (tomb-key) gate's tier, derived from its key id — tints the gate by difficulty.
   difficulty?: Difficulty
-}
-
-const KEY_COLOR_HEX: Record<KeyColor, { visible: string; reachable: string }> = {
-  blue: { visible: "#2060c0", reachable: "#4090e0" },
-  red: { visible: "#c04020", reachable: "#e06040" },
-  green: { visible: "#208040", reachable: "#30b060" },
-  yellow: { visible: "#b09010", reachable: "#d0c030" },
-  purple: { visible: "#7030b0", reachable: "#9050d0" },
 }
 
 const PuzzleShape = ({ state }: ShapeProps) => {
@@ -205,7 +198,7 @@ const GateNodeShape = ({ state, gateVariant, keyColor, difficulty }: ShapeProps)
       : isTomb
         ? (tombAccent ?? tombGateStroke[state])
         : keyColor
-          ? KEY_COLOR_HEX[keyColor][colorKey]
+          ? keyColorHex[keyColor][colorKey]
           : gateStroke[state]
   const barColor =
     state === "fogged"
@@ -213,7 +206,7 @@ const GateNodeShape = ({ state, gateVariant, keyColor, difficulty }: ShapeProps)
       : isTomb
         ? (tombAccent ?? (colorKey === "visible" ? "#8040c0" : "#9060e0"))
         : keyColor
-          ? KEY_COLOR_HEX[keyColor][colorKey]
+          ? keyColorHex[keyColor][colorKey]
           : colorKey === "visible"
             ? "#c04020"
             : "#c09020"
@@ -227,7 +220,7 @@ const GateNodeShape = ({ state, gateVariant, keyColor, difficulty }: ShapeProps)
           width={r * 2}
           height={r * 2}
           rx={1}
-          fill={KEY_COLOR_HEX[keyColor][colorKey]}
+          fill={keyColorHex[keyColor][colorKey]}
           fillOpacity={0.18}
         />
       )}
@@ -257,7 +250,7 @@ const TreasureShape = ({ state, keyColor, keyColors }: ShapeProps) => {
   const badges = keyColors && keyColors.length > 0 ? keyColors : keyColor ? [keyColor] : []
   const primaryColor = badges[0]
   const fill = treasureFill[state]
-  const stroke = state !== "fogged" && primaryColor ? KEY_COLOR_HEX[primaryColor][colorKey] : treasureStroke[state]
+  const stroke = state !== "fogged" && primaryColor ? keyColorHex[primaryColor][colorKey] : treasureStroke[state]
   // Badge positions: single circle at top-right; multiple stacked in a column, 2-col for 4+
   const badgePositions = (n: number): [number, number][] => {
     if (n === 1) return [[9, -9]]
@@ -272,7 +265,7 @@ const TreasureShape = ({ state, keyColor, keyColors }: ShapeProps) => {
       {state !== "fogged" && primaryColor && (
         <polygon
           points={`0,${-r} ${r},0 0,${r} ${-r},0`}
-          fill={KEY_COLOR_HEX[primaryColor][colorKey]}
+          fill={keyColorHex[primaryColor][colorKey]}
           fillOpacity={0.18}
         />
       )}
@@ -289,7 +282,7 @@ const TreasureShape = ({ state, keyColor, keyColors }: ShapeProps) => {
             cx={positions[i][0]}
             cy={positions[i][1]}
             r={badgeR}
-            fill={KEY_COLOR_HEX[color][colorKey]}
+            fill={keyColorHex[color][colorKey]}
           />
         ))}
     </>

--- a/src/game/floorKeys.spec.ts
+++ b/src/game/floorKeys.spec.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest"
+import { floorKeyRing } from "./floorKeys"
+import type { CellState, Direction, FloorGrid, GridCell, KeyColor } from "./siteTypes"
+
+const noDirs = new Set<Direction>()
+
+const keyChest = (keyId: string, colors: KeyColor[], state: CellState): GridCell => ({
+  type: "room",
+  roomType: "encounter",
+  dirs: noDirs,
+  state,
+  reward: { type: "tombKey", keyId },
+  ...(colors.length === 1 ? { keyColor: colors[0] } : { keyColors: colors }),
+})
+
+const door = (requiredKeyId: string, color: KeyColor, state: CellState): GridCell => ({
+  type: "room",
+  roomType: "encounter",
+  dirs: noDirs,
+  state,
+  gateVariant: "floor-key",
+  keyColor: color,
+  requiredKeyId,
+})
+
+const gridOf = (cells: GridCell[]): FloorGrid => ({
+  siteId: "test",
+  rows: 1,
+  cols: cells.length,
+  entrancePos: [0, 0],
+  exitPos: [0, cells.length - 1],
+  staircases: {},
+  cells: [cells],
+})
+
+describe(floorKeyRing, () => {
+  it("reports a colour as held once its key chest is opened, not while it still stands closed", () => {
+    const closed = gridOf([keyChest("k1", ["blue"], "reachable"), door("k1", "blue", "reachable")])
+    expect(floorKeyRing(closed, new Set())).toEqual({ held: [], needed: ["blue"] })
+
+    const opened = gridOf([keyChest("k1", ["blue"], "completed"), door("k1", "blue", "reachable")])
+    expect(floorKeyRing(opened, new Set(["k1"]))).toEqual({ held: ["blue"], needed: [] })
+  })
+
+  it("lists every colour a multi-key chest carries", () => {
+    const grid = gridOf([
+      keyChest("k1", ["red", "green"], "completed"),
+      door("k1", "red", "reachable"),
+      door("k1", "green", "reachable"),
+    ])
+    expect(floorKeyRing(grid, new Set(["k1"]))).toEqual({ held: ["red", "green"], needed: [] })
+  })
+
+  it("keeps a fogged door's colour secret — it would spoil layout the player hasn't found", () => {
+    const grid = gridOf([keyChest("k1", ["purple"], "reachable"), door("k1", "purple", "fogged")])
+    expect(floorKeyRing(grid, new Set())).toEqual({ held: [], needed: [] })
+  })
+
+  it("a colour in hand outranks another door still shut in the same colour", () => {
+    const grid = gridOf([
+      keyChest("k1", ["yellow"], "completed"),
+      door("k1", "yellow", "reachable"),
+      // A second yellow door wanting a different key — same hue, so the ring shows it as held, not
+      // as both held and needed.
+      door("k2", "yellow", "reachable"),
+    ])
+    expect(floorKeyRing(grid, new Set(["k1"]))).toEqual({ held: ["yellow"], needed: [] })
+  })
+
+  it("ignores ward (tomb-key) doors — those keys come from tombs, not from this floor", () => {
+    const grid = gridOf([
+      {
+        type: "room",
+        roomType: "encounter",
+        dirs: noDirs,
+        state: "reachable",
+        gateVariant: "tomb-key",
+        requiredKeyId: "starter_a_1",
+      },
+    ])
+    expect(floorKeyRing(grid, new Set())).toEqual({ held: [], needed: [] })
+  })
+
+  it("lists colours in a fixed order regardless of where they sit on the floor", () => {
+    const grid = gridOf([
+      keyChest("k1", ["purple"], "completed"),
+      keyChest("k2", ["red"], "completed"),
+      keyChest("k3", ["blue"], "completed"),
+    ])
+    expect(floorKeyRing(grid, new Set(["k1", "k2", "k3"])).held).toEqual(["blue", "red", "purple"])
+  })
+
+  it("a treasure chest with no key colour is not a key host", () => {
+    const grid = gridOf([
+      {
+        type: "room",
+        roomType: "encounter",
+        dirs: noDirs,
+        state: "completed",
+        reward: { type: "tombKey", keyId: "starter_a_1" },
+      },
+    ])
+    expect(floorKeyRing(grid, new Set(["starter_a_1"]))).toEqual({ held: [], needed: [] })
+  })
+})

--- a/src/game/floorKeys.ts
+++ b/src/game/floorKeys.ts
@@ -1,0 +1,46 @@
+import { KEY_COLORS, type FloorGrid, type KeyColor, type TombKeyReward } from "./siteTypes"
+
+export type FloorKeyRing = {
+  /** Colours whose key chest on this floor is already opened — the keys the player carries here. */
+  held: KeyColor[]
+  /** Colours of doors the player has SEEN on this floor and cannot open yet. */
+  needed: KeyColor[]
+}
+
+const sortByPresentationOrder = (colors: Set<KeyColor>): KeyColor[] => KEY_COLORS.filter(c => colors.has(c))
+
+// Floor keys are floor-local: the chest that holds one and the door it opens sit on the same floor,
+// and a key is "held" the moment its chest is opened (nothing consumes it). So the grid itself is
+// the whole truth — which key chests are completed, and which floor-key doors are still shut.
+//
+// Gate satisfaction is by key id, never by colour: the colour is the sign the door wears so the
+// player can tell which chest to look for. Two doors may share a hue and still want different keys.
+export const floorKeyRing = (grid: FloorGrid, ownedKeys: ReadonlySet<string>): FloorKeyRing => {
+  const held = new Set<KeyColor>()
+  const needed = new Set<KeyColor>()
+
+  for (const row of grid.cells) {
+    for (const cell of row) {
+      if (cell.type !== "room") continue
+      const colors = cell.keyColors ?? (cell.keyColor ? [cell.keyColor] : [])
+
+      // A key host: a chest whose tombKey reward opens this floor's doors of these colours.
+      if (cell.reward?.type === "tombKey" && colors.length > 0) {
+        if (ownedKeys.has((cell.reward as TombKeyReward).keyId)) for (const color of colors) held.add(color)
+        continue
+      }
+
+      // A door. Fogged ones stay secret — surfacing their colour would spoil layout the player
+      // hasn't discovered yet.
+      if (cell.gateVariant === "floor-key" && cell.state !== "fogged") {
+        const satisfied = !cell.requiredKeyId || ownedKeys.has(cell.requiredKeyId)
+        if (!satisfied) for (const color of colors) needed.add(color)
+      }
+    }
+  }
+
+  // A colour in hand outranks a door still shut in that colour (a second door, a second key).
+  for (const color of held) needed.delete(color)
+
+  return { held: sortByPresentationOrder(held), needed: sortByPresentationOrder(needed) }
+}

--- a/src/game/siteTypes.ts
+++ b/src/game/siteTypes.ts
@@ -29,6 +29,10 @@ export type CorridorCell = {
 }
 export type GateVariant = "floor-key" | "tomb-key"
 export type KeyColor = "blue" | "red" | "green" | "yellow" | "purple"
+// Canonical order for anything that LISTS colors (a key ring, a chest's badges) — world-gen assigns
+// hues in whatever order a floor's gates came out, and a status readout that reshuffles between
+// floors is unreadable.
+export const KEY_COLORS: readonly KeyColor[] = ["blue", "red", "green", "yellow", "purple"]
 export type DecorationKind = "sarcophagus" | "statue" | "fountain" | "pit" | "rubble" | "pillar" | "chestProp"
 export type RoomCell = {
   type: "room"

--- a/src/mods/core/app/keyGate/plugin.spec.tsx
+++ b/src/mods/core/app/keyGate/plugin.spec.tsx
@@ -67,4 +67,42 @@ describe("ward gate", () => {
 
     expect(queryByText("gate.markedWith")).toBeNull()
   })
+
+  it("carries no key colour — a ward is identified by its treasure, not by a hue", () => {
+    const { queryByText } = renderGate({ requiredKeyId: "starter_a_1", ownedKeys: new Set() })
+
+    expect(queryByText("gate.needsKey")).toBeNull()
+  })
+})
+
+describe("floor-key door", () => {
+  const floorGate = (overrides: Partial<FamilyContext> = {}) =>
+    renderGate({ gateVariant: "floor-key", keyColor: "red", requiredKeyId: "site-3-4", ...overrides })
+
+  it("names the colour of the key it wants, so the player knows what to hunt for", () => {
+    const { queryByText } = floorGate({ ownedKeys: new Set() })
+
+    expect(queryByText("gate.needsKey")).not.toBeNull()
+    expect(queryByText("keys.red")).not.toBeNull()
+  })
+
+  it("says the key is missing from THIS floor, not just that some key is missing", () => {
+    const { queryByText } = floorGate({ ownedKeys: new Set() })
+
+    expect(queryByText("gate.lockedColor")).not.toBeNull()
+    expect(queryByText("gate.locked")).toBeNull()
+  })
+
+  it("keeps naming the colour once the key is held, and reads as unlocked", () => {
+    const { queryByText } = floorGate({ ownedKeys: new Set(["site-3-4"]) })
+
+    expect(queryByText("keys.red")).not.toBeNull()
+    expect(queryByText("gate.unlocked")).not.toBeNull()
+  })
+
+  it("falls back to blue when world-gen left the colour unset — the same default the map draws", () => {
+    const { queryByText } = floorGate({ keyColor: undefined, ownedKeys: new Set() })
+
+    expect(queryByText("keys.blue")).not.toBeNull()
+  })
 })

--- a/src/mods/core/app/keyGate/plugin.tsx
+++ b/src/mods/core/app/keyGate/plugin.tsx
@@ -4,6 +4,7 @@ import { registerFamily, type FamilyContext, type FamilyPlugin } from "@/app/fam
 import { KEY_GATE_META } from "@/mods/core/game/keyGate/meta"
 import { wardKeyDifficulty } from "@/data/difficultyLevels"
 import { useMergedKeyDisplay } from "@/app/SiteMap/keyProviders"
+import { KeyIcon } from "@/ui/atoms/KeyIcon"
 
 type KeyGatePuzzle = { satisfied: boolean }
 
@@ -22,6 +23,10 @@ const KeyGateComponent: FamilyPlugin["Component"] = ({ puzzle, ctx, onSolved, on
   const wardDifficulty = ctx.gateVariant === "tomb-key" ? wardKeyDifficulty(ctx.requiredKeyId) : undefined
   const keyDisplay = useMergedKeyDisplay()
   const keySymbol = ctx.requiredKeyId ? keyDisplay(ctx.requiredKeyId)?.symbol : undefined
+  // A floor-key door is identified by colour, not by a symbol: the key that opens it sits somewhere
+  // on this same floor, in a chest wearing the matching badge. Say the colour outright — the tinted
+  // door tile on the map is easy to miss, and "the right key" told the player nothing.
+  const gateColor = ctx.gateVariant === "floor-key" ? (ctx.keyColor ?? "blue") : undefined
   return (
     <div className="fixed inset-0 z-30 flex flex-col items-center justify-center gap-6 bg-black/85">
       <p className="font-pyramid text-2xl text-amber-300">{t("gate.title")}</p>
@@ -39,7 +44,18 @@ const KeyGateComponent: FamilyPlugin["Component"] = ({ puzzle, ctx, onSolved, on
           <span className="font-mono text-5xl text-amber-200">{keySymbol}</span>
         </div>
       )}
-      <p className="text-sm text-stone-300">{satisfied ? t("gate.unlocked") : t("gate.locked")}</p>
+      {gateColor && (
+        <div className="flex flex-col items-center gap-1">
+          <p className="text-sm text-stone-400">{t("gate.needsKey")}</p>
+          {/* Decorative: the colour is spelled out in the line below, so the icon needs no name of
+              its own — one accessible name per fact. */}
+          <KeyIcon color={gateColor} size={56} />
+          <p className="font-pyramid text-lg text-amber-200">{t(`keys.${gateColor}`)}</p>
+        </div>
+      )}
+      <p className="text-sm text-stone-300">
+        {satisfied ? t("gate.unlocked") : gateColor ? t("gate.lockedColor") : t("gate.locked")}
+      </p>
       <div className="flex flex-col items-center gap-3">
         {satisfied && (
           <button onClick={onSolved} className="rounded bg-amber-700 px-6 py-2 text-amber-100 hover:bg-amber-600">

--- a/src/mods/shop/app/ShopHud.tsx
+++ b/src/mods/shop/app/ShopHud.tsx
@@ -1,20 +1,12 @@
-import { use, type FC } from "react"
+import type { FC } from "react"
 import { useTranslation } from "react-i18next"
 import { useProgression } from "@/app/state/useProgression"
-import { DevelopContext } from "@/contexts/DevelopMode"
 import { ShopBalance } from "@/ui/atoms/ShopBalance"
-import { DeveloperButton } from "@/ui/atoms/DeveloperButton"
 
-// The shop mod's HUD widget: the money balance (plus a dev top-up). Reads money from the ledger
-// via progression, so core renders it through the HUD registry without naming `money`.
+// The shop mod's HUD widget: the money balance. Reads money from the ledger via progression, so
+// core renders it through the HUD registry without naming `money`.
 export const ShopHud: FC = () => {
   const { t } = useTranslation("common")
-  const { isDevelopMode } = use(DevelopContext)
   const progression = useProgression()
-  return (
-    <>
-      <ShopBalance amount={progression.ledger.get("money")} label={t("money.label")} />
-      {isDevelopMode && <DeveloperButton onClick={() => progression.ledger.grant("money", 1000)} label="+1000 Coins" />}
-    </>
-  )
+  return <ShopBalance amount={progression.ledger.get("money")} label={t("money.label")} />
 }

--- a/src/ui/atoms/KeyIcon.stories.tsx
+++ b/src/ui/atoms/KeyIcon.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import { KEY_COLORS } from "@/game/siteTypes"
+import { KeyIcon } from "./KeyIcon"
+
+const meta = {
+  component: KeyIcon,
+  decorators: [
+    Story => (
+      <div className="bg-stone-950 p-4">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof KeyIcon>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Blue: Story = { args: { color: "blue", title: "Blue key" } }
+
+export const AllColors: Story = {
+  args: { color: "blue" },
+  render: () => (
+    <div className="flex items-center gap-3">
+      {KEY_COLORS.map(color => (
+        <KeyIcon key={color} color={color} size={32} title={`${color} key`} />
+      ))}
+    </div>
+  ),
+}
+
+export const HeldVersusNeeded: Story = {
+  args: { color: "red" },
+  render: () => (
+    <div className="flex items-center gap-3">
+      <KeyIcon color="red" size={32} title="held" />
+      <KeyIcon color="red" size={32} outlined title="not held" />
+    </div>
+  ),
+}

--- a/src/ui/atoms/KeyIcon.tsx
+++ b/src/ui/atoms/KeyIcon.tsx
@@ -1,0 +1,50 @@
+import type { FC } from "react"
+import clsx from "clsx"
+import type { KeyColor } from "@/game/siteTypes"
+import { keyColorHex } from "@/ui/tokens/keyColors"
+
+type KeyIconProps = {
+  color: KeyColor
+  /** Rendered pixel size (square). Defaults to a HUD-sized 20. */
+  size?: number
+  /** Draws the key hollow — a colour the player does not hold yet. */
+  outlined?: boolean
+  /** Accessible name; the shape is decorative without one. */
+  title?: string
+  className?: string
+}
+
+// A single floor key, drawn in its own hue. Deliberately a drawn key rather than the 🗝 emoji: an
+// emoji can't be recoloured, and the colour IS the information here.
+export const KeyIcon: FC<KeyIconProps> = ({ color, size = 20, outlined = false, title, className }) => {
+  const hex = keyColorHex[color].reachable
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      role={title ? "img" : "presentation"}
+      aria-label={title}
+      aria-hidden={title ? undefined : true}
+      className={clsx("shrink-0", className)}
+    >
+      {title && <title>{title}</title>}
+      {/* Bow (the ring you hold) + shaft + two teeth — a stylised warded key, readable at 16px. */}
+      <circle
+        cx={8}
+        cy={8}
+        r={4.5}
+        fill={outlined ? "none" : hex}
+        stroke={hex}
+        strokeWidth={outlined ? 1.75 : 1}
+        opacity={outlined ? 0.7 : 1}
+      />
+      <circle cx={8} cy={8} r={1.6} fill="#1c1917" />
+      <g stroke={hex} strokeWidth={2} strokeLinecap="round" opacity={outlined ? 0.7 : 1}>
+        <line x1={11} y1={11} x2={19} y2={19} />
+        <line x1={17} y1={15} x2={14.5} y2={17.5} />
+        <line x1={19.5} y1={17.5} x2={17} y2={20} />
+      </g>
+    </svg>
+  )
+}

--- a/src/ui/molecules/FloorKeyRing.spec.tsx
+++ b/src/ui/molecules/FloorKeyRing.spec.tsx
@@ -1,0 +1,26 @@
+import { render } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+import { FloorKeyRing } from "./FloorKeyRing"
+
+const labels = {
+  heldLabel: (color: string) => `${color} held`,
+  neededLabel: (color: string) => `${color} needed`,
+}
+
+describe(FloorKeyRing, () => {
+  it("names every key it draws, so held and still-needed are told apart without relying on colour", () => {
+    const { getByTitle } = render(<FloorKeyRing held={["blue"]} needed={["red"]} {...labels} />)
+    expect(getByTitle("blue held")).toBeTruthy()
+    expect(getByTitle("red needed")).toBeTruthy()
+  })
+
+  it("renders nothing at all on a floor with no keys and no known doors", () => {
+    const { container } = render(<FloorKeyRing held={[]} needed={[]} {...labels} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it("falls back to the empty label when one is supplied", () => {
+    const { container } = render(<FloorKeyRing held={[]} needed={[]} emptyLabel="no keys" {...labels} />)
+    expect(container.textContent).toBe("no keys")
+  })
+})

--- a/src/ui/molecules/FloorKeyRing.stories.tsx
+++ b/src/ui/molecules/FloorKeyRing.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import { FloorKeyRing } from "./FloorKeyRing"
+
+const labels = {
+  heldLabel: (color: string) => `${color} key — in hand`,
+  neededLabel: (color: string) => `${color} door — still locked`,
+}
+
+const meta = {
+  component: FloorKeyRing,
+  args: labels,
+  decorators: [
+    Story => (
+      <div className="bg-stone-950 p-4">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof FloorKeyRing>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const OneKeyHeld: Story = { args: { held: ["blue"], needed: [] } }
+export const KeyHeldAndDoorsLeft: Story = { args: { held: ["blue", "green"], needed: ["red", "purple"] } }
+export const NothingFoundYet: Story = { args: { held: [], needed: ["yellow"] } }
+export const EmptyWithLabel: Story = { args: { held: [], needed: [], emptyLabel: "No keys on this floor" } }
+export const EmptyRendersNothing: Story = { args: { held: [], needed: [] } }

--- a/src/ui/molecules/FloorKeyRing.tsx
+++ b/src/ui/molecules/FloorKeyRing.tsx
@@ -1,0 +1,35 @@
+import type { FC } from "react"
+import type { KeyColor } from "@/game/siteTypes"
+import { KeyIcon } from "@/ui/atoms/KeyIcon"
+
+type FloorKeyRingProps = {
+  /** Colours the player carries on this floor — drawn solid. */
+  held: readonly KeyColor[]
+  /** Colours of doors seen on this floor and still shut — drawn hollow. */
+  needed?: readonly KeyColor[]
+  /** Accessible name per colour, e.g. "Blue key (held)". */
+  heldLabel: (color: KeyColor) => string
+  neededLabel: (color: KeyColor) => string
+  /** Shown when the ring holds nothing at all — omit to render nothing instead. */
+  emptyLabel?: string
+}
+
+// The floor's key ring, as a HUD readout: which coloured keys are in hand, and which coloured doors
+// are still waiting. Keys are floor-local, so this whole readout resets when the player changes
+// floor — that is the point of it being here rather than in the collection.
+export const FloorKeyRing: FC<FloorKeyRingProps> = ({ held, needed = [], heldLabel, neededLabel, emptyLabel }) => {
+  if (held.length === 0 && needed.length === 0) {
+    return emptyLabel ? <span className="text-xs text-stone-500">{emptyLabel}</span> : null
+  }
+  return (
+    <div className="flex items-center gap-1 rounded border border-amber-900/60 bg-stone-900/70 px-2 py-1">
+      {held.map(color => (
+        <KeyIcon key={`held-${color}`} color={color} title={heldLabel(color)} />
+      ))}
+      {held.length > 0 && needed.length > 0 && <span className="mx-0.5 h-4 w-px bg-amber-900/60" />}
+      {needed.map(color => (
+        <KeyIcon key={`needed-${color}`} color={color} outlined title={neededLabel(color)} />
+      ))}
+    </div>
+  )
+}

--- a/src/ui/tokens/keyColors.ts
+++ b/src/ui/tokens/keyColors.ts
@@ -1,0 +1,13 @@
+import type { KeyColor } from "@/game/siteTypes"
+
+// The five floor-key hues, in one place: the site map's gate/chest accents, a locked door's sign,
+// the loot popup's key, and the HUD key ring all read from here, so a blue key looks like the same
+// blue everywhere. Two shades per hue — `visible` is the muted, not-yet-reachable map state,
+// `reachable` the lit one. Anything outside the map (door sign, popup, HUD) uses `reachable`.
+export const keyColorHex: Record<KeyColor, { visible: string; reachable: string }> = {
+  blue: { visible: "#2060c0", reachable: "#4090e0" },
+  red: { visible: "#c04020", reachable: "#e06040" },
+  green: { visible: "#208040", reachable: "#30b060" },
+  yellow: { visible: "#b09010", reachable: "#d0c030" },
+  purple: { visible: "#7030b0", reachable: "#9050d0" },
+}


### PR DESCRIPTION
Branched fresh from `main`.

> [!NOTE]
> This branch previously carried the `mosaic-info` docs commit that this PR was originally opened for. That commit is untouched on the new `mosaic-info-report` branch — open a separate PR for it if it's still wanted.

## Floor keys, made readable

Floor keys were colour-coded on the site map and nowhere else: a locked door said only "you don't have the right key yet", a found key announced itself as a generic "Tomb Key", and nothing told you which keys you were carrying.

- **At the door** — a floor-key door draws the key it wants and names its colour ("Blue key"), and its locked line now says the key hasn't been found *on this floor* yet. Ward (tomb-key) doors are untouched: they keep their treasure sign and tier flavour.
- **In the loot popup** — a found floor key is named by its colour instead of falling through to the tomb-key label, with one key drawn per colour when a chest holds several. A real tomb treasure (no colour on its chest) keeps the tomb-treasure mod's rich display.
- **In the HUD** — a key ring for the current floor: colours in hand drawn solid, colours of doors already seen here and still shut drawn hollow. Doors still fogged stay secret, so the readout can't spoil layout you haven't found. Renders nothing on a floor with no keys and no known doors.

`floorKeyRing` (`src/game/floorKeys.ts`) derives all of that from the grid — keys are floor-local and nothing consumes them, so the grid is the whole truth. Gate satisfaction stays keyed on key **id**, never colour; the colour is only the sign the door wears.

The five hues moved to `src/ui/tokens/keyColors.ts`, so the map, the door sign, the popup and the HUD read one palette instead of a copy that lived inside `SiteMapView`.

## Cheat buttons removed

Gone from the interior HUD: `+Junk`, `+Hieroglyphs` (both in `SiteMapScreen`) and `+1000 Coins` (the shop mod's HUD widget). The playtesting menu on the travel screen and the `Complete Level` button in the expedition header are unaffected.

## New components

| File | Tier |
| --- | --- |
| `src/ui/atoms/KeyIcon.tsx` | atom — a drawn key in one hue (an emoji can't be recoloured, and the colour is the information) |
| `src/ui/molecules/FloorKeyRing.tsx` | molecule — the HUD readout |

Both have stories; `FloorKeyRing` also has a behaviour spec.

## Checks

- `yarn test` — 121 files, 1241 passed
- `yarn check-types`, `yarn lint`, `yarn build` — clean
- New/extended specs: `src/game/floorKeys.spec.ts`, `src/mods/core/app/keyGate/plugin.spec.tsx`, `src/app/SiteMap/RewardFlow.render.spec.tsx`, `src/app/SiteMap/SiteMapScreen.spec.tsx`, `src/ui/molecules/FloorKeyRing.spec.tsx`
- English + Dutch strings added in sync; `CHANGELOG.md [Unreleased]` updated
