### PR TITLE
test(mosaic): guard that glass never leaks a tier ahead of its key

### DIFF
--- a/src/mods/mosaic/game/mosaicTierGating.spec.ts
+++ b/src/mods/mosaic/game/mosaicTierGating.spec.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest"
+import { generatedWorldConfigs } from "@/data/generatedWorld"
+import { collectPlacedRewards } from "@/worldGen/effectiveWardKeys"
+import { difficulties, difficultyCompare, wardKeyDifficulty, type Difficulty } from "@/data/difficultyLevels"
+import { MOSAIC_TIERS } from "./mosaicCurrency"
+
+// Mosaic glass must never show up easier-to-reach than the difficulty it belongs to. Two separate
+// promises, both of which have been broken in shipped builds:
+//
+// 1. A piece sits on a node of its own difficulty. Enforced by MOSAIC_CURRENCIES' hard
+//    `eligible: slot => slot.tier === tier` filter — asserted here so a change to that filter
+//    (or to how slots report their tier) can't silently re-tier the registers.
+//
+// 2. A piece harder than the journey hosting it is behind a key at least as hard as the piece.
+//    This is the player-facing outcome, and it regressed for real: a starter pyramid's ward path
+//    opened a JUNIOR floor, so the first ward key in the game handed out junior glass before the
+//    player had set foot in a junior expedition (fixed in #171). `wardGateInvariants.spec.ts`
+//    guards the structural cause that produced it (a ward staircase's target floor must match its
+//    key's difficulty); this guards the consequence, so ANY future cause is caught — a mis-tiered
+//    loot pocket, a nested subsection, a longer staircase chain — not just that one mechanism.
+//
+// Cross-tier glass is deliberate, not a bug to eliminate: a junior wing inside a starter pyramid
+// is a "come back stronger" pocket (pyramid-interior-design.md). The rule is only that reaching it
+// requires that tier's own key.
+
+const rank = (d: Difficulty) => difficulties.indexOf(d)
+
+const journeyTierOf = (journeyId: string): Difficulty | undefined =>
+  difficulties.find(t => journeyId.startsWith(`${t}_`))
+
+const glass = collectPlacedRewards(generatedWorldConfigs).filter(p => p.reward.type === "mosaicPiece")
+
+// The reward's own tier field — mosaic's own vocabulary (`{ type: "mosaicPiece", tier }`).
+const tierOf = (reward: { tier?: unknown }): Difficulty => reward.tier as Difficulty
+
+describe("mosaic glass lands at its own difficulty", () => {
+  it("places every piece (a broken traversal can't pass by finding nothing)", () => {
+    expect(glass.length).toBeGreaterThan(0)
+  })
+
+  it("puts each piece on a node of its own difficulty", () => {
+    const offTier = glass
+      .filter(p => tierOf(p.reward) !== p.difficulty)
+      .map(p => `${tierOf(p.reward)} glass on ${p.difficulty} node in ${p.journeyId} L${p.levelIndex}`)
+    expect(offTier, `${offTier.length} off-tier piece(s): ${offTier.slice(0, 8).join("; ")}`).toEqual([])
+  })
+
+  it("only uses tiers the mosaic actually has registers for", () => {
+    const unknown = [...new Set(glass.map(p => tierOf(p.reward)))].filter(
+      t => !(MOSAIC_TIERS as readonly string[]).includes(t)
+    )
+    expect(unknown).toEqual([])
+  })
+})
+
+describe("mosaic glass harder than its host journey stays behind an equally-hard key", () => {
+  // Only pieces deeper than the journey they sit in can leak a tier early; a starter piece in a
+  // starter pyramid needs no key to be legitimate.
+  const crossTier = glass.filter(p => {
+    const journeyTier = journeyTierOf(p.journeyId)
+    return journeyTier !== undefined && difficultyCompare(tierOf(p.reward), journeyTier) > 0
+  })
+
+  it("has cross-tier glass to check (else this spec proves nothing)", () => {
+    expect(crossTier.length).toBeGreaterThan(0)
+  })
+
+  it("guards each cross-tier piece with a key of at least the piece's own difficulty", () => {
+    const leaks = crossTier
+      .filter(p => {
+        const keyTiers = p.wardKeys.map(wardKeyDifficulty).filter((d): d is Difficulty => d !== undefined)
+        const strongest = keyTiers.length ? Math.max(...keyTiers.map(rank)) : -1
+        return strongest < rank(tierOf(p.reward))
+      })
+      .map(
+        p =>
+          `${tierOf(p.reward)} glass in ${p.journeyId} (${journeyTierOf(p.journeyId)}) L${p.levelIndex} ` +
+          `floor${p.floorIndex} guarded by [${p.wardKeys.join(", ") || "nothing"}]`
+      )
+    expect(leaks, `${leaks.length} early-tier leak(s): ${leaks.slice(0, 8).join("; ")}`).toEqual([])
+  })
+})

