### PR TITLE
refactor: stop syncing derived state in an effect in two places

### DIFF
--- a/src/app/PyramidLevel/LevelCompletionHandler.spec.tsx
+++ b/src/app/PyramidLevel/LevelCompletionHandler.spec.tsx
@@ -1,0 +1,51 @@
+import { render, cleanup } from "@testing-library/react"
+import { describe, expect, it, vi, afterEach } from "vitest"
+import type { CombinedJourneyState } from "@/app/state/useJourneys"
+import { FezContext } from "@/app/fez/context"
+
+vi.mock("react-i18next", () => ({ useTranslation: () => ({ t: (key: string) => key }) }))
+
+// The overlay and the popup are other components' business; stand them in so this spec is about
+// which phase the sequence starts in.
+vi.mock("./LevelCompletedOverlay", () => ({
+  LevelCompletedOverlay: () => <div data-testid="level-completed-overlay" />,
+}))
+vi.mock("@/ui/atoms/LootPopup", () => ({
+  LootPopup: ({ isOpen }: { isOpen: boolean }) => (isOpen ? <div data-testid="loot-popup" /> : null),
+}))
+
+// Loot determination reaches into journeys and inventory; the phase logic only cares whether there
+// is loot waiting, so it is supplied directly.
+const loot = vi.fn<() => { loot: unknown; collectLoot: () => void }>(() => ({ loot: null, collectLoot: vi.fn() }))
+vi.mock("./useLootDetermination", () => ({ useLootDetermination: () => loot() }))
+
+const { LevelCompletionHandler } = await import("./LevelCompletionHandler")
+
+const journey = { journeyId: "starter_1", levelNr: 1 } as unknown as CombinedJourneyState
+
+const renderHandler = () =>
+  render(
+    <FezContext value={{ showConversation: vi.fn() }}>
+      <LevelCompletionHandler onCompletionFinished={vi.fn()} activeJourney={journey} />
+    </FezContext>
+  )
+
+afterEach(cleanup)
+
+// Characterisation, not regression: these pass against the pre-refactor version too, because
+// render() flushes effects inside act(), so the old start-hidden-then-advance-in-an-effect version
+// had already reached the overlay phase by the time anything could be asserted. What they pin is the
+// contract a later change could break — the overlay is up as soon as this mounts, and loot waits.
+describe("LevelCompletionHandler", () => {
+  it("shows the completion overlay on its first render", () => {
+    const { queryByTestId } = renderHandler()
+    expect(queryByTestId("level-completed-overlay")).not.toBeNull()
+  })
+
+  it("does not open the loot popup before the overlay phase has run its course", () => {
+    loot.mockReturnValueOnce({ loot: { itemId: "money", itemName: "coins" }, collectLoot: vi.fn() })
+    const { queryByTestId } = renderHandler()
+    expect(queryByTestId("level-completed-overlay")).not.toBeNull()
+    expect(queryByTestId("loot-popup")).toBeNull()
+  })
+})

