### PR TITLE
feat(detector): make the corridor readout answer at every range it covers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- The passageway detector answers at every range it has reached, and says so when the answer is nothing: whether a hidden corridor is close by, waiting on this floor, or waiting on another floor of this pyramid. It used to speak up only when it had news, so a silent panel could mean either "nothing here" or "this thing is broken".
+- Walking now moves the detector's closest reading: it tells you a corridor is near as you come within a few steps of one, rather than only stating what the detector does.
+- Dropped the "(L4)" tag from the readout. It was the detector's own level shown as a code, with nothing anywhere to say what it meant.
+- A pyramid's tally still counts only floors you have walked, so the detector never sends you after a corridor behind a door you cannot open yet — its "nothing found so far" says exactly that, rather than claiming the pyramid is empty.
+
 ## 0.34.1 - 2026-08-12
 
 ### Fixed

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -200,10 +200,8 @@
     "allCollected": "All pieces collected",
     "noSkippedChests": "No skipped chests",
     "more": "+{{count}} more",
-    "corridorNearby": "Suspicious corners revealed nearby (L{{level}})",
+    "corridorNearby": "A hidden corridor is close by",
     "corridorOnFloor": "A hidden corridor waits on this floor",
-    "corridorPyramidCount_one": "This pyramid hides {{count}} unexplored corridor",
-    "corridorPyramidCount_other": "This pyramid hides {{count}} unexplored corridors",
     "hunting": "Hunting {{symbol}}",
     "huntStop": "Stop",
     "huntHint": "Select an uncollected hieroglyph, then hunt it with the compass",
@@ -214,7 +212,11 @@
       "locked": "Locked — you don't hold the key for this one yet",
       "hidden": "In a hidden corridor — needs the passageway detector",
       "unknown": "Might not be reachable yet — it's inside a tomb or for sale"