--- a/src/mods/mosaic/game/mosaicTierGating.spec.ts
+++ b/src/mods/mosaic/game/mosaicTierGating.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 import { generatedWorldConfigs } from "@/data/generatedWorld"
 import { collectPlacedRewards } from "@/worldGen/effectiveWardKeys"
 import { difficulties, difficultyCompare, wardKeyDifficulty, type Difficulty } from "@/data/difficultyLevels"
+import type { TreasureReward } from "@/worldGen/types"
 import { MOSAIC_TIERS } from "./mosaicCurrency"
 
 // Mosaic glass must never show up easier-to-reach than the difficulty it belongs to. Two separate
@@ -28,10 +29,14 @@ const rank = (d: Difficulty) => difficulties.indexOf(d)
 const journeyTierOf = (journeyId: string): Difficulty | undefined =>
   difficulties.find(t => journeyId.startsWith(`${t}_`))
 
-const glass = collectPlacedRewards(generatedWorldConfigs).filter(p => p.reward.type === "mosaicPiece")
+// `TreasureReward` is deliberately open (`{ type: string } & Record<string, unknown>`), so a mod
+// narrows to its own reward shape with a predicate — same pattern as mosaicPlacement.spec.ts.
+const isMosaic = (r: TreasureReward): r is TreasureReward & { tier: Difficulty } => r.type === "mosaicPiece"
 