--- a/src/app/PyramidLevel/LevelCompletionHandler.tsx
+++ b/src/app/PyramidLevel/LevelCompletionHandler.tsx
@@ -19,24 +19,19 @@ export const LevelCompletionHandler: FC<LevelCompletionHandlerProps> = ({
   skipLoot = false,
 }) => {
   const { t } = useTranslation("common")
-  const [showOverlay, setShowOverlay] = useState(false)
-  const [showFez, setShowFez] = useState(false)
+  // This component is only mounted once the level is already complete (PyramidExpedition renders it
+  // behind `levelCompleted`), so the sequence starts in the overlay phase rather than starting hidden
+  // and having an effect immediately advance it. That effect cost a render pass and showed one blank
+  // frame before the overlay appeared; there was never a path back to "hidden".
+  const [showOverlay, setShowOverlay] = useState(true)
+  const [showFez, setShowFez] = useState(true)
   const [showLoot, setShowLoot] = useState(false)
-  const [completionPhase, setCompletionPhase] = useState<"hidden" | "overlay" | "loot" | "finished">("hidden")
+  const [completionPhase, setCompletionPhase] = useState<"overlay" | "loot" | "finished">("overlay")
   const [scheduleTimer, cancelTimer] = useTimeout()
 
   // Use the loot determination hook
   const { loot: rawLoot, collectLoot } = useLootDetermination(activeJourney)
   const loot = skipLoot ? null : rawLoot
-
-  useEffect(() => {
-    if (completionPhase === "hidden") {
-      // Start the completion sequence only when level is completed
-      setCompletionPhase("overlay")
-      setShowOverlay(true)
-      setShowFez(true)
-    }
-  }, [completionPhase])
 
   const { showConversation } = use(FezContext)
 

--- a/src/app/SettingsModal.spec.tsx
+++ b/src/app/SettingsModal.spec.tsx
@@ -1,0 +1,51 @@
+import { render, cleanup, fireEvent } from "@testing-library/react"
+import { describe, expect, it, vi, afterEach } from "vitest"
+
+// `language` stands in for i18n's own current language, so a test can move it the way
+// changeLanguage would and then re-render — which is what react-i18next does for real.
+let language = "en"
+const changeLanguage = vi.fn((next: string) => {
+  language = next
+})
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language, changeLanguage } }),
+}))
+
+vi.mock("@/support/useGameStorage", () => ({
+  useGameStorage: () => [true, vi.fn()],
+  clearGameData: vi.fn(),
+}))
+
+const { SettingsModal } = await import("./SettingsModal")
+
+const selectIn = (container: HTMLElement) => container.querySelector<HTMLSelectElement>("#language-select")!
+
+afterEach(() => {
+  cleanup()
+  language = "en"
+  changeLanguage.mockClear()
+})
+
+// Characterisation, not regression: these also pass against the version that mirrored the language
+// into local state, since after effects flush the two agree. What they pin is that the select always
+// reports i18n's language — which is what stops a copy being reintroduced and drifting from it.
+describe("SettingsModal language selection", () => {
+  it("shows the language i18n is actually using, not a copy made when it mounted", () => {
+    language = "nl"
+    const { container } = render(<SettingsModal isOpen onClose={() => {}} />)
+    expect(selectIn(container).value).toBe("nl")
+  })
+
+  it("hands the choice to i18n and reads the result back on the next render", () => {
+    const { container, rerender } = render(<SettingsModal isOpen onClose={() => {}} />)
+    expect(selectIn(container).value).toBe("en")
+
+    fireEvent.change(selectIn(container), { target: { value: "nl" } })
+    expect(changeLanguage).toHaveBeenCalledWith("nl")
+
+    // No local copy to keep in step: the next render simply reflects i18n's new language.
+    rerender(<SettingsModal isOpen onClose={() => {}} />)
+    expect(selectIn(container).value).toBe("nl")
+  })
+})