-    }
+    },
+    "corridorNoneNearby": "No hidden corridor close by",
+    "corridorNoneOnFloor": "No hidden corridor on this floor",
+    "corridorOtherFloor": "A hidden corridor waits on another floor",
+    "corridorNoneInPyramid": "No hidden corridors found so far in this pyramid"
   },
   "keys": {
     "blue": "Blue key",

--- a/public/locales/nl/common.json
+++ b/public/locales/nl/common.json
@@ -200,14 +200,16 @@
     "allCollected": "Alle stukken verzameld",
     "noSkippedChests": "Geen overgeslagen kisten",
     "more": "+{{count}} meer",
-    "corridorNearby": "Verdachte hoeken onthuld in de buurt (N{{level}})",
+    "corridorNearby": "Een verborgen gang is vlakbij",
     "corridorOnFloor": "Een verborgen gang wacht op deze verdieping",
-    "corridorPyramidCount_one": "Deze piramide verbergt {{count}} onontdekte gang",
-    "corridorPyramidCount_other": "Deze piramide verbergt {{count}} onontdekte gangen",
     "hunting": "Op jacht naar {{symbol}}",
     "huntStop": "Stop",
     "huntHint": "Selecteer een niet-verzamelde hiëroglief en jaag erop met het kompas",
-    "huntAction": "Jaag op {{symbol}}"
+    "huntAction": "Jaag op {{symbol}}",
+    "corridorNoneNearby": "Geen verborgen gang in de buurt",
+    "corridorNoneOnFloor": "Geen verborgen gang op deze verdieping",
+    "corridorOtherFloor": "Een verborgen gang wacht op een andere verdieping",
+    "corridorNoneInPyramid": "Nog geen verborgen gangen gevonden in deze piramide"
   },
   "keys": {
     "blue": "Blauwe sleutel",

--- a/src/app/SiteMap/SiteMapScreen.tsx
+++ b/src/app/SiteMap/SiteMapScreen.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { findPath, getCell, getOwnedKeys } from "@/game/gridNavigation"
 import { floorKeyRing } from "@/game/floorKeys"
+import { isCorridorNearby } from "@/app/SiteMap/corridorProximity"
 import { getFamilyPlugin, type FamilyContext } from "@/app/families/familyRegistry"
 import { hashString } from "@/support/hashString"
 import { useTimeout } from "@/support/useTimeout"
@@ -108,7 +109,22 @@ export const SiteMapScreen = ({ journeyId, siteConfig, seed, onSiteComplete, onC
     () => [...hiddenSectionHashes].some(h => !foundCorridors.has(h)),
     [hiddenSectionHashes, foundCorridors]
   )
-  const pyramidHiddenCorridorCount = journeys.getOutstandingHiddenCorridorCount(journeyId)
+  // L1's scope: a lead within a few steps of where the player stands. Recomputed as they walk, so the
+  // readout flips from "nothing nearby" to "something nearby" on approach.
+  const corridorNearby = useMemo(
+    () => isCorridorNearby(grid, explorerPos, junctionSections),
+    [grid, explorerPos, junctionSections]
+  )
+  // L3's scope: still-unnoticed corridors on OTHER floors. The pyramid tally counts every floor the
+  // player has viewed, this floor included, so subtracting this floor's own outstanding leaves the
+  // ones worth travelling for. Only visited floors count — an unvisited floor's corridors are not
+  // "known", which is deliberate: a corridor behind a door the player cannot open yet would otherwise
+  // send them hunting for something unreachable.
+  const floorOutstanding = useMemo(
+    () => [...hiddenSectionHashes].filter(h => !foundCorridors.has(h)).length,
+    [hiddenSectionHashes, foundCorridors]
+  )
+  const hiddenCorridorOnOtherFloor = journeys.getOutstandingHiddenCorridorCount(journeyId) - floorOutstanding > 0
   // Keys the player already holds for THIS floor's gates: this floor's own completed
   // tomb-key treasures, union'd with ward keys owned entering the site (progression's
   // global tombKeyIds, above). Gating is soft, so this union is purely a "is this gate
@@ -413,9 +429,12 @@ export const SiteMapScreen = ({ journeyId, siteConfig, seed, onSiteComplete, onC
             },
             more: count => t("common:detector.more", { count }),
             noSkippedChests: t("common:detector.noSkippedChests"),
-            corridorNearby: level => t("common:detector.corridorNearby", { level }),
+            corridorNearby: t("common:detector.corridorNearby"),
+            corridorNoneNearby: t("common:detector.corridorNoneNearby"),
             corridorOnFloor: t("common:detector.corridorOnFloor"),
-            corridorPyramidCount: count => t("common:detector.corridorPyramidCount", { count }),
+            corridorNoneOnFloor: t("common:detector.corridorNoneOnFloor"),
+            corridorOtherFloor: t("common:detector.corridorOtherFloor"),
+            corridorNoneInPyramid: t("common:detector.corridorNoneInPyramid"),
           }}
           activeDetector={detector.activeDetector}
           compassLevel={detectorLevels.compass}
@@ -426,8 +445,9 @@ export const SiteMapScreen = ({ journeyId, siteConfig, seed, onSiteComplete, onC
           journeyName={journeyName}
           compassResults={detector.compassResults}
           consumableResults={detector.consumableResults}
+          corridorNearby={corridorNearby}
           floorHasHiddenCorridor={floorHasHiddenCorridor}
-          pyramidHiddenCorridorCount={pyramidHiddenCorridorCount}
+          hiddenCorridorOnOtherFloor={hiddenCorridorOnOtherFloor}
         />
         {/* pointer-events-auto: opts this row back into hit-testing inside SiteHudBar's
             non-hit-testing band (the detector toggles and mod widgets below are clickable). */}

--- a/src/app/SiteMap/corridorProximity.spec.ts
+++ b/src/app/SiteMap/corridorProximity.spec.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest"
+import type { Direction, FloorGrid, GridCell } from "@/game/siteTypes"
+import { isCorridorNearby, NEARBY_STEPS } from "./corridorProximity"
+
+// A single straight corridor, so distance along it is just the column difference.
+const corridor = (dirs: Direction[]): GridCell => ({
+  type: "corridor",
+  dirs: new Set(dirs),
+  state: "completed",
+})
+
+const rowOf = (length: number): FloorGrid => ({
+  cells: [Array.from({ length }, (_, i) => corridor(i === 0 ? ["e"] : i === length - 1 ? ["w"] : ["w", "e"]))],
+  rows: 1,
+  cols: length,
+  entrancePos: [0, 0],
+  exitPos: [0, length - 1],
+  siteId: "test-site",
+  staircases: {},
+})
+
+const junctionsAt = (...cols: number[]) =>
+  new Map(cols.map(col => [`0,${col}`, new Set(["section-hash"]) as ReadonlySet<string>]))
+
+describe("isCorridorNearby", () => {
+  it("is false when the floor holds no unnoticed corridor at all", () => {
+    expect(isCorridorNearby(rowOf(10), [0, 0], new Map())).toBe(false)
+  })
+
+  it("is false with no grid to measure across", () => {
+    expect(isCorridorNearby(null, [0, 0], junctionsAt(1))).toBe(false)
+  })
+
+  it("counts the junction the player is standing on as nearby", () => {
+    expect(isCorridorNearby(rowOf(10), [0, 3], junctionsAt(3))).toBe(true)
+  })
+
+  it("is true just inside the radius and false just outside it", () => {
+    const grid = rowOf(20)
+    expect(isCorridorNearby(grid, [0, 0], junctionsAt(NEARBY_STEPS))).toBe(true)
+    expect(isCorridorNearby(grid, [0, 0], junctionsAt(NEARBY_STEPS + 1))).toBe(false)
+  })
+
+  it("takes the closest lead when several are on the floor", () => {
+    const grid = rowOf(20)
+    expect(isCorridorNearby(grid, [0, 0], junctionsAt(15, 2, 18))).toBe(true)
+  })
+
+  // Walking distance, not straight-line: the row is severed at column 2, so a junction at column 4 —
+  // four columns away on paper, unreachable in practice — must not read as nearby.
+  it("measures how far the player must walk, not how close the corridor looks", () => {
+    const severed: FloorGrid = {
+      ...rowOf(6),
+      cells: [
+        [corridor(["e"]), corridor(["w"]), { type: "empty" }, corridor(["e"]), corridor(["w"]), { type: "empty" }],
+      ],
+    }
+    expect(isCorridorNearby(severed, [0, 0], junctionsAt(4))).toBe(false)
+    // ...while a junction on the player's own side of the break still counts.
+    expect(isCorridorNearby(severed, [0, 0], junctionsAt(1))).toBe(true)
+  })
+})

--- a/src/app/SiteMap/corridorProximity.ts
+++ b/src/app/SiteMap/corridorProximity.ts
@@ -1,0 +1,60 @@
+import type { Direction, FloorGrid } from "@/game/siteTypes"
+
+// How close the corridor detector calls a hidden passage "nearby", in steps along the walkable
+// floor — not straight-line distance, so a corridor on the far side of a wall stays far away.
+// Tunable: this is the whole feel of the L1 readout. Too small and it only lights up when you are
+// already standing on the corner; too large and it says "nearby" for most of the floor.
+export const NEARBY_STEPS = 4
+
+const MOVES: Record<Direction, readonly [number, number]> = { n: [-1, 0], s: [1, 0], e: [0, 1], w: [0, -1] }
+
+// Is the player within `maxSteps` of a corner that borders an unnoticed hidden corridor?
+//
+// `junctionSections` only ever holds junctions bordering corridors that are still hidden — a noticed
+// one is revealed and drops out — so any entry here is a live lead.
+//
+// Deliberately its own bounded search rather than findPath: findPath answers "draw me a route" and
+// falls back to a synthetic `[from, to]` when there is no route at all, which reads as exactly one
+// step and would call every unreachable corridor "nearby". It also runs a full-floor BFS per call.
+// This walks outward once, at most `maxSteps` deep, and stops at the first lead.
+//
+// Traversal follows the same rules as the player's own movement — through a cell's open directions,
+// never into empty or fogged ground — so "nearby" means reachable across floor they have actually
+// seen, not close as the crow flies.
+export const isCorridorNearby = (
+  grid: FloorGrid | null,
+  explorerPos: readonly [number, number],
+  junctionSections: ReadonlyMap<string, ReadonlySet<string>>,
+  maxSteps: number = NEARBY_STEPS
+): boolean => {
+  if (!grid || junctionSections.size === 0) return false
+
+  const key = (row: number, col: number) => `${row},${col}`
+  if (junctionSections.has(key(explorerPos[0], explorerPos[1]))) return true
+
+  const seen = new Set([key(explorerPos[0], explorerPos[1])])
+  let frontier: Array<readonly [number, number]> = [explorerPos]
+
+  for (let step = 0; step < maxSteps && frontier.length > 0; step++) {
+    const next: Array<readonly [number, number]> = []
+    for (const [row, col] of frontier) {
+      const cell = grid.cells[row]?.[col]
+      if (!cell || cell.type === "empty") continue
+      const dirs: ReadonlySet<Direction> = cell.dirs
+      for (const dir of dirs) {
+        const [dr, dc] = MOVES[dir]
+        const nr = row + dr
+        const nc = col + dc
+        const nk = key(nr, nc)
+        if (seen.has(nk)) continue
+        const neighbor = grid.cells[nr]?.[nc]
+        if (!neighbor || neighbor.type === "empty" || neighbor.state === "fogged") continue
+        if (junctionSections.has(nk)) return true
+        seen.add(nk)
+        next.push([nr, nc])
+      }
+    }
+    frontier = next
+  }
+  return false
+}

--- a/src/i18n/plurals.spec.ts
+++ b/src/i18n/plurals.spec.ts
@@ -32,13 +32,4 @@ describe("plural forms in the shipped locales", () => {
   ])("renders %s money reward for %i as %s", (lng, count, expected) => {
     expect(t(lng, "chest.money", { count })).toBe(expected)
   })
-
-  it.each([
-    ["en", 1, "This pyramid hides 1 unexplored corridor"],
-    ["en", 3, "This pyramid hides 3 unexplored corridors"],
-    ["nl", 1, "Deze piramide verbergt 1 onontdekte gang"],
-    ["nl", 3, "Deze piramide verbergt 3 onontdekte gangen"],
-  ])("renders %s corridor count for %i as %s", (lng, count, expected) => {
-    expect(t(lng, "detector.corridorPyramidCount", { count })).toBe(expected)
-  })
 })

--- a/src/ui/atoms/DetectorPanel.spec.tsx
+++ b/src/ui/atoms/DetectorPanel.spec.tsx
@@ -16,9 +16,12 @@ const labels: DetectorPanelLabels = {
   },
   more: count => `+${count} more`,
   noSkippedChests: "No skipped chests",
-  corridorNearby: level => `Corridor nearby (L${level})`,
-  corridorOnFloor: "Corridor on this floor",
-  corridorPyramidCount: count => `${count} corridors in this pyramid`,
+  corridorNearby: "A hidden corridor is close by",
+  corridorNoneNearby: "No hidden corridor close by",
+  corridorOnFloor: "A hidden corridor waits on this floor",
+  corridorNoneOnFloor: "No hidden corridor on this floor",
+  corridorOtherFloor: "A hidden corridor waits on another floor",
+  corridorNoneInPyramid: "No hidden corridors found so far in this pyramid",
 }
 
 // This project doesn't enable RTL's automatic cleanup, so without this each test's markup stays
