### PR TITLE
docs: require one stateful topic per component

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,10 @@ Code is split into three layers with strict one-way dependencies (domain ← app
 
 Any feature with non-trivial in-progress state (a grid, marks, a partial solution, a block-id → value map) gets its state modeled in `src/game/` as a domain object: a state type + factory, named action functions that mutate via immer, and plain query functions for checks (win state, line status, etc.). Applies beyond puzzles/traps — level progress, journeys, inventory, anything with nested structure or more than one kind of move. See **[`docs/instructions/state-models.md`](docs/instructions/state-models.md)** — Sumplete (`src/game/puzzles/sumplete/sumpleteState.ts`) is the reference implementation.
 
+### 10. One Topic per Component
+
+A component in `src/app/` or `src/mods/*/app/` owns the state and effects of **one** topic. A second separable topic (zoom, selection, reveal animation, storage sync) moves into its own co-located `use<Topic>.ts` hook with its own spec. The trigger is topic count, not line count. Logic with no React state at all becomes a plain function, not a hook. See **[`docs/instructions/hooks.md`](docs/instructions/hooks.md)** for the hook contract, how to spot a tangle, and the behavior-neutral untangle gate.
+
 ---
 
 ## Common Workflows
@@ -179,6 +183,7 @@ Version bumps are a deployment decision, not a per-feature step — see the CI/C
 - ❌ Skipping the Dutch translation when adding English strings
 - ❌ Committing without running `yarn check-types` and `yarn lint`
 - ❌ Managing game state locally in components (use state hooks instead)
+- ❌ Holding two separable stateful topics in one component (extract a hook per topic)
 
 ---
 
@@ -193,6 +198,7 @@ Topic-specific guidelines for contributors and AI agents. Apply the relevant ins
 | [`docs/instructions/documentation.md`](docs/instructions/documentation.md)             | Creating, moving, or editing any documentation file (esp. keeping design docs free of build status)                                            |
 | [`docs/instructions/testing.md`](docs/instructions/testing.md)                         | Writing, reviewing, or deciding whether to add tests for any code                                                                              |
 | [`docs/instructions/comments.md`](docs/instructions/comments.md)                       | Writing or reviewing any code comment                                                                                                          |
+| [`docs/instructions/hooks.md`](docs/instructions/hooks.md)                             | Adding state or effects to a `src/app/` or mod component, or untangling an existing one                                                        |
 | [`docs/instructions/changelog.md`](docs/instructions/changelog.md)                     | Adding any user-facing change — to decide what belongs in `CHANGELOG.md`                                                                       |
 | [`docs/instructions/design-doc-fidelity.md`](docs/instructions/design-doc-fidelity.md) | Implementing or reviewing code against an existing `docs/game-design/` doc, or when the same kind of architectural gap surfaces more than once |
 

--- a/docs/instructions/hooks.md
+++ b/docs/instructions/hooks.md
@@ -1,0 +1,80 @@
+# One Topic per Component
+
+Applies to `src/app/**` and `src/mods/*/app/**`. `src/ui/**` keeps its own rule
+(stateless — props in, JSX out; see `docs/instructions/architecture.md`).
+
+## The rule
+
+A component may own the state and effects of **one** topic. A second separable
+topic — zoom, selection, reveal animation, storage sync, a timer — moves into its
+own `use<Topic>.ts` file with its own spec.
+
+The trigger is topic count, not line count. A 300-line component about one thing
+is fine. A 60-line component juggling three is not.
+
+Logic with **no** React state, effect or context is not a hook: it moves to a
+plain exported function (`src/game/` if portable, a module beside the component
+otherwise) and is tested without `renderHook`.
+
+## Spotting a tangle
+
+List the topics the component owns. One is fine; two or more separable ones means
+extract. Smells:
+
+- A `useEffect` whose dependencies share no vocabulary with the JSX
+- State names from different domains in one component (`zoom*` + `selected*` + `reveal*`)
+- Handlers that touch one cluster of state and never any other
+- A comment that exists to explain which block of the component does what
+
+## Hook contract
+
+- One hook per file, filename = hook name, co-located with the consuming component
+- Inputs arrive as **arguments** — a hook does not reach into context or globals
+  itself, so a spec can drive it directly
+- Returns a **named object**: values plus verb-named actions
+- **No JSX** from a hook — something returning JSX is a component
+
+```ts
+export const useMapZoom = (bounds: Bounds) => {
+  // ...
+  return { scale, offset, zoomIn, zoomOut, reset };
+};
+
+// spec drives it directly
+renderHook(() => useMapZoom(testBounds));
+```
+
+Promote a hook to `src/app/state/` only when a second feature consumes it or it
+owns persisted game state. Otherwise it stays beside its component.
+
+## Where the state itself lives
+
+| Kind of state                                    | Home                                                  |
+| ------------------------------------------------ | ----------------------------------------------------- |
+| Nested shape, more than one kind of move          | Domain state model in `src/game/` (AGENTS.md §9)      |
+| Persisted / cross-feature game state              | `src/app/state/` hook (AGENTS.md §3)                  |
+| Ephemeral view state for one feature              | Co-located `use<Topic>.ts`                            |
+
+A feature hook is React wiring: it holds the state and calls the domain's named
+actions. It does not model the shape itself.
+
+## Tests
+
+Every extracted hook gets a sibling `use<Topic>.spec.ts` driven by `renderHook`.
+
+One exemption: a hook that only wires already-tested hooks together, with no
+branching of its own. If it grows a condition, it grows a spec.
+
+## Untangling existing components
+
+Extraction is behavior-neutral. An untangle ships as its own PR:
+
+```
++ useRevealAnimation.ts
++ useRevealAnimation.spec.ts
+~ SiteMapView.tsx        topic removed
+= existing specs          zero changes
+```
+
+Existing specs must stay green **without edits**. Having to edit one is the signal
+that behavior moved — say so in the PR description, or back the change out.

--- a/docs/instructions/hooks.md
+++ b/docs/instructions/hooks.md
@@ -33,6 +33,8 @@ extract. Smells:
   itself, so a spec can drive it directly
 - Returns a **named object**: values plus verb-named actions
 - **No JSX** from a hook — something returning JSX is a component
+- An **effect-only** hook (it synchronizes or persists something and has no value to hand back)
+  returns nothing. `useFloorExplorationRecorder` is the reference.
 
 ```ts
 export const useMapZoom = (bounds: Bounds) => {


### PR DESCRIPTION
Adds an instruction file that keeps component intent visible: a component owns the state and effects of **one** topic, and a second separable topic moves into its own hook file with its own spec.

## The rule

- **Trigger** — topic count, not line count. Two separable stateful topics (zoom + selection + reveal animation) means extract.
- **Scope** — `src/app/**` and `src/mods/*/app/**`. `src/ui/**` keeps its existing stateless rule.
- **Pure logic** — no React state/effect/context means it is not a hook: it becomes a plain exported function, tested without `renderHook`.
- **Hook contract** — one per file, co-located with its component, inputs as arguments (so a spec can drive it), a named object out, no JSX. Promotion to `src/app/state/` only for shared or persisted state.
- **State shape** — nested/multi-move state still gets a domain state model in `src/game/` (convention 9); the hook is React wiring around it.
- **Tests** — a sibling spec per hook, exempting only branchless hooks that wire already-tested hooks together.
- **Untangling** — a behavior-neutral PR; existing specs must stay green with zero edits, and having to edit one is the signal that behavior moved.

Also includes a "spotting a tangle" section so each sweep applies the same standard, without any file list or build status in the doc.

## Wiring

`AGENTS.md` gains convention 10, a row in the Agent Instructions table, and a Things-to-Avoid bullet.

Docs only — no code, no player-visible change, so no CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CX9UqcJ8vN1uGPfLWzZMCr