### PR TITLE
fix: keep floor key icons readable on any background

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,5 @@ dist-ssr
 *storybook.log
 storybook-static
 .claude/worktrees
+.claude/settings.local.json
 .playwright-mcp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Floor keys stay readable on any background: the key icon now carries a dark halo, and the hole in its ring is see-through instead of a black dot.
+
 ## 0.34.4 - 2026-08-15
 
 ### Changed

--- a/src/ui/atoms/KeyIcon.tsx
+++ b/src/ui/atoms/KeyIcon.tsx
@@ -27,19 +27,22 @@ export const KeyIcon: FC<KeyIconProps> = ({ color, size = 20, outlined = false, 
       aria-label={title}
       aria-hidden={title ? undefined : true}
       className={clsx("shrink-0", className)}
+      // Dark halo so a light key stays readable on a light background. drop-shadow follows the drawn
+      // shape (unlike box-shadow), so the bow's hole stays open.
+      style={{ filter: "drop-shadow(0 0 1px rgba(0,0,0,0.85))" }}
     >
       {title && <title>{title}</title>}
-      {/* Bow (the ring you hold) + shaft + two teeth — a stylised warded key, readable at 16px. */}
+      {/* Bow (the ring you hold) + shaft + two teeth — a stylised warded key, readable at 16px.
+          The bow is a stroked ring, so its hole shows the background through. */}
       <circle
         cx={8}
         cy={8}
-        r={4.5}
-        fill={outlined ? "none" : hex}
+        r={outlined ? 4.5 : 3.2}
+        fill="none"
         stroke={hex}
-        strokeWidth={outlined ? 1.75 : 1}
+        strokeWidth={outlined ? 1.75 : 3}
         opacity={outlined ? 0.7 : 1}
       />
-      <circle cx={8} cy={8} r={1.6} fill="#1c1917" />
       <g stroke={hex} strokeWidth={2} strokeLinecap="round" opacity={outlined ? 0.7 : 1}>
         <line x1={11} y1={11} x2={19} y2={19} />
         <line x1={17} y1={15} x2={14.5} y2={17.5} />


### PR DESCRIPTION
Playtest finding: the key drawn in the loot popup was hard to read against some backgrounds, and the hole in its bow was an opaque black disc instead of being see-through.

## Changes

- `KeyIcon` draws the bow as a **stroked ring** (`fill="none"`) rather than a filled circle with a dark dot punched into it, so the hole shows the background through.
- A 1px dark `drop-shadow` on the svg gives every stroke a halo, so a light key hue stays legible on a light background. `drop-shadow` follows the drawn shape, so it hugs the key without filling the hole back in.

Both the held (solid) and outlined (not-yet-held) variants keep their existing silhouette.

Also ignores `.claude/settings.local.json` — worktrees symlink it to the main checkout so per-project Claude Code settings are shared without being committed.

## Testing

- `yarn check-types`, `yarn lint` clean (lint warnings are pre-existing)
- `FloorKeyRing`, `RewardFlow`, `keyGate` specs pass
- Verified in the running app during playtest

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0127TSNk6bxiyFxqvUeJEriW