@@ -125,29 +128,67 @@ describe("DetectorPanel precision by level (§7.2)", () => {
     expect(screen.getByText("Sphinx Dawn L1 F2 · (5,2)")).toBeTruthy()
   })
 
-  it("corridor detector widens outward: L1 silent, L2 floor line, L3 pyramid count", () => {
-    const base = {
-      labels,
-      activeDetector: "hiddenPassageway" as const,
-      compassLevel: 0,
-      consumableDetectorLevel: 0,
-      compassTarget: null,
-      compassResults: [],
-      consumableResults: [],
+  // The corridor readout widens outward one scope per level (§7.2), and each unlocked scope answers
+  // either way. A scope that only spoke up when it had news read as a broken detector.
+  const corridorBase = {
+    labels,
+    activeDetector: "hiddenPassageway" as const,
+    compassLevel: 0,
+    consumableDetectorLevel: 0,
+    compassTarget: null,
+    compassResults: [],
+    consumableResults: [],
+  }
+
+  it("unlocks one scope per level, and says nothing about scopes still locked", () => {
+    const found = {
+      ...corridorBase,
+      corridorNearby: true,
       floorHasHiddenCorridor: true,
-      pyramidHiddenCorridorCount: 3,
+      hiddenCorridorOnOtherFloor: true,
     }
-    const { rerender } = render(<DetectorPanel {...base} detectionLevel={1} />)
-    expect(screen.queryByText("Corridor on this floor")).toBeNull() // L1 = proximity only
-    expect(screen.queryByText(/corridors in this pyramid/)).toBeNull()
 
-    rerender(<DetectorPanel {...base} detectionLevel={2} />)
-    expect(screen.getByText("Corridor on this floor")).toBeTruthy()
-    expect(screen.queryByText(/corridors in this pyramid/)).toBeNull() // pyramid count is L3+
+    const { rerender } = render(<DetectorPanel {...found} detectionLevel={1} />)
+    expect(screen.getByText("A hidden corridor is close by")).toBeTruthy()
+    expect(screen.queryByText(/on this floor/)).toBeNull() // floor scope is L2+
+    expect(screen.queryByText(/another floor|in this pyramid/)).toBeNull() // pyramid scope is L3+
 
-    rerender(<DetectorPanel {...base} detectionLevel={3} />)
-    expect(screen.getByText("Corridor on this floor")).toBeTruthy()
-    expect(screen.getByText("3 corridors in this pyramid")).toBeTruthy()
+    rerender(<DetectorPanel {...found} detectionLevel={2} />)
+    expect(screen.getByText("A hidden corridor waits on this floor")).toBeTruthy()
+    expect(screen.queryByText(/another floor|in this pyramid/)).toBeNull()
+
+    rerender(<DetectorPanel {...found} detectionLevel={3} />)
+    expect(screen.getByText("A hidden corridor waits on another floor")).toBeTruthy()
+  })
+
+  it("states the absence at every unlocked scope rather than going quiet", () => {
+    render(
+      <DetectorPanel
+        {...corridorBase}
+        detectionLevel={3}
+        corridorNearby={false}
+        floorHasHiddenCorridor={false}
+        hiddenCorridorOnOtherFloor={false}
+      />
+    )
+    expect(screen.getByText("No hidden corridor close by")).toBeTruthy()
+    expect(screen.getByText("No hidden corridor on this floor")).toBeTruthy()
+    expect(screen.getByText("No hidden corridors found so far in this pyramid")).toBeTruthy()
+  })
+
+  it("answers each scope on its own, so a lead nearby does not imply one elsewhere", () => {
+    render(
+      <DetectorPanel
+        {...corridorBase}
+        detectionLevel={3}
+        corridorNearby
+        floorHasHiddenCorridor
+        hiddenCorridorOnOtherFloor={false}
+      />
+    )
+    expect(screen.getByText("A hidden corridor is close by")).toBeTruthy()
+    expect(screen.getByText("A hidden corridor waits on this floor")).toBeTruthy()
+    expect(screen.getByText("No hidden corridors found so far in this pyramid")).toBeTruthy()
   })
 
   it("supplies L1 pyramid only; L3 exact cell", () => {

--- a/src/ui/atoms/DetectorPanel.stories.tsx
+++ b/src/ui/atoms/DetectorPanel.stories.tsx
@@ -17,9 +17,12 @@ const meta = {
       },
       more: count => `+${count} more`,
       noSkippedChests: "No skipped chests",
-      corridorNearby: level => `Suspicious corners revealed nearby (L${level})`,
+      corridorNearby: "A hidden corridor is close by",
+      corridorNoneNearby: "No hidden corridor close by",
       corridorOnFloor: "A hidden corridor waits on this floor",
-      corridorPyramidCount: count => `This pyramid hides ${count} unexplored corridors`,
+      corridorNoneOnFloor: "No hidden corridor on this floor",
+      corridorOtherFloor: "A hidden corridor waits on another floor",
+      corridorNoneInPyramid: "No hidden corridors found so far in this pyramid",
     },
     activeDetector: null,
     compassLevel: 0,
@@ -121,7 +124,20 @@ export const CorridorLevel3: Story = {
   args: {
     detectionLevel: 3,
     activeDetector: "hiddenPassageway",
+    corridorNearby: true,
     floorHasHiddenCorridor: true,
-    pyramidHiddenCorridorCount: 3,
+    hiddenCorridorOnOtherFloor: true,
+  },
+}
+
+// The point of the rework: every unlocked scope answers, so an empty floor is stated rather than
+// leaving the panel looking broken.
+export const CorridorLevel3NothingFound: Story = {
+  args: {
+    detectionLevel: 3,
+    activeDetector: "hiddenPassageway",
+    corridorNearby: false,
+    floorHasHiddenCorridor: false,
+    hiddenCorridorOnOtherFloor: false,
   },
 }

--- a/src/ui/atoms/DetectorPanel.tsx
+++ b/src/ui/atoms/DetectorPanel.tsx
@@ -10,9 +10,13 @@ export type DetectorPanelLabels = {
   access: Record<CompassAccess, string>
   more: (count: number) => string
   noSkippedChests: string
-  corridorNearby: (level: number) => string
+  // The corridor ladder: each unlocked scope answers either way, so the readout is never silent.
+  corridorNearby: string
+  corridorNoneNearby: string
   corridorOnFloor: string
-  corridorPyramidCount: (count: number) => string
+  corridorNoneOnFloor: string
+  corridorOtherFloor: string
+  corridorNoneInPyramid: string
 }
 
 type Props = {
@@ -29,10 +33,14 @@ type Props = {
   journeyName?: (journeyId: string) => string
   compassResults: CompassHit[]
   consumableResults: ConsumableResult[]
-  // Corridor detector widens outward (§7.2): L2 = an unfound corridor on this floor; L3 = the count
-  // still outstanding across the whole pyramid. Both default off so lower levels stay silent.
+  // Corridor detector widens outward (§7.2), one scope per level: L1 = within a few steps of the
+  // player, L2 = anywhere on this floor, L3 = any other floor of this pyramid (L4 adds the marker on
+  // the journey map, which JourneyCard draws). Each scope reports either way once unlocked.
+  corridorNearby?: boolean
   floorHasHiddenCorridor?: boolean
-  pyramidHiddenCorridorCount?: number
+  // Outstanding on floors OTHER than this one — and only floors already visited, so the L3 negative
+  // says "none found so far" rather than claiming a pyramid is clean before it has been walked.
+  hiddenCorridorOnOtherFloor?: boolean
 }
 
 const uniqueBy = <T,>(items: T[], key: (item: T) => string): T[] => {
@@ -101,8 +109,9 @@ export const DetectorPanel: FC<Props> = ({
   journeyName = id => id,
   compassResults,
   consumableResults,
+  corridorNearby = false,
   floorHasHiddenCorridor = false,
-  pyramidHiddenCorridorCount = 0,
+  hiddenCorridorOnOtherFloor = false,
 }) => {
   // Purely a readout — with no mode switched on there's nothing to report, so the card doesn't
   // render at all rather than sitting there empty above the HUD row. The buttons that switch a mode
@@ -158,11 +167,22 @@ export const DetectorPanel: FC<Props> = ({
       )}
 
       {activeDetector === "hiddenPassageway" && (
+        // One line per unlocked scope, each stating what it found OR that it found nothing. A scope
+        // that goes quiet reads as a broken detector, which is exactly how the old single-line
+        // version came across: it only ever spoke up when it had news.
         <div className="text-stone-400">
-          <p>{labels.corridorNearby(detectionLevel)}</p>
-          {detectionLevel >= 2 && floorHasHiddenCorridor && <p className="text-amber-200">{labels.corridorOnFloor}</p>}
-          {detectionLevel >= 3 && pyramidHiddenCorridorCount > 0 && (
-            <p className="text-amber-200">{labels.corridorPyramidCount(pyramidHiddenCorridorCount)}</p>
+          <p className={corridorNearby ? "text-amber-200" : undefined}>
+            {corridorNearby ? labels.corridorNearby : labels.corridorNoneNearby}
+          </p>
+          {detectionLevel >= 2 && (
+            <p className={floorHasHiddenCorridor ? "text-amber-200" : undefined}>
+              {floorHasHiddenCorridor ? labels.corridorOnFloor : labels.corridorNoneOnFloor}
+            </p>
+          )}
+          {detectionLevel >= 3 && (
+            <p className={hiddenCorridorOnOtherFloor ? "text-amber-200" : undefined}>
+              {hiddenCorridorOnOtherFloor ? labels.corridorOtherFloor : labels.corridorNoneInPyramid}
+            </p>
           )}
         </div>
       )}


### PR DESCRIPTION
Tapping the eye showed one line — *"Verdachte hoeken onthuld in de buurt (N4)"* — and nothing else. That line describes what the perk **does**, not what it **found**, and the lines carrying actual findings only appeared when there was something to report. On a clean floor you got a cryptic sentence and no information, which reads as a broken detector.

Implements the ladder from your spec. Each unlocked level owns a range and always states its answer:

| level | range | when found | when not |
|---|---|---|---|
| L1 | within a few steps | *A hidden corridor is close by* | *No hidden corridor close by* |
| L2 | + this floor | *…waits on this floor* | *No hidden corridor on this floor* |
| L3 | + other floors | *…waits on another floor* | *No hidden corridors found so far in this pyramid* |
| L4 | + journey map | (marker on the pyramid card) | — |

**L4 needed no work** — `Travel.tsx:328` and `JourneyCard.tsx:136` already draw that marker at level ≥ 4.

## L1's reading is genuinely new

Proximity was never computed, so the level that *unlocks* the detector said nothing about your surroundings. `isCorridorNearby` walks outward from the explorer, at most `NEARBY_STEPS` (4) deep, and stops at the first junction bordering an unnoticed corridor. The constant is named and commented — it's the whole feel of the L1 readout, so it's meant to be tuned.

**It deliberately does not use `findPath`,** and that's the interesting bug in this PR. My first version did, and the spec caught it: `findPath` answers "draw me a route", and when there is no route it returns a synthetic `[from, to]` (`gridNavigation.ts:135`). That reads as exactly *one step*, so every unreachable corridor on the floor would have been reported as "close by". A guard for "the path starts where the player stands" doesn't help either, because the synthetic path does. The bounded BFS avoids the trap entirely and is one traversal instead of one per junction. `corridorProximity.spec.ts` pins it, including the severed-floor case.

Traversal mirrors the player's own movement — through open directions, never into empty or fogged ground — so "nearby" means reachable across floor you've actually seen, not close as the crow flies.

## The pyramid range stays honest

Per your call: only floors you've already walked count, so the detector can't send you after a corridor behind a door you have no key for. That's why the negative reads *"none found so far in this pyramid"* rather than claiming it's clean — the weaker sentence is the true one.

## Also gone

- **The `(N4)` / `(L4)` tag.** The detector's own level, shown as a bare code with nothing anywhere to explain it. Each line now says what it means on its own.
- **The pyramid count.** The readout reports presence per range, not totals, so `corridorPyramidCount` and its plural forms are dropped — along with their cases in `plurals.spec.ts`.

## Tests

- `corridorProximity.spec.ts` — new: radius boundary, closest-of-several, standing on the junction, walked-distance vs straight-line, no grid, no leads.
- `DetectorPanel.spec.tsx` — rewritten to the new ladder: scopes unlock one per level, every unlocked scope states an absence rather than going quiet, and each scope answers independently (a lead nearby must not imply one elsewhere).
- A `CorridorLevel3NothingFound` story for the all-negative state, which is the case that used to render as an empty panel.

## Verification

`yarn check-types` ✅ · `yarn lint` (0 errors, 44 warnings — unchanged) ✅ · `yarn build` ✅ · `yarn test --run` — **1256 passed** ✅

## Worth a look by eye

The wording is the point of this change, so it's worth reading in place — particularly the Dutch, which I've written to match the existing register (*"Een verborgen gang is vlakbij"*, *"Nog geen verborgen gangen gevonden in deze piramide"*). Walking toward a hidden corridor should flip the first line from negative to positive within a few steps.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BU4goDhQufw7LQAdvGzqn2)_