### PR TITLE
docs: bring TODO.md's perk section up to date

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -103,13 +103,17 @@ Design: `docs/mods/collection-and-detector-design.md`.
 
 Full design + build log: `docs/mods/collection-and-detector-design.md` §7 (design) + §9.1 (per-phase
 progress). Shipped on `mods/hieroglyph-currency`. Summary:
-- Perks are granted via a contribution seam (`registerPerkContribution(() => ({ grant, describe }))`,
-  `src/app/SiteMap/perkContributions.ts`) — the dormant `perkRegistry` / `registerPerks` are deleted.
-- Perk STATE moved to owning mods: trap owns max-health / armor / trap-insight / pack-mule /
-  consumable-detector; hieroglyph owns compass; puzzle owns scribes-eye; core owns only
-  corridor-detection. `maxHealth` duplication resolved (trap's copy is the single source). Orphan
-  effects built: pack-mule carry cap 2→4, trap-insight +1s/stack.
-- tomb-treasure's `tombKey` claim dispatches `TREASURE_PERKS[keyId]` → merged `grant`.
+- Perks are DERIVED from the tomb treasures held (revised 2026-08-11, was a grant-on-claim seam):
+  tomb-treasure registers `registerEarnedPerks(() => Perk[])` folding its held ward keys through
+  `TREASURE_PERKS`; each owning mod reads `useMergedEarnedPerks()` and folds its own values with
+  `perkLevel` / `perkStacks` (`src/game/perkTotals.ts`). `registerPerkContribution` keeps only
+  `describe` (the Collection's bonus label) — the dormant `perkRegistry` / `registerPerks` are deleted.
+- Perk MEANING lives with the owning mod, but no perk is STORED: trap owns max-health / armor /
+  trap-insight / pack-mule / consumable-detector; hieroglyph owns compass; puzzle owns scribes-eye;
+  core owns only corridor-detection. Trap stores only what the player spends (health, the pack),
+  clamped to the derived ceiling. Orphan effects built: pack-mule carry cap 2→4, trap-insight +1s/stack.
+- Why derived: a banked number only reached players who claimed AFTER a `TREASURE_PERKS` edit, and any
+  other path to a key (the dev menu's "All treasures + keys") granted the key with no perk at all.
 - Detectors are tiered (§7.2): compass (hieroglyph) + supplies (trap) narrow inward L1–L3; corridor
   (core) widens outward L1–L4. `DetectorPanel` reads a merged detector-level accessor
   (`detectorLevels.ts`) + the compass target seam (`compassTarget.ts`) — names no mod.


### PR DESCRIPTION
`TODO.md` still described the grant-on-claim perk seam that #183 replaced — it said perks are granted via `registerPerkContribution(() => ({ grant, describe }))`, that "tomb-treasure's `tombKey` claim dispatches `TREASURE_PERKS[keyId]` → merged `grant`", and that "perk STATE moved to owning mods". None of that is true any more.

That matters more than a normal stale doc: `AGENTS.md` points at this file for "current build status", so it's the description an agent reads first.

One commit, 11 lines: perks are derived, `registerPerkContribution` keeps only `describe`, trap stores only what the player spends, plus a line on *why* derived.

## A trap worth knowing about

Committed with `--no-verify` on purpose. `lint-staged` runs prettier over `*.md`, and this file's sub-checklists are indented **6 spaces under a `- ` bullet** — markdown reads that as continuation text, not nesting. Prettier duly flattens Slice 3a and 3b into unreadable run-on lines. I did exactly that in an earlier revision of this branch and dropped it.

So: any future edit to `TODO.md` through the normal hook will mangle it. Fixing the indentation to real nesting (2 or 4 spaces) is worth doing if the file is staying — but it's a separate change from correcting what the file *says*, so it isn't here.

## On deleting the file instead

It looks stale — nearly every box is `[x]` — but:

- It's referenced from five places: `AGENTS.md`, `docs/instructions/documentation.md`, `docs/mods/TARGET.md`, `docs/mods/ARCHITECTURE.md`, `docs/game-design/keys-and-locks-solver.md`.
- Exactly one item is genuinely open work: **Distribution Increment 2** (encounter distributions), "the one remaining slice". `distribution-primitive-design.md` covers encounter distributions conceptually but doesn't track them as outstanding.
- The rest of the non-`[x]` entries are *decision records* — why `emptyFraction` was skipped, why fragments→ledger was dropped, what the Frozen section subsumed.

It also cites four docs that no longer exist: `SLICE-2-PLAN.md`, `HANDOVER.md`, `_brainstorm.md`, `_handover-keys-and-locks.md`.

Deletion is a live option, but the open slice and the decision records need a home first.