-// The reward's own tier field — mosaic's own vocabulary (`{ type: "mosaicPiece", tier }`).
-const tierOf = (reward: { tier?: unknown }): Difficulty => reward.tier as Difficulty
+// Each piece with its own tier lifted out of mosaic's reward vocabulary (`{ type, tier }`).
+const glass = collectPlacedRewards(generatedWorldConfigs)
+  .filter(p => isMosaic(p.reward))
+  .map(p => ({ ...p, tier: (p.reward as TreasureReward & { tier: Difficulty }).tier }))
 
 describe("mosaic glass lands at its own difficulty", () => {
   it("places every piece (a broken traversal can't pass by finding nothing)", () => {
@@ -40,15 +45,13 @@ describe("mosaic glass lands at its own difficulty", () => {
 
   it("puts each piece on a node of its own difficulty", () => {
     const offTier = glass
-      .filter(p => tierOf(p.reward) !== p.difficulty)
-      .map(p => `${tierOf(p.reward)} glass on ${p.difficulty} node in ${p.journeyId} L${p.levelIndex}`)
+      .filter(p => p.tier !== p.difficulty)
+      .map(p => `${p.tier} glass on ${p.difficulty} node in ${p.journeyId} L${p.levelIndex}`)
     expect(offTier, `${offTier.length} off-tier piece(s): ${offTier.slice(0, 8).join("; ")}`).toEqual([])
   })
 
   it("only uses tiers the mosaic actually has registers for", () => {
-    const unknown = [...new Set(glass.map(p => tierOf(p.reward)))].filter(
-      t => !(MOSAIC_TIERS as readonly string[]).includes(t)
-    )
+    const unknown = [...new Set(glass.map(p => p.tier))].filter(t => !(MOSAIC_TIERS as readonly string[]).includes(t))
     expect(unknown).toEqual([])
   })
 })
@@ -58,7 +61,7 @@ describe("mosaic glass harder than its host journey stays behind an equally-hard
   // starter pyramid needs no key to be legitimate.
   const crossTier = glass.filter(p => {
     const journeyTier = journeyTierOf(p.journeyId)
-    return journeyTier !== undefined && difficultyCompare(tierOf(p.reward), journeyTier) > 0
+    return journeyTier !== undefined && difficultyCompare(p.tier, journeyTier) > 0
   })
 
   it("has cross-tier glass to check (else this spec proves nothing)", () => {
@@ -70,11 +73,11 @@ describe("mosaic glass harder than its host journey stays behind an equally-hard
       .filter(p => {
         const keyTiers = p.wardKeys.map(wardKeyDifficulty).filter((d): d is Difficulty => d !== undefined)
         const strongest = keyTiers.length ? Math.max(...keyTiers.map(rank)) : -1
-        return strongest < rank(tierOf(p.reward))
+        return strongest < rank(p.tier)
       })
       .map(
         p =>
-          `${tierOf(p.reward)} glass in ${p.journeyId} (${journeyTierOf(p.journeyId)}) L${p.levelIndex} ` +
+          `${p.tier} glass in ${p.journeyId} (${journeyTierOf(p.journeyId)}) L${p.levelIndex} ` +
           `floor${p.floorIndex} guarded by [${p.wardKeys.join(", ") || "nothing"}]`
       )
     expect(leaks, `${leaks.length} early-tier leak(s): ${leaks.slice(0, 8).join("; ")}`).toEqual([])

--- a/src/worldGen/effectiveWardKeys.ts
+++ b/src/worldGen/effectiveWardKeys.ts
@@ -1,0 +1,87 @@
+import type { SiteConfig, SideSection, TreasureReward } from "./types"
+import type { Difficulty } from "../data/difficultyLevels"
+
+// Which ward keys a player must hold to reach a given placed reward — the FULL chain, propagated
+// across staircases, not just the gate on the reward's own section.
+//
+// Why this exists separately from slots.ts's `Slot.wardKeys`: that field is section-local by
+// design. A section reached by descending a ward-gated staircase starts a fresh chain, because the
+// placement engine learns "this floor is behind a key" from reachability.ts's floor model instead
+// (`reachableFloors`), never from the slot tag. That's fine for placement, but it means no existing
+// structure answers "what actually guards this reward" for a whole-world audit — a floor two hops
+// behind a master key looks ungated if you only read section gates.
+//
+// The gap is not theoretical: a starter pyramid's ward path once opened a JUNIOR floor, so the
+// first key in the game paid out junior mosaic glass and junior fragments before the player had
+// seen a junior expedition (fixed in #171 by tying a ward staircase's target floor difficulty to
+// its key — wardGateInvariants.spec.ts). That check guards the one structural cause; this helper
+// exists so a mod can assert the player-facing OUTCOME for its own currency — cross-tier loot is
+// never reachable without a key at least as hard as the loot — and so catch any future cause.
+//
+// Structural only: yields each reward with the difficulty of the node holding it and its key
+// chain. It never interprets a reward type, so it names no currency (docs/mods/ARCHITECTURE.md:
+// core owns mechanisms, mods own meaning) — each mod reads its own rewards out of the result.
+
+export type PlacedReward = {
+  journeyId: string
+  levelIndex: number
+  floorIndex: number
+  /** The node's OWN authored difficulty — the tier every currency filters placement on. */
+  difficulty: Difficulty
+  /** Every ward key gating the path to this reward, nearest-last. Empty = freely reachable. */
+  wardKeys: string[]
+  reward: TreasureReward
+}
+
+const stairIdOf = (link: SideSection["end"] | SiteConfig[number]["entrance"]): string | undefined =>
+  typeof link === "object" && link !== null && "stairId" in link ? link.stairId : undefined
+
+const gateKeyOf = (section: SideSection): string | undefined =>
+  section.gate?.type === "tomb-key" ? section.gate.wardKeyId : undefined
+
+// Every reward placed anywhere in the world, each tagged with the key chain guarding it.
+// Two passes per pyramid: first map every staircase to the keys guarding it, so a floor entered
+// by that staircase inherits them; then walk each floor's rewards with that inherited chain as
+// the starting point.
+export const collectPlacedRewards = (configs: Record<string, SiteConfig[]>): PlacedReward[] => {
+  const placed: PlacedReward[] = []
+
+  for (const [journeyId, siteConfigs] of Object.entries(configs)) {
+    siteConfigs.forEach((floors, levelIndex) => {
+      const keysByStair = new Map<string, string[]>()
+      const mapStairs = (inherited: string[], section: SideSection): void => {
+        const key = gateKeyOf(section)
+        const keys = key ? [...inherited, key] : inherited
+        const stairId = stairIdOf(section.end)
+        if (stairId) keysByStair.set(stairId, keys)
+        for (const sub of section.sideSections ?? []) mapStairs(keys, sub)
+      }
+      for (const floor of floors) for (const section of floor.sideSections) mapStairs([], section)
+
+      floors.forEach((floor, floorIndex) => {
+        // A floor's own gating is whatever guarded the staircase that enters it. Resolved one hop
+        // at a time, but chains compose: the mapping above already carries the full chain down to
+        // each staircase, so a floor three ward gates deep inherits all three.
+        const entryStair = stairIdOf(floor.entrance)
+        const floorKeys = entryStair ? (keysByStair.get(entryStair) ?? []) : []
+        const at = (difficulty: Difficulty, wardKeys: string[], reward: TreasureReward | undefined) => {
+          if (reward) placed.push({ journeyId, levelIndex, floorIndex, difficulty, wardKeys, reward })
+        }
+
+        at(floor.difficulty, floorKeys, floor.mainEndReward)
+        for (const r of floor.rewards ?? []) at(floor.difficulty, floorKeys, r)
+
+        const walk = (inherited: string[], section: SideSection): void => {
+          const key = gateKeyOf(section)
+          const keys = key ? [...inherited, key] : inherited
+          at(section.difficulty, keys, section.endReward)
+          for (const r of section.rewards ?? []) at(section.difficulty, keys, r)
+          for (const sub of section.sideSections ?? []) walk(keys, sub)
+        }
+        for (const section of floor.sideSections) walk(floorKeys, section)
+      })
+    })
+  }
+
+  return placed
+}


### PR DESCRIPTION
Reported from play: **junior mosaic glass turned up in a starter pyramid behind a starter ward key.**

## That was a real bug, and it's already fixed

#171 fixed the cause — a ward staircase could open a floor harder than the key that opened it, so the first key in the game paid out junior glass before the player had seen a junior expedition. Shipped in 0.33.1. If you're still seeing junior glass from starter pyramids, it's from a save made on an older build.

I verified the current world is clean: all 4 cross-tier mosaic pieces are correctly guarded by a key of their own tier, and mosaic's hard `eligible: slot => slot.tier === tier` filter has 0 violations across all 252 pieces.

## What's missing, and what this adds

`wardGateInvariants.spec.ts` (from #171) guards **one structural cause**: a ward staircase's target floor must match its key's difficulty. Nothing guards the **consequence** — so a mis-tiered loot pocket, a nested subsection, or a longer staircase chain could reintroduce the same player-visible leak by a different route.

- **`collectPlacedRewards()`** (`src/worldGen/effectiveWardKeys.ts`) — walks the world and tags every placed reward with the *full* ward-key chain guarding it, propagated across staircases. This didn't exist: `slots.ts`'s `Slot.wardKeys` is section-local by design (placement learns floor gating from `reachability.ts`'s floor model instead), so a floor two gates deep read as ungated to any whole-world audit. Purely structural — it never interprets a reward type, so core names no currency.
- **`mosaicTierGating.spec.ts`** (in the mosaic mod, which owns its own currency's meaning) asserts two things:
  1. every piece sits on a node of its own difficulty (locks in the `eligible` filter);
  2. any piece harder than its host journey is behind a key at least as hard as the piece.

Cross-tier pockets stay legal — a junior wing inside a starter pyramid is a deliberate "come back stronger" pocket. The rule is only that reaching it requires that tier's own key.

## The guard has teeth

Run against the pre-#171 world it fails with the exact reported case plus 5 more:

```
6 early-tier leak(s):
  junior glass in starter_1 (starter) L0 floor1 guarded by [starter_a_1]
  junior glass in starter_1 (starter) L0 floor1 guarded by [starter_a_1]
  expert glass in starter_2 (starter) L0 floor1 guarded by [junior_a_2]
  ... master glass in starter_2 (starter) L1 floor1 guarded by [expert_a_3]
```

## Verification

1202 tests passing, `yarn check-types` and `eslint` clean. No production behaviour changes and `generatedWorld.ts` is untouched — this is a guard plus the helper it needs.

Hieroglyph fragments were checked for the same leak and are clean today (25 cross-tier fragments, all correctly key-guarded). Extending the same assertion to fragments is a cheap follow-up if wanted — not done here to keep this scoped to what was reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01BU4goDhQufw7LQAdvGzqn2)_