--- a/src/app/SettingsModal.tsx
+++ b/src/app/SettingsModal.tsx
@@ -1,4 +1,4 @@
-import { type FC, useState, useEffect } from "react"
+import { type FC, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { version } from "@/../package.json"
 import { clearGameData, useGameStorage } from "@/support/useGameStorage"
@@ -11,7 +11,6 @@ type SettingsModalProps = {
 
 export const SettingsModal: FC<SettingsModalProps> = ({ isOpen, onClose }) => {
   const { t, i18n } = useTranslation("common")
-  const [selectedLanguage, setSelectedLanguage] = useState(i18n.language)
   const [showClearConfirm, setShowClearConfirm] = useState(false)
   const [tutorialsEnabled, setTutorialsEnabled] = useGameStorage<boolean>("tutorialsEnabled", true)
 
@@ -22,13 +21,12 @@ export const SettingsModal: FC<SettingsModalProps> = ({ isOpen, onClose }) => {
     window.location.reload()
   }
 
-  // Update local state when i18n language changes
-  useEffect(() => {
-    setSelectedLanguage(i18n.language)
-  }, [i18n.language])
+  // The chosen language IS i18n's language — read it, don't mirror it. This used to be local state
+  // kept in step by an effect, which meant every language change rendered twice (once for the state,
+  // once for useTranslation's own re-render) and the two could disagree in between.
+  const selectedLanguage = i18n.language
 
   const handleLanguageChange = (language: string) => {
-    setSelectedLanguage(language)
     i18n.changeLanguage(language)
   }
 


### PR DESCRIPTION
The two `react-hooks/set-state-in-effect` warnings that were about *derived state* rather than timers. In both, the effect existed only to keep a piece of state in step with something that already knew the answer.

**Lint: 44 → 42 warnings, 0 errors.**

## SettingsModal

```tsx
const [selectedLanguage, setSelectedLanguage] = useState(i18n.language)
useEffect(() => { setSelectedLanguage(i18n.language) }, [i18n.language])
```

`selectedLanguage` was only ever used as `<select value>` — a copy of `i18n.language`, re-synced from an effect. It now reads `i18n.language` directly.

One source of truth instead of two that could disagree mid-update, and a language change no longer renders twice (once for the local state, once for `useTranslation`'s own re-render).

## LevelCompletionHandler

```tsx
const [completionPhase, setCompletionPhase] = useState<"hidden" | ...>("hidden")
useEffect(() => {
  if (completionPhase === "hidden") { setCompletionPhase("overlay"); setShowOverlay(true); setShowFez(true) }
}, [completionPhase])
```

The component is only mounted once the level is already complete — `PyramidExpedition.tsx:395` renders it behind `levelCompleted` — so "hidden" was a mount-time artifact the effect immediately advanced past. The initial state now says `"overlay"` outright, which drops a render pass and a blank first frame. Nothing ever set the phase back to `"hidden"`, so that variant is gone from the union as well.

## About the tests

**They are characterisation tests, not regression tests, and I checked.** I reverted both source files and ran the new specs against the old code: they pass there too, because `render()` flushes effects inside `act()`, so the old start-hidden-then-advance version had already reached the overlay phase before anything could be asserted, and the mirrored language state had already re-synced. The blank frame and the extra render aren't observable at this level.

That's the honest confirmation these changes are behaviour-preserving. I kept the specs because they're the first tests either component has had, and they pin the contract a later change could quietly break — the select always reports i18n's language, and the overlay is up as soon as the handler mounts.

## Worth a manual look before merging

Because of the above, the automated tests can't distinguish this from the previous behaviour — they only prove the settled state matches. The transitions are what changed, so two quick checks by eye:

1. **Settings → language.** Open Settings, switch English ⇄ Nederlands. The dropdown should show the new language immediately and the UI copy should follow. (What to watch for: the select briefly showing the old value, or reverting.)
2. **Finish a level.** The "level completed" overlay should appear immediately, with Fez's conversation starting as before, then loot after the 2s beat — or the click-to-continue hint when there's no loot. (What to watch for: a blank frame before the overlay, or the overlay not appearing at all.)

Both paths are unchanged in intent; these confirm the frame-level behaviour a unit test can't see.

## Deliberately left alone

- **Timer-driven** `set-state-in-effect`: `LootPopup:39`, `MosaicWindow:49` — animation timers with cleanup, not derived state.
- **`FezShop:72`** — `if (!isOpen) setScrollProgress(0)`, resetting a scroll-linked animation on close. The alternatives (reset in `onDismiss`, or restructure so closing unmounts the state) each trade robustness for lint cleanliness: the effect catches *every* close path, an `onDismiss` handler only catches the ones that go through it. Not worth the risk to a visual animation for one warning.
- **`SiteMapScreen:261`** — the family-absence pass-through, resolving a room whose family isn't registered so the player isn't stuck. That's a genuine side effect in response to state, not state being mirrored, and doing it during render would be wrong.

I'd mislabelled the last two as timers in my earlier triage; they aren't, they're just not worth changing.

Still outstanding after this: 19 react-hooks warnings — `refs` (6, two in `useOfflineStorage` which I'd treat very carefully), `preserve-manual-memoization` (3, all in `PyramidExpedition.tsx`), `use-memo` (3, the registry-merge seams), plus the four above.

## Verification

`yarn check-types` ✅ · `yarn lint` (0 errors, 44 → 42) ✅ · `yarn build` ✅ · `yarn test --run` — **1256 passed** (up 4) ✅

No user-facing change, so no CHANGELOG entry.