### PR TITLE
feat(detector): keep reading while the readout is closed, with a proximity dot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- A detector keeps reading with its readout closed, so you can put the panel away and still see the map. The button now opens and closes the readout rather than switching the detector on and off; tapping the running detector in the readout is what stops it.
+- A pulsing dot beside the detector button carries the reading while the readout is shut: slow for something elsewhere in this pyramid, quicker for something on this floor, fast for something a few steps away. It reports whichever detector is running — corridors, hieroglyphs or supplies.
+- The dot never says more than your detector level knows. A level-1 compass reports "somewhere in this pyramid" even when the piece is around the corner, because that is all a level-1 compass can tell.
+
 ## 0.34.2 - 2026-08-13
 
 ### Changed

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -217,7 +217,13 @@
     "corridorNoneOnFloor": "No hidden corridor on this floor",
     "corridorOtherFloor": "A hidden corridor waits on another floor",
     "corridorNoneInPyramid": "No hidden corridors found so far in this pyramid",
-    "title": "Detector"
+    "title": "Detector",
+    "band": {
+      "none": "Nothing detected",
+      "pyramid": "Something in this pyramid",
+      "floor": "Something on this floor",
+      "near": "Something close by"
+    }
   },
   "keys": {
     "blue": "Blue key",

--- a/public/locales/nl/common.json
+++ b/public/locales/nl/common.json
@@ -210,7 +210,13 @@
     "corridorNoneOnFloor": "Geen verborgen gang op deze verdieping",
     "corridorOtherFloor": "Een verborgen gang wacht op een andere verdieping",
     "corridorNoneInPyramid": "Nog geen verborgen gangen gevonden in deze piramide",
-    "title": "Detector"
+    "title": "Detector",
+    "band": {
+      "none": "Niets gevonden",
+      "pyramid": "Iets in deze piramide",
+      "floor": "Iets op deze verdieping",
+      "near": "Iets dichtbij"
+    }
   },
   "keys": {
     "blue": "Blauwe sleutel",

--- a/src/app/SiteMap/SiteMapScreen.tsx
+++ b/src/app/SiteMap/SiteMapScreen.tsx
@@ -2,7 +2,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { findPath, getCell, getOwnedKeys } from "@/game/gridNavigation"
 import { floorKeyRing } from "@/game/floorKeys"
-import { isCorridorNearby } from "@/app/SiteMap/corridorProximity"
+import { isAnyCellWithinSteps } from "@/app/SiteMap/cellProximity"
+import { bandFromHits, corridorBand, type ProximityBand } from "@/app/SiteMap/detectorProximity"
 import { getFamilyPlugin, type FamilyContext } from "@/app/families/familyRegistry"
 import { hashString } from "@/support/hashString"
 import { useTimeout } from "@/support/useTimeout"
@@ -121,7 +122,7 @@ export const SiteMapScreen = ({ journeyId, siteConfig, seed, onSiteComplete, onC
   // L1's scope: a lead within a few steps of where the player stands. Recomputed as they walk, so the
   // readout flips from "nothing nearby" to "something nearby" on approach.
   const corridorNearby = useMemo(
-    () => isCorridorNearby(grid, explorerPos, junctionSections),
+    () => isAnyCellWithinSteps(grid, explorerPos, new Set(junctionSections.keys())),
     [grid, explorerPos, junctionSections]
   )
   // L3's scope: still-unnoticed corridors on OTHER floors. The pyramid tally counts every floor the
@@ -134,6 +135,63 @@ export const SiteMapScreen = ({ journeyId, siteConfig, seed, onSiteComplete, onC
     [hiddenSectionHashes, foundCorridors]
   )
   const hiddenCorridorOnOtherFloor = journeys.getOutstandingHiddenCorridorCount(journeyId) - floorOutstanding > 0
+  // The running detector's closest reading, for the pulsing dot beside the HUD button. Each detector
+  // is narrowed to what its own level may know (see detectorProximity) — the dot must not hand the
+  // player L3 precision at L1.
+  //
+  // A hit's pyramid: CompassHit carries levelIdx, so a hit elsewhere in this journey is correctly
+  // "another pyramid" rather than this floor. ConsumableResult carries no levelIdx (it is rebuilt from
+  // an edgeId), so supplies can only match journey + floor index — a skipped chest on floor 2 of a
+  // DIFFERENT pyramid of the same journey reads as "this floor". Same limitation the supplies readout
+  // already has in its labels; fixing it means recording the pyramid when the skip is stored.
+  const currentLevelIdx = (journeyState?.levelNr ?? 1) - 1
+  const detectorBand = useMemo((): ProximityBand => {
+    if (detector.activeDetector === "hiddenPassageway")
+      return corridorBand(detectorLevels.corridor, {
+        nearby: corridorNearby,
+        onThisFloor: floorHasHiddenCorridor,
+        onOtherFloor: hiddenCorridorOnOtherFloor,
+      })
+
+    // One search for the whole floor rather than one per hit: `bandFromHits` only asks whether ANY hit
+    // is close, so "is any of these cells within reach" is a single walk outward.
+    const anyNearby = (cells: readonly { row: number; col: number }[]) =>
+      isAnyCellWithinSteps(grid, explorerPos, new Set(cells.map(c => `${c.row},${c.col}`)))
+
+    if (detector.activeDetector === "compass") {
+      const here = detector.compassResults.filter(
+        r => r.journeyId === journeyId && r.levelIdx === currentLevelIdx && r.floorIdx === currentFloor
+      )
+      const close = anyNearby(here.flatMap(r => (r.cell ? [r.cell] : [])))
+      return bandFromHits(
+        detectorLevels.compass,
+        detector.compassResults.map(r => ({ onThisFloor: here.includes(r), nearby: here.includes(r) && close }))
+      )
+    }
+    if (detector.activeDetector === "consumable") {
+      const here = detector.consumableResults.filter(r => r.journeyId === journeyId && r.floorIdx === currentFloor)
+      const close = anyNearby(here.map(r => r.cell))
+      return bandFromHits(
+        detectorLevels.supplies,
+        detector.consumableResults.map(r => ({ onThisFloor: here.includes(r), nearby: here.includes(r) && close }))
+      )
+    }
+    return "none"
+  }, [
+    detector.activeDetector,
+    detector.compassResults,
+    detector.consumableResults,
+    detectorLevels,
+    corridorNearby,
+    floorHasHiddenCorridor,
+    hiddenCorridorOnOtherFloor,
+    grid,
+    explorerPos,
+    journeyId,
+    currentFloor,
+    currentLevelIdx,
+  ])
+
   // Which detectors the player owns, in the order the switcher shows them. The HUD's single button
   // opens the readout on the first of these; with none owned there is no button at all.
   const availableDetectors = useMemo(
@@ -456,7 +514,7 @@ export const SiteMapScreen = ({ journeyId, siteConfig, seed, onSiteComplete, onC
             corridorOtherFloor: t("common:detector.corridorOtherFloor"),
             corridorNoneInPyramid: t("common:detector.corridorNoneInPyramid"),
           }}
-          activeDetector={detector.activeDetector}
+          activeDetector={detector.readoutOpen ? detector.activeDetector : null}
           compassLevel={detectorLevels.compass}
           consumableDetectorLevel={detectorLevels.supplies}
           detectionLevel={detectorLevels.corridor}
@@ -466,7 +524,12 @@ export const SiteMapScreen = ({ journeyId, siteConfig, seed, onSiteComplete, onC
           compassResults={detector.compassResults}
           consumableResults={detector.consumableResults}
           detectorTitles={detectorTitles}
-          onSetDetector={detector.setDetector}
+          onSetDetector={mode => {
+            detector.setDetector(mode)
+            // Tapping the running detector in the switcher stops it; with nothing left to read there
+            // is nothing for the readout to show either, so it shuts with it.
+            if (!mode) detector.setReadoutOpen(false)
+          }}
           corridorNearby={corridorNearby}
           floorHasHiddenCorridor={floorHasHiddenCorridor}
           hiddenCorridorOnOtherFloor={hiddenCorridorOnOtherFloor}
@@ -482,8 +545,16 @@ export const SiteMapScreen = ({ journeyId, siteConfig, seed, onSiteComplete, onC
           {availableDetectors.length > 0 && (
             <DetectorButton
               activeDetector={detector.activeDetector}
+              readoutOpen={detector.readoutOpen}
               title={t("common:detector.title")}
-              onToggle={() => detector.setDetector(detector.activeDetector ? null : availableDetectors[0])}
+              band={detectorBand}
+              bandLabel={t(`common:detector.band.${detectorBand}`)}
+              onToggle={() => {
+                // Opening with nothing running starts the first detector owned; closing leaves it
+                // running, which is what the dot reports.
+                if (!detector.activeDetector) detector.setDetector(availableDetectors[0])
+                detector.setReadoutOpen(!detector.readoutOpen)
+              }}
             />
           )}
           {/* This floor's key ring: coloured keys already in hand, plus the colours of doors seen

--- a/src/app/SiteMap/cellProximity.spec.ts
+++ b/src/app/SiteMap/cellProximity.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import type { Direction, FloorGrid, GridCell } from "@/game/siteTypes"
-import { isCorridorNearby, NEARBY_STEPS } from "./corridorProximity"
+import { isAnyCellWithinSteps, NEARBY_STEPS } from "./cellProximity"
 
 // A single straight corridor, so distance along it is just the column difference.
 const corridor = (dirs: Direction[]): GridCell => ({
@@ -19,31 +19,31 @@ const rowOf = (length: number): FloorGrid => ({
   staircases: {},
 })
 
-const junctionsAt = (...cols: number[]) =>
-  new Map(cols.map(col => [`0,${col}`, new Set(["section-hash"]) as ReadonlySet<string>]))
+// Cells keyed "row,col", the shape every detector hands in: corridor junctions, compass hits, chests.
+const cellsAt = (...cols: number[]) => new Set(cols.map(col => `0,${col}`))
 
-describe("isCorridorNearby", () => {
+describe("isAnyCellWithinSteps", () => {
   it("is false when the floor holds no unnoticed corridor at all", () => {
-    expect(isCorridorNearby(rowOf(10), [0, 0], new Map())).toBe(false)
+    expect(isAnyCellWithinSteps(rowOf(10), [0, 0], new Set())).toBe(false)
   })
 
   it("is false with no grid to measure across", () => {
-    expect(isCorridorNearby(null, [0, 0], junctionsAt(1))).toBe(false)
+    expect(isAnyCellWithinSteps(null, [0, 0], cellsAt(1))).toBe(false)
   })
 
   it("counts the junction the player is standing on as nearby", () => {
-    expect(isCorridorNearby(rowOf(10), [0, 3], junctionsAt(3))).toBe(true)
+    expect(isAnyCellWithinSteps(rowOf(10), [0, 3], cellsAt(3))).toBe(true)
   })
 
   it("is true just inside the radius and false just outside it", () => {
     const grid = rowOf(20)
-    expect(isCorridorNearby(grid, [0, 0], junctionsAt(NEARBY_STEPS))).toBe(true)
-    expect(isCorridorNearby(grid, [0, 0], junctionsAt(NEARBY_STEPS + 1))).toBe(false)
+    expect(isAnyCellWithinSteps(grid, [0, 0], cellsAt(NEARBY_STEPS))).toBe(true)
+    expect(isAnyCellWithinSteps(grid, [0, 0], cellsAt(NEARBY_STEPS + 1))).toBe(false)
   })
 
   it("takes the closest lead when several are on the floor", () => {
     const grid = rowOf(20)
-    expect(isCorridorNearby(grid, [0, 0], junctionsAt(15, 2, 18))).toBe(true)
+    expect(isAnyCellWithinSteps(grid, [0, 0], cellsAt(15, 2, 18))).toBe(true)
   })
 
   // Walking distance, not straight-line: the row is severed at column 2, so a junction at column 4 —
@@ -55,8 +55,8 @@ describe("isCorridorNearby", () => {
         [corridor(["e"]), corridor(["w"]), { type: "empty" }, corridor(["e"]), corridor(["w"]), { type: "empty" }],
       ],
     }
-    expect(isCorridorNearby(severed, [0, 0], junctionsAt(4))).toBe(false)
+    expect(isAnyCellWithinSteps(severed, [0, 0], cellsAt(4))).toBe(false)
     // ...while a junction on the player's own side of the break still counts.
-    expect(isCorridorNearby(severed, [0, 0], junctionsAt(1))).toBe(true)
+    expect(isAnyCellWithinSteps(severed, [0, 0], cellsAt(1))).toBe(true)
   })
 })

--- a/src/app/SiteMap/cellProximity.ts
+++ b/src/app/SiteMap/cellProximity.ts
@@ -8,10 +8,10 @@ export const NEARBY_STEPS = 4
 
 const MOVES: Record<Direction, readonly [number, number]> = { n: [-1, 0], s: [1, 0], e: [0, 1], w: [0, -1] }
 
-// Is the player within `maxSteps` of a corner that borders an unnoticed hidden corridor?
+// Is the player within `maxSteps` of any of `targets` — cells keyed "row,col"?
 //
-// `junctionSections` only ever holds junctions bordering corridors that are still hidden — a noticed
-// one is revealed and drops out — so any entry here is a live lead.
+// Used for every detector's "close by" reading: the corridor detector passes the junctions bordering
+// corridors still hidden, the compass and supplies detectors pass the cells their hits sit in.
 //
 // Deliberately its own bounded search rather than findPath: findPath answers "draw me a route" and
 // falls back to a synthetic `[from, to]` when there is no route at all, which reads as exactly one
@@ -21,16 +21,16 @@ const MOVES: Record<Direction, readonly [number, number]> = { n: [-1, 0], s: [1,
 // Traversal follows the same rules as the player's own movement — through a cell's open directions,
 // never into empty or fogged ground — so "nearby" means reachable across floor they have actually
 // seen, not close as the crow flies.
-export const isCorridorNearby = (
+export const isAnyCellWithinSteps = (
   grid: FloorGrid | null,
   explorerPos: readonly [number, number],
-  junctionSections: ReadonlyMap<string, ReadonlySet<string>>,
+  targets: ReadonlySet<string>,
   maxSteps: number = NEARBY_STEPS
 ): boolean => {
-  if (!grid || junctionSections.size === 0) return false
+  if (!grid || targets.size === 0) return false
 
   const key = (row: number, col: number) => `${row},${col}`
-  if (junctionSections.has(key(explorerPos[0], explorerPos[1]))) return true
+  if (targets.has(key(explorerPos[0], explorerPos[1]))) return true
 
   const seen = new Set([key(explorerPos[0], explorerPos[1])])
   let frontier: Array<readonly [number, number]> = [explorerPos]
@@ -49,7 +49,7 @@ export const isCorridorNearby = (
         if (seen.has(nk)) continue
         const neighbor = grid.cells[nr]?.[nc]
         if (!neighbor || neighbor.type === "empty" || neighbor.state === "fogged") continue
-        if (junctionSections.has(nk)) return true
+        if (targets.has(nk)) return true
         seen.add(nk)
         next.push([nr, nc])
       }

--- a/src/app/SiteMap/detectorProximity.spec.ts
+++ b/src/app/SiteMap/detectorProximity.spec.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest"
+import { bandFromHits, corridorBand } from "./detectorProximity"
+
+const hit = (onThisFloor: boolean, nearby: boolean) => ({ onThisFloor, nearby })
+
+describe("bandFromHits — precision the level actually grants", () => {
+  it("reports nothing when the detector is not owned, whatever the hits say", () => {
+    expect(bandFromHits(0, [hit(true, true)])).toBe("none")
+  })
+
+  it("reports nothing when there are no hits", () => {
+    expect(bandFromHits(3, [])).toBe("none")
+  })
+
+  // The whole point of the ladder (§7.2): at L1 the compass knows only WHICH PYRAMID holds a hit, so
+  // a hit two steps away must still read "pyramid". Feeding raw distance to the dot would hand the
+  // player L3 precision at L1.
+  it("caps at pyramid on L1 even when the hit is underfoot", () => {
+    expect(bandFromHits(1, [hit(true, true)])).toBe("pyramid")
+  })
+
+  it("adds the floor at L2, but still not the cell", () => {
+    expect(bandFromHits(2, [hit(true, true)])).toBe("floor")
+    expect(bandFromHits(2, [hit(false, false)])).toBe("pyramid")
+  })
+
+  it("adds close-by at L3", () => {
+    expect(bandFromHits(3, [hit(true, true)])).toBe("near")
+    expect(bandFromHits(3, [hit(true, false)])).toBe("floor")
+    expect(bandFromHits(3, [hit(false, false)])).toBe("pyramid")
+  })
+
+  it("takes the closest hit when several are in play", () => {
+    expect(bandFromHits(3, [hit(false, false), hit(true, true), hit(true, false)])).toBe("near")
+    expect(bandFromHits(3, [hit(false, false), hit(true, false)])).toBe("floor")
+  })
+
+  it("honours a detector whose levels reveal floors and cells at other steps", () => {
+    // A detector that only ever learns the floor, never the cell.
+    expect(bandFromHits(9, [hit(true, true)], { cellsAt: Infinity })).toBe("floor")
+  })
+})
+
+describe("corridorBand", () => {
+  it("reports nothing when the detector is not owned", () => {
+    expect(corridorBand(0, { nearby: true, onThisFloor: true, onOtherFloor: true })).toBe("none")
+  })
+
+  // Proximity is what L1 buys, so it reads at L1 — unlike the compass, whose L1 is pyramid-wide.
+  it("reads close-by from L1", () => {
+    expect(corridorBand(1, { nearby: true, onThisFloor: true, onOtherFloor: false })).toBe("near")
+  })
+
+  it("keeps this floor to L2 and up", () => {
+    expect(corridorBand(1, { nearby: false, onThisFloor: true, onOtherFloor: false })).toBe("none")
+    expect(corridorBand(2, { nearby: false, onThisFloor: true, onOtherFloor: false })).toBe("floor")
+  })
+
+  it("keeps other floors to L3 and up", () => {
+    expect(corridorBand(2, { nearby: false, onThisFloor: false, onOtherFloor: true })).toBe("none")
+    expect(corridorBand(3, { nearby: false, onThisFloor: false, onOtherFloor: true })).toBe("pyramid")
+  })
+
+  it("reports nothing when every scope it can see is clear", () => {
+    expect(corridorBand(4, { nearby: false, onThisFloor: false, onOtherFloor: false })).toBe("none")
+  })
+})

--- a/src/app/SiteMap/detectorProximity.ts
+++ b/src/app/SiteMap/detectorProximity.ts
@@ -1,0 +1,50 @@
+// How close the running detector's nearest reading is. Drives the pulsing dot beside the HUD's
+// detector button, so the reading is legible with the readout closed.
+//
+//   "none"     nothing to report — no dot at all
+//   "pyramid"  somewhere else in this pyramid: slow pulse
+//   "floor"    on the floor the player is standing on: quicker
+//   "near"     within a few steps: fast
+export type ProximityBand = "none" | "pyramid" | "floor" | "near"
+
+export const PULSE_SECONDS: Record<Exclude<ProximityBand, "none">, number> = {
+  pyramid: 2.6,
+  floor: 1.2,
+  near: 0.5,
+}
+
+/**
+ * A detector's reading, narrowed to what its own level is allowed to know.
+ *
+ * Precision is the point of the detector ladder (§7.2), so the dot must not leak past it: at L1 the
+ * compass knows only which pyramid holds a hit, so its best band is "pyramid" however close the hit
+ * physically is. L2 adds the floor, L3 adds the exact cell and with it "near". Feeding the dot raw
+ * distances would hand the player L3 precision at L1.
+ */
+export const bandFromHits = (
+  level: number,
+  hits: readonly { onThisFloor: boolean; nearby: boolean }[],
+  // Whether this detector reports floors at all at this level, and cells at this level.
+  { floorsAt = 2, cellsAt = 3 }: { floorsAt?: number; cellsAt?: number } = {}
+): ProximityBand => {
+  if (level <= 0 || hits.length === 0) return "none"
+  if (level >= cellsAt && hits.some(h => h.nearby)) return "near"
+  if (level >= floorsAt && hits.some(h => h.onThisFloor)) return "floor"
+  return "pyramid"
+}
+
+/**
+ * The corridor detector's reading. Its own scopes already match the bands one-for-one, and each is
+ * gated on the level that unlocks it — L1 proximity, L2 this floor, L3 elsewhere in the pyramid — so
+ * this is a straight fold rather than a distance calculation.
+ */
+export const corridorBand = (
+  level: number,
+  { nearby, onThisFloor, onOtherFloor }: { nearby: boolean; onThisFloor: boolean; onOtherFloor: boolean }
+): ProximityBand => {
+  if (level <= 0) return "none"
+  if (nearby) return "near"
+  if (level >= 2 && onThisFloor) return "floor"
+  if (level >= 3 && onOtherFloor) return "pyramid"
+  return "none"
+}

--- a/src/app/state/useDetector.ts
+++ b/src/app/state/useDetector.ts
@@ -10,9 +10,13 @@ import { PYRAMID_JOURNEYS, TOMB_JOURNEYS } from "@/worldGen/data"
 import { TIER_UNLOCK_PERK_IDS } from "@/data/treasurePerks"
 
 export type DetectorAPI = {
+  /** Which detector is RUNNING. Independent of whether the readout is showing. */
   activeDetector: DetectorMode
+  /** Whether the readout panel is showing. Closing it leaves the detector running. */
+  readoutOpen: boolean
   compassTarget: string | null
   setDetector: (mode: DetectorMode) => void
+  setReadoutOpen: (open: boolean) => void
   compassResults: CompassHit[]
   consumableResults: ConsumableResult[]
 }
@@ -45,7 +49,12 @@ const accessOf = (
 }
 
 export const useDetector = (journeys: JourneyAPI): DetectorAPI => {
+  // Two separate things, deliberately: which detector is running, and whether its readout is on
+  // screen. The readout is a card over the map, so the player wants it shut most of the time — while
+  // the detector keeps reading, reported by the pulsing dot beside its button. Results below stay
+  // keyed on activeDetector alone, which is what keeps them coming while the card is closed.
   const [activeDetector, setActiveDetector] = useState<DetectorMode>(null)
+  const [readoutOpen, setReadoutOpen] = useState(false)
   // The hunt target is picked on Collection and owned by the fragment mod (§3C); core reads it via
   // the seam (null when no mod owns it) so a target survives navigation into a site.
   const compassTarget = useCompassTarget()
@@ -82,8 +91,10 @@ export const useDetector = (journeys: JourneyAPI): DetectorAPI => {
 
   return {
     activeDetector,
+    readoutOpen,
     compassTarget,
     setDetector: setActiveDetector,
+    setReadoutOpen,
     compassResults,
     consumableResults,
   }

--- a/src/ui/atoms/DetectorButton.spec.tsx
+++ b/src/ui/atoms/DetectorButton.spec.tsx
@@ -4,28 +4,56 @@ import { DetectorButton } from "./DetectorButton"
 
 afterEach(cleanup)
 
+const base = { title: "Detector", onToggle: vi.fn() }
+
 describe("DetectorButton", () => {
-  it("shows a plain lens while the readout is closed", () => {
-    render(<DetectorButton activeDetector={null} title="Detector" onToggle={vi.fn()} />)
+  it("shows a plain lens while no detector is running", () => {
+    render(<DetectorButton {...base} activeDetector={null} readoutOpen={false} />)
     expect(screen.getByRole("button").textContent).toBe("🔍")
-    expect(screen.getByRole("button").getAttribute("aria-pressed")).toBe("false")
   })
 
   // The point of folding three buttons into one: the row must still say which detector is reading,
   // otherwise compacting the HUD costs the player the information those buttons carried.
-  it("wears the running mode's own icon while open", () => {
-    render(<DetectorButton activeDetector="hiddenPassageway" title="Detector" onToggle={vi.fn()} />)
+  it("wears the running detector's own icon", () => {
+    render(<DetectorButton {...base} activeDetector="hiddenPassageway" readoutOpen={false} />)
     expect(screen.getByRole("button").textContent).toBe("👁")
-    expect(screen.getByRole("button").getAttribute("aria-pressed")).toBe("true")
 
     cleanup()
-    render(<DetectorButton activeDetector="compass" title="Detector" onToggle={vi.fn()} />)
+    render(<DetectorButton {...base} activeDetector="compass" readoutOpen={false} />)
     expect(screen.getByRole("button").textContent).toBe("🧭")
+  })
+
+  // The readout being open is what the button reports — a detector keeps running once shut, so
+  // aria-expanded tracks the panel and not the detector.
+  it("reports whether the readout is open, not whether a detector runs", () => {
+    const { rerender } = render(<DetectorButton {...base} activeDetector="compass" readoutOpen={false} />)
+    expect(screen.getByRole("button").getAttribute("aria-expanded")).toBe("false")
+
+    rerender(<DetectorButton {...base} activeDetector="compass" readoutOpen />)
+    expect(screen.getByRole("button").getAttribute("aria-expanded")).toBe("true")
+  })
+
+  it("shows the reading beside it, named for anyone who cannot time a pulse", () => {
+    render(
+      <DetectorButton
+        {...base}
+        activeDetector="hiddenPassageway"
+        readoutOpen={false}
+        band="near"
+        bandLabel="close by"
+      />
+    )
+    expect(screen.getByLabelText("close by")).toBeTruthy()
+  })
+
+  it("shows no dot when the running detector has nothing to report", () => {
+    render(<DetectorButton {...base} activeDetector="compass" readoutOpen={false} band="none" bandLabel="nothing" />)
+    expect(screen.queryByLabelText("nothing")).toBeNull()
   })
 
   it("reports a tap so the screen can open or close the readout", () => {
     const onToggle = vi.fn()
-    render(<DetectorButton activeDetector={null} title="Detector" onToggle={onToggle} />)
+    render(<DetectorButton {...base} onToggle={onToggle} activeDetector={null} readoutOpen={false} />)
     fireEvent.click(screen.getByRole("button"))
     expect(onToggle).toHaveBeenCalledTimes(1)
   })

--- a/src/ui/atoms/DetectorButton.stories.tsx
+++ b/src/ui/atoms/DetectorButton.stories.tsx
@@ -16,10 +16,42 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const Closed: Story = { args: { activeDetector: null } }
+export const Idle: Story = { args: { activeDetector: null, readoutOpen: false } }
 
-// Open, the button wears the running mode's icon — the row still says which detector is reading
-// without the panel having to be open.
-export const OpenOnCorridor: Story = { args: { activeDetector: "hiddenPassageway" } }
-export const OpenOnCompass: Story = { args: { activeDetector: "compass" } }
-export const OpenOnSupplies: Story = { args: { activeDetector: "consumable" } }
+// The readout open, so the button reads as pressed and wears the running mode's icon.
+export const ReadoutOpen: Story = { args: { activeDetector: "hiddenPassageway", readoutOpen: true } }
+
+// The case this feature exists for: a detector still reading with its readout shut, the dot carrying
+// the reading. Pulse rate is the distance — slow in the pyramid, quicker on the floor, fast up close.
+export const RunningPyramid: Story = {
+  args: { activeDetector: "hiddenPassageway", readoutOpen: false, band: "pyramid", bandLabel: "in this pyramid" },
+}
+export const RunningFloor: Story = {
+  args: { activeDetector: "hiddenPassageway", readoutOpen: false, band: "floor", bandLabel: "on this floor" },
+}
+export const RunningNear: Story = {
+  args: { activeDetector: "hiddenPassageway", readoutOpen: false, band: "near", bandLabel: "close by" },
+}
+export const RunningCompassNear: Story = {
+  args: { activeDetector: "compass", readoutOpen: false, band: "near", bandLabel: "close by" },
+}
+
+// All three rates side by side, to compare how distinguishable they are.
+export const AllRates: Story = {
+  args: { activeDetector: "hiddenPassageway", readoutOpen: false },
+  render: () => (
+    <div className="flex items-center gap-6">
+      {(["pyramid", "floor", "near"] as const).map(band => (
+        <DetectorButton
+          key={band}
+          activeDetector="hiddenPassageway"
+          readoutOpen={false}
+          title="Detector"
+          band={band}
+          bandLabel={band}
+          onToggle={() => {}}
+        />
+      ))}
+    </div>
+  ),
+}

--- a/src/ui/atoms/DetectorButton.tsx
+++ b/src/ui/atoms/DetectorButton.tsx
@@ -1,30 +1,49 @@
 import type { FC } from "react"
 import type { DetectorMode } from "@/game/siteTypes"
 import { MODE_ICON } from "./detectorModeIcons"
+import { ProximityDot } from "./ProximityDot"
+import type { ProximityBand } from "@/app/SiteMap/detectorProximity"
 
 type Props = {
-  /** The mode currently showing, or null when the readout is closed. */
+  /** The detector currently running, or null when none is. Survives closing the readout. */
   activeDetector: DetectorMode
+  /** Whether the readout is showing — the button opens and closes it. */
+  readoutOpen: boolean
   title: string
+  /** The running detector's closest reading, shown as a pulsing dot beside the button. */
+  band?: ProximityBand
+  bandLabel?: string
   onToggle: () => void
 }
 
 // The one detector control in the HUD row. Every detector the player owns used to have its own button
 // here; with three of them beside the key ring, the hearts, the supplies and the balance, the row ran
-// out of phone. This opens and closes the readout, and the choice of WHICH detector moved inside it
+// out of phone. This opens and closes the readout, and the choice of WHICH detector lives inside it
 // (DetectorToggles), next to the results that change with it.
 //
-// Closed it shows a plain lens; open it shows the running mode's own icon, so the row still says which
-// detector is reading without the panel having to be open.
-export const DetectorButton: FC<Props> = ({ activeDetector, title, onToggle }) => (
-  <button
-    onClick={onToggle}
-    className={`rounded px-2 py-1 text-xs ${
-      activeDetector ? "bg-amber-700 text-amber-100" : "bg-stone-800/90 text-stone-300 hover:bg-stone-700"
-    }`}
-    title={title}
-    aria-pressed={activeDetector !== null}
-  >
-    {activeDetector ? MODE_ICON[activeDetector] : "🔍"}
-  </button>
+// A detector keeps running with the readout closed, so the map is not covered while it reads. The dot
+// is what makes that worth doing: without it, closing the readout would cost the player every reading
+// the detector has. Closed and idle the button shows a lens; with a detector running it wears that
+// detector's own icon, so the row says which one is reading either way.
+export const DetectorButton: FC<Props> = ({
+  activeDetector,
+  readoutOpen,
+  title,
+  band = "none",
+  bandLabel = "",
+  onToggle,
+}) => (
+  <div className="flex items-center gap-1">
+    <button
+      onClick={onToggle}
+      className={`rounded px-2 py-1 text-xs ${
+        readoutOpen ? "bg-amber-700 text-amber-100" : "bg-stone-800/90 text-stone-300 hover:bg-stone-700"
+      }`}
+      title={title}
+      aria-expanded={readoutOpen}
+    >
+      {activeDetector ? MODE_ICON[activeDetector] : "🔍"}
+    </button>
+    <ProximityDot band={band} label={bandLabel} />
+  </div>
 )

--- a/src/ui/atoms/DetectorPanel.spec.tsx
+++ b/src/ui/atoms/DetectorPanel.spec.tsx
@@ -191,9 +191,10 @@ describe("DetectorPanel precision by level (§7.2)", () => {
     expect(screen.getByText("No hidden corridors found so far in this pyramid")).toBeTruthy()
   })
 
-  // Folding the HUD's three detector buttons into one moved the choice of mode in here. With only one
-  // detector owned there is no choice to offer, so the row must not appear at all.
-  it("offers the mode switcher only when more than one detector is owned", () => {
+  // The switcher carries the off switch now: a detector keeps running once the readout is shut, so
+  // tapping the running one here is the only way to stop it. That has to be reachable even for a
+  // player who owns exactly one detector — where it used to be hidden as "no choice to offer".
+  it("offers the switcher whenever a detector is owned, so it can also be switched off", () => {
     const withSwitcher = {
       ...corridorBase,
       detectionLevel: 1,
@@ -202,8 +203,8 @@ describe("DetectorPanel precision by level (§7.2)", () => {
     }
 
     const { rerender } = render(<DetectorPanel {...withSwitcher} />)
-    expect(screen.queryByTitle("Compass")).toBeNull() // corridor detector alone
-    expect(screen.queryByTitle("Corridors")).toBeNull()
+    expect(screen.getByTitle("Corridors")).toBeTruthy() // the one owned — its own off switch
+    expect(screen.queryByTitle("Compass")).toBeNull() // not owned, not offered
 
     rerender(<DetectorPanel {...withSwitcher} compassLevel={2} />)
     expect(screen.getByTitle("Compass")).toBeTruthy()

--- a/src/ui/atoms/DetectorPanel.tsx
+++ b/src/ui/atoms/DetectorPanel.tsx
@@ -35,8 +35,9 @@ type Props = {
   compassResults: CompassHit[]
   consumableResults: ConsumableResult[]
   // Switching modes happens in here rather than in the HUD row — see DetectorButton. Passed through
-  // to DetectorToggles; the row is hidden when the player owns only one detector, since a switcher
-  // between one thing tells them nothing.
+  // to DetectorToggles. Shown whenever the readout is open, even with one detector owned: since a
+  // detector keeps running once the readout is shut, tapping the active one here is the only way to
+  // stop it, so this row carries the off switch and not just the choice.
   detectorTitles?: Record<Exclude<DetectorMode, null>, string>
   onSetDetector?: (mode: DetectorMode) => void
   // Corridor detector widens outward (§7.2), one scope per level: L1 = within a few steps of the
@@ -136,8 +137,8 @@ export const DetectorPanel: FC<Props> = ({
     // `pointer-events-auto` re-enables hit-testing inside SiteHudBar's non-hit-testing band, so taps
     // on this opaque card don't fall through to the map behind it.
     <div className="pointer-events-auto rounded-lg border border-stone-700 bg-stone-900/90 p-2 text-xs text-stone-300">
-      {/* Mode switcher, only worth showing when there is a choice to make. */}
-      {detectorTitles && onSetDetector && ownedDetectors > 1 && (
+      {/* Mode switcher — and the off switch: tapping the running detector here stops it. */}
+      {detectorTitles && onSetDetector && ownedDetectors > 0 && (
         <div className="mb-2 border-b border-stone-700 pb-2">
           <DetectorToggles
             activeDetector={activeDetector}

--- a/src/ui/atoms/ProximityDot.spec.tsx
+++ b/src/ui/atoms/ProximityDot.spec.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect, afterEach } from "vitest"
+import { render, screen, cleanup } from "@testing-library/react"
+import { ProximityDot } from "./ProximityDot"
+import { PULSE_SECONDS } from "@/app/SiteMap/detectorProximity"
+
+afterEach(cleanup)
+
+describe("ProximityDot", () => {
+  it("draws nothing when there is nothing to report", () => {
+    const { container } = render(<ProximityDot band="none" label="nothing" />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  // Pulse rate is the reading, so the rates must actually differ and get faster as it closes —
+  // otherwise the dot carries no information at all.
+  it("pulses faster the closer the reading is", () => {
+    expect(PULSE_SECONDS.pyramid).toBeGreaterThan(PULSE_SECONDS.floor)
+    expect(PULSE_SECONDS.floor).toBeGreaterThan(PULSE_SECONDS.near)
+  })
+
+  it("sets its own pulse duration from the band", () => {
+    const { container } = render(<ProximityDot band="floor" label="on this floor" />)
+    const pulse = container.querySelector<HTMLElement>(".animate-pulse")
+    expect(pulse?.style.animationDuration).toBe(`${PULSE_SECONDS.floor}s`)
+  })
+
+  // A pulse rate is useless to a screen reader, and hard to judge for anyone who cannot compare a
+  // 0.5s cycle against a 1.2s one — so the reading is named too.
+  it("names the reading rather than relying on the rate alone", () => {
+    render(<ProximityDot band="near" label="close by" />)
+    expect(screen.getByLabelText("close by")).toBeTruthy()
+  })
+})

--- a/src/ui/atoms/ProximityDot.stories.tsx
+++ b/src/ui/atoms/ProximityDot.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import { ProximityDot } from "./ProximityDot"
+
+const meta = {
+  component: ProximityDot,
+  decorators: [
+    Story => (
+      <div className="bg-stone-950 p-6">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof ProximityDot>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+// Side by side is the only way to judge whether the three rates are actually tellable apart.
+export const AllBands: Story = {
+  args: { band: "near", label: "close by" },
+  render: () => (
+    <div className="flex items-center gap-8 text-xs text-stone-400">
+      {(["pyramid", "floor", "near"] as const).map(band => (
+        <span key={band} className="flex items-center gap-2">
+          <ProximityDot band={band} label={band} />
+          {band}
+        </span>
+      ))}
+    </div>
+  ),
+}
+
+export const NothingDetected: Story = { args: { band: "none", label: "nothing" } }

--- a/src/ui/atoms/ProximityDot.tsx
+++ b/src/ui/atoms/ProximityDot.tsx
@@ -1,0 +1,36 @@
+import type { FC } from "react"
+import { PULSE_SECONDS, type ProximityBand } from "@/app/SiteMap/detectorProximity"
+
+type Props = {
+  band: ProximityBand
+  /** What this reading means, for anyone who cannot see a pulse rate. */
+  label: string
+}
+
+// The running detector's closest reading, as one pulsing dot beside its button — so the reading is
+// still there with the readout closed and the map unobstructed.
+//
+// Rate carries the distance: slow somewhere in the pyramid, quicker on this floor, fast within a few
+// steps. Rate alone is no good to a screen reader, or to anyone who cannot pick a 0.5s pulse apart
+// from a 1.2s one, so the band is also named in `label` and the colour warms as it closes.
+const BAND_COLOR: Record<Exclude<ProximityBand, "none">, string> = {
+  pyramid: "bg-stone-400",
+  floor: "bg-amber-300",
+  near: "bg-amber-200",
+}
+
+export const ProximityDot: FC<Props> = ({ band, label }) => {
+  if (band === "none") return null
+  return (
+    <span className="relative inline-flex size-2 shrink-0" role="img" aria-label={label} title={label}>
+      {/* The pulse itself: `animate-pulse` carries the easing, the inline duration sets the rate —
+          an inline longhand overrides the shorthand the utility class sets. */}
+      <span
+        className={`absolute inset-0 animate-pulse rounded-full ${BAND_COLOR[band]}`}
+        style={{ animationDuration: `${PULSE_SECONDS[band]}s` }}
+      />
+      {/* A solid core under the pulse, so the dot never disappears entirely mid-cycle. */}
+      <span className={`absolute inset-0.5 rounded-full ${BAND_COLOR[band]}`} />
+    </span>
+  )
+}


### PR DESCRIPTION
Both halves of the ask, because they only work together: closing the readout is only acceptable if the reading survives it, and the dot is what makes it survive.

## Running and showing are now two things

They were one piece of state, so seeing the map meant switching the detector off. Now:

- **the button opens and closes the readout** (`aria-expanded` tracks the panel, not the detector)
- **the detector keeps reading either way** — `compassResults` / `consumableResults` stay keyed on `activeDetector` alone, which is what keeps them coming with the card shut
- **tapping the running detector in the readout's switcher stops it**, and closes the readout with it

One consequence worth flagging: that switcher now shows whenever a detector is owned, not only when there are several. It carries the off switch, so hiding it for a single-detector player would strand them with a detector they cannot stop. That inverts the rule I shipped in #189 — the semantics changed under it, and its test is updated to say why rather than just flipped.

## The dot

Beside the button, pulsing at the distance of the nearest reading:

| band | rate | meaning |
|---|---|---|
| `pyramid` | 2.6s | somewhere else in this pyramid |
| `floor` | 1.2s | on the floor you're standing on |
| `near` | 0.5s | within a few steps |
| `none` | — | no dot at all |

Works for all three detectors, as you asked — corridors, hieroglyphs, supplies.

**Rate alone isn't enough information.** It's useless to a screen reader and hard to judge for anyone who can't compare a 0.5s cycle against a 1.2s one, so the band is also named in an `aria-label` and the colour warms as it closes. I rendered it beside the button and in the full HUD row at 390px to check size and contrast — it costs almost no width.

## The dot never outruns the detector's precision

This is the part I'd most want you to sanity-check, because it's a design call rather than a mechanic. The whole point of the detector ladder (§7.2) is that precision is earned, so the dot mustn't leak past it:

- **compass L1** knows only *which pyramid* holds a hit → reports `pyramid` even for a piece around the corner
- **L2** adds the floor → `floor` becomes reachable
- **L3** adds the exact cell → `near` becomes reachable

Feeding raw distances to the dot would hand out L3 precision at L1. `bandFromHits` takes the level plus the steps at which *that* detector learns floors and cells, so each ladder keeps its own shape. The corridor detector is different and gets its own fold: proximity is exactly what its L1 buys, so it reads `near` from L1.

`detectorProximity.spec.ts` pins all of that, including the "caps at pyramid on L1 even when the hit is underfoot" case.

## Refactor

`corridorProximity` → `cellProximity`: the same bounded walk now answers "is any of these cells within reach" for every detector rather than only corridor junctions. Its tests came along unchanged in substance. I also collapsed the per-hit searches into **one search per floor** — `bandFromHits` only asks whether *any* hit is close, so one walk outward answers it.

## Known limitation, noted at the call site

`ConsumableResult` carries no `levelIdx` (it's rebuilt from an `edgeId`), so supplies can only match journey + floor index — a skipped chest on floor 2 of a *different* pyramid of the same journey reads as "this floor". The supplies readout's labels already have that limitation; fixing it means recording the pyramid when the skip is stored. Flagged rather than silently approximated.

## Verification

`yarn check-types` ✅ · `yarn lint` (0 errors, 44 warnings) ✅ · `yarn build` ✅ · `yarn test --run` — **1280 passed** (up 19) ✅

## Worth a look by eye

- **Are the three rates actually tellable apart in play?** `PULSE_SECONDS` in `detectorProximity.ts` is one line to retune, and the `AllBands` / `AllRates` stories put them side by side.
- Does closing the readout and walking with just the dot feel like enough to hunt by?

---
_Generated by [Claude Code](https://claude.ai/code/session_01BU4goDhQufw7LQAdvGzqn2)_