### PR TITLE
Futoshiki: a fuller ladder, hint focus, and notes that survive a correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Wizard comparison grids ask for four harder kinds of reasoning, with hints that explain each, so they no longer solve like master ones.
 - Asking for a hint now moves the cursor to the square it is about, so the number pad is already aimed there.
 - The same number twice in a row or column now turns the squares red outright, instead of a dark tint that was easy to miss.
+- Writing a number no longer rubs out your notes elsewhere. Notes it rules out are struck through in red, and come back if you correct the number.
 
 ## 0.35.0 - 2026-08-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Comparison grids show only the signs the puzzle actually turns on: a starter board carries four or five instead of sixteen.
 - A comparison grid leans on its signs rather than on pre-filled numbers, so every board still teaches what a sign means.
-- Wizard comparison grids ask for two harder kinds of reasoning, with hints that explain both, so they no longer solve like master ones.
+- Wizard comparison grids ask for four harder kinds of reasoning, with hints that explain each, so they no longer solve like master ones.
+- Asking for a hint now moves the cursor to the square it is about, so the number pad is already aimed there.
+- The same number twice in a row or column now turns the squares red outright, instead of a dark tint that was easy to miss.
 
 ## 0.35.0 - 2026-08-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Comparison grids show only the signs the puzzle actually turns on: a starter board carries four or five instead of sixteen.
+- A comparison grid leans on its signs rather than on pre-filled numbers, so every board still teaches what a sign means.
+
 ## 0.35.0 - 2026-08-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Comparison grids show only the signs the puzzle actually turns on: a starter board carries four or five instead of sixteen.
 - A comparison grid leans on its signs rather than on pre-filled numbers, so every board still teaches what a sign means.
+- Wizard comparison grids ask for two harder kinds of reasoning, with hints that explain both, so they no longer solve like master ones.
 
 ## 0.35.0 - 2026-08-16
 

--- a/docs/game-design/puzzles/futoshiki.md
+++ b/docs/game-design/puzzles/futoshiki.md
@@ -73,17 +73,19 @@ show". The solver then applies techniques to the whole board, cheapest first, an
 repeats until nothing changes. Rows feed columns feed signs and back — that
 cross-constraint propagation is where the puzzle lives.
 
-| #      | Technique       | Fires when                                          | Decides                                            |
-| ------ | --------------- | --------------------------------------------------- | -------------------------------------------------- |
-| **T0** | Naked single    | A square has one candidate left                     | Write it in                                        |
-| **T1** | Hidden single   | A number fits only one square of a row or column    | Write it in there                                  |
-| **T2** | Sign bound      | One sign points away from a square                  | Rule out `N` (or `1` the other way)                |
-| **T3** | Sign vs. number | The square across a sign already holds a number     | Rule out everything on the wrong side of it        |
-| **T4** | Sign chain      | `k ≥ 2` squares rise (or fall) away in a run        | Cap the square at `N - k` (or floor it at `1 + k`) |
-| **T5** | Sign pair       | Neither side of a sign is settled                   | Cap each side by what the other can still hold     |
-| **T6** | Naked pair      | Two squares in a line hold the same two candidates  | Rule that pair out of the rest of the line         |
-| **T7** | Hidden pair     | Two numbers fit only the same two squares of a line | Rule everything else out of those two squares      |
-| **T8** | X-wing          | A number fits only the same two lanes in two lines  | Rule it out of the rest of both lanes              |
+| #       | Technique       | Fires when                                              | Decides                                            |
+| ------- | --------------- | ------------------------------------------------------- | -------------------------------------------------- |
+| **T0**  | Naked single    | A square has one candidate left                         | Write it in                                        |
+| **T1**  | Hidden single   | A number fits only one square of a row or column        | Write it in there                                  |
+| **T2**  | Sign bound      | One sign points away from a square                      | Rule out `N` (or `1` the other way)                |
+| **T3**  | Sign vs. number | The square across a sign already holds a number         | Rule out everything on the wrong side of it        |
+| **T4**  | Sign chain      | `k ≥ 2` squares rise (or fall) away in a run            | Cap the square at `N - k` (or floor it at `1 + k`) |
+| **T5**  | Sign pair       | Neither side of a sign is settled                       | Cap each side by what the other can still hold     |
+| **T6**  | Naked pair      | Two squares in a line hold the same two candidates      | Rule that pair out of the rest of the line         |
+| **T7**  | Hidden pair     | Two numbers fit only the same two squares of a line     | Rule everything else out of those two squares      |
+| **T8**  | Naked triple    | Three squares in a line hold three numbers between them | Rule those three out of the rest of the line       |
+| **T9**  | Hidden triple   | Three numbers fit only the same three squares of a line | Rule everything else out of those squares          |
+| **T10** | X-wing          | A number fits only the same two lanes in two lines      | Rule it out of the rest of both lanes              |
 
 ### 4.1 The ordering is about explainability, not power
 
@@ -97,23 +99,34 @@ Placements rank above eliminations for the same reason they do in Sumplete:
 writing a number in moves the board on, while ruling one out is the bookkeeping
 that gets you there.
 
-### 4.2 The top of the ladder is where wizard lives
+### 4.2 A technique we can explain is a technique we use
 
-T7 and T8 are the two rungs a 7×7 actually reaches for; below that size neither
-fires, because the board settles before it needs them. Measured over eight 7×7
-boards accepted at the T8 cap, five demanded an x-wing and two a hidden pair — so
-the top tier reaches its ceiling on its own, without generation being made to
-reject boards until it does.
+The bar for admitting a rung is that its reason can be said in one checkable
+sentence, not that a board is currently stuck without it. Holding an explainable
+technique back only means the hint engine has to reach for a worse reason when
+that position comes up.
 
-That is what separates wizard from master. At the T5 cap both tiers produced
-boards whose hardest step was the same, and wizard's higher ceiling was
-decorative.
+The bar for _keeping_ one is that it fires. A rung no board ever reaches is not a
+technique, it is dead code claiming to be one, so the reachability sweep asserts
+every rung fires on a real board and would fail the moment one stopped.
 
-### 4.3 Deliberately absent
+### 4.3 The top of the ladder is where wizard lives
 
-Swordfish, XY-wing, colouring, and the rest of the Sudoku ladder. They are real
-techniques, but nothing in the tier table needs them yet — they get added when a
-board demands one, not before.
+T6–T10 are the rungs a 7×7 actually reaches for; below that size none of them
+fire, because the board settles before it needs them. That is what separates
+wizard from master: at the T5 cap both tiers produced boards whose hardest step
+was the same, and wizard's higher ceiling was decorative.
+
+How often each is the hardest step of a wizard solve, and how rare they get:
+counted over thirty 7×7 boards, x-wing fired 14 times, naked pair 24, hidden pair
+22, naked triple 4, and hidden triple twice — the last first appearing at seed 14.
+Rarity is why the reachability sweep runs deeper on the top tier than on the rest.
+
+### 4.4 Still absent
+
+Swordfish, XY-wing and colouring. Not on the "not needed yet" grounds §4.2
+rejects — they are candidates under exactly the same bar, and go in when someone
+can write the one-sentence reason and show it firing.
 
 ## 5. Difficulty knobs
 
@@ -131,7 +144,7 @@ the redundancy §3.1 exists to remove.
 | junior  | 5×5  | T4 sign chain      | 8–12 of 40  |
 | expert  | 6×6  | T4 sign chain      | 11–20 of 60 |
 | master  | 6×6  | T5 sign pair       | 13–19 of 60 |
-| wizard  | 7×7  | T8 x-wing          | ~23 of 84   |
+| wizard  | 7×7  | T10 x-wing         | ~23 of 84   |
 
 The cap is inclusive: a tier permits every technique up to it, so wizard boards
 may use the whole ladder.
@@ -211,7 +224,28 @@ directions; nothing about a theme reaches the puzzle logic.
 Side family — the answer is an arrangement, not a number, so it does not feed
 carry-forward (`PUZZLE_FAMILIES.md` P3).
 
-## 11. Open questions
+## 11. Generation cost, and where it should go
+
+A wizard board is the dear one: seven squares wide, eleven techniques, and a
+prune loop that re-solves the board once per sign it tries to remove. That lands
+at roughly 225ms today, paid on the main thread the moment a puzzle room opens.
+
+Two things keep it there. The ladder **short-circuits** — only the cheapest
+technique that fires is spent on a pass, so the dear rungs at the end are rarely
+reached (mapping the whole ladder and taking the first non-empty result cost 6×
+that, since `map` is eager). And difficulty is never bought by rejecting boards
+until one demands the top rung, which measured at ~1050ms per accepted board.
+
+**The direction out is to stop generating at play time at all**: run generation
+offline, verify the boards, and ship a table of known-good seeds per family and
+tier with the build. Play time then costs one lookup plus one deterministic
+replay of the seed — and the offline pass is free to be as thorough as we like,
+including gates that are too slow to run in front of a player (every board
+demanding its cap, duration sampling, difficulty grading). Generation is already
+seeded and deterministic, which is the whole precondition. Prior art: the same
+mechanic in Block Sort.
+
+## 12. Open questions
 
 1. **Auto-pencilling.** Filling every square's notes with its row/column
    candidates at a tap is standard in Sudoku apps and would suit the higher

--- a/docs/game-design/puzzles/futoshiki.md
+++ b/docs/game-design/puzzles/futoshiki.md
@@ -39,12 +39,24 @@ need:
 3. If the technique solver stalls, fill in one of the squares it could not reach
    and try again. More than `N` pre-filled squares means the board is more answer
    than puzzle: abandon the attempt and draw a fresh square.
-4. Take signs away one at a time, in seeded random order, keeping each removal
-   only while the solver still reaches the end. The `pruneFraction` knob decides
-   how many removals are even attempted.
-5. Do the same to the pre-filled squares — thinning the signs usually makes an
-   earlier concession redundant, and a board should show only what it still
-   needs.
+4. Take the **pre-filled squares** away one at a time, in seeded random order,
+   keeping each removal while the solver still reaches the end.
+5. Then take the **signs** away the same way, repeating full sweeps until one
+   removes nothing.
+
+### 3.1 Why that order, and why to a fixpoint
+
+Signs and pre-filled numbers substitute for each other, so **whichever is thinned
+first is the one that survives**. Thinning signs first produced 4×4 boards
+carrying a single sign and three given numbers — a Latin square with a
+decoration, teaching nothing about what a sign means. The signs are the family;
+the givens are scaffolding, so the scaffolding goes first.
+
+Sweeping the signs to a **fixpoint** matters because removing one sign can make
+another removable. A single pass left most signs standing: measured on starter
+boards, 13–16 of the 16 signs shown could each still have been taken away. A sign
+the player cannot spend is worse than no sign — it hides which ones the deduction
+actually turns on. Every shipped board now has **zero** removable signs.
 
 **Gate: the technique solver settles every square** (§4), within the tier's
 technique cap, at every step above. A board that stalls needs a guess and is
@@ -93,18 +105,22 @@ board demands one, not before.
 
 - **Technique cap** — the highest technique the solver may use while accepting a
   board. This is what a board may _demand_ of the player.
-- **Prune fraction** — how hard generation tries to take signs away. Fewer signs
-  left is a thinner board with more to work out, and it is the same dial seen
-  from the board's side rather than the solver's.
 - **Grid size** — footprint, and how much bookkeeping a solve carries.
 
-| Tier    | Grid | Cap                | Prune |
-| ------- | ---- | ------------------ | ----- |
-| starter | 4×4  | T3 sign vs. number | 0.35  |
-| junior  | 5×5  | T4 sign chain      | 0.7   |
-| expert  | 6×6  | T4 sign chain      | 0.8   |
-| master  | 6×6  | T5 sign pair       | 1     |
-| wizard  | 7×7  | T6 naked pair      | 1     |
+Sign count is **not** a dial. It falls out of the cap: a weak ladder cannot spare
+many signs, a strong one strips the board bare. Setting it by hand only put back
+the redundancy §3.1 exists to remove.
+
+| Tier    | Grid | Cap                | Signs shown |
+| ------- | ---- | ------------------ | ----------- |
+| starter | 4×4  | T3 sign vs. number | 3–6 of 24   |
+| junior  | 5×5  | T4 sign chain      | 8–12 of 40  |
+| expert  | 6×6  | T4 sign chain      | 11–20 of 60 |
+| master  | 6×6  | T5 sign pair       | 13–19 of 60 |
+| wizard  | 7×7  | T6 naked pair      | 18–30 of 84 |
+
+The cap is inclusive: a tier permits every technique up to it, so wizard boards
+may use the whole ladder.
 
 7×7 is the ceiling, the same as Puzzle Express. Inside the encounter modal a
 360px screen leaves the board about 320px, so seven squares measure ~44px across

--- a/docs/game-design/puzzles/futoshiki.md
+++ b/docs/game-design/puzzles/futoshiki.md
@@ -73,15 +73,17 @@ show". The solver then applies techniques to the whole board, cheapest first, an
 repeats until nothing changes. Rows feed columns feed signs and back — that
 cross-constraint propagation is where the puzzle lives.
 
-| #      | Technique       | Fires when                                         | Decides                                            |
-| ------ | --------------- | -------------------------------------------------- | -------------------------------------------------- |
-| **T0** | Naked single    | A square has one candidate left                    | Write it in                                        |
-| **T1** | Hidden single   | A number fits only one square of a row or column   | Write it in there                                  |
-| **T2** | Sign bound      | One sign points away from a square                 | Rule out `N` (or `1` the other way)                |
-| **T3** | Sign vs. number | The square across a sign already holds a number    | Rule out everything on the wrong side of it        |
-| **T4** | Sign chain      | `k ≥ 2` squares rise (or fall) away in a run       | Cap the square at `N - k` (or floor it at `1 + k`) |
-| **T5** | Sign pair       | Neither side of a sign is settled                  | Cap each side by what the other can still hold     |
-| **T6** | Naked pair      | Two squares in a line hold the same two candidates | Rule that pair out of the rest of the line         |
+| #      | Technique       | Fires when                                          | Decides                                            |
+| ------ | --------------- | --------------------------------------------------- | -------------------------------------------------- |
+| **T0** | Naked single    | A square has one candidate left                     | Write it in                                        |
+| **T1** | Hidden single   | A number fits only one square of a row or column    | Write it in there                                  |
+| **T2** | Sign bound      | One sign points away from a square                  | Rule out `N` (or `1` the other way)                |
+| **T3** | Sign vs. number | The square across a sign already holds a number     | Rule out everything on the wrong side of it        |
+| **T4** | Sign chain      | `k ≥ 2` squares rise (or fall) away in a run        | Cap the square at `N - k` (or floor it at `1 + k`) |
+| **T5** | Sign pair       | Neither side of a sign is settled                   | Cap each side by what the other can still hold     |
+| **T6** | Naked pair      | Two squares in a line hold the same two candidates  | Rule that pair out of the rest of the line         |
+| **T7** | Hidden pair     | Two numbers fit only the same two squares of a line | Rule everything else out of those two squares      |
+| **T8** | X-wing          | A number fits only the same two lanes in two lines  | Rule it out of the rest of both lanes              |
 
 ### 4.1 The ordering is about explainability, not power
 
@@ -95,9 +97,21 @@ Placements rank above eliminations for the same reason they do in Sumplete:
 writing a number in moves the board on, while ruling one out is the bookkeeping
 that gets you there.
 
-### 4.2 Deliberately absent
+### 4.2 The top of the ladder is where wizard lives
 
-Hidden pairs, X-wings, and the rest of the Sudoku ladder. They are real
+T7 and T8 are the two rungs a 7×7 actually reaches for; below that size neither
+fires, because the board settles before it needs them. Measured over eight 7×7
+boards accepted at the T8 cap, five demanded an x-wing and two a hidden pair — so
+the top tier reaches its ceiling on its own, without generation being made to
+reject boards until it does.
+
+That is what separates wizard from master. At the T5 cap both tiers produced
+boards whose hardest step was the same, and wizard's higher ceiling was
+decorative.
+
+### 4.3 Deliberately absent
+
+Swordfish, XY-wing, colouring, and the rest of the Sudoku ladder. They are real
 techniques, but nothing in the tier table needs them yet — they get added when a
 board demands one, not before.
 
@@ -117,7 +131,7 @@ the redundancy §3.1 exists to remove.
 | junior  | 5×5  | T4 sign chain      | 8–12 of 40  |
 | expert  | 6×6  | T4 sign chain      | 11–20 of 60 |
 | master  | 6×6  | T5 sign pair       | 13–19 of 60 |
-| wizard  | 7×7  | T6 naked pair      | 18–30 of 84 |
+| wizard  | 7×7  | T8 x-wing          | ~23 of 84   |
 
 The cap is inclusive: a tier permits every technique up to it, so wizard boards
 may use the whole ladder.

--- a/docs/game-design/puzzles/futoshiki.md
+++ b/docs/game-design/puzzles/futoshiki.md
@@ -170,14 +170,22 @@ That is not decoration; three consequences follow:
   the player wrote down, so notes that rule out the number that belongs in a
   square send the deductions toward a dead end. That outranks the whole ladder,
   the same way a wrong number does (§7).
-- **Writing a number prunes the notes it invalidates**, across its row and
-  column. That is the bookkeeping a player does by hand on paper.
+- **A placement never destroys a note.** Writing a number used to sweep it out of
+  the pencilled options across its row and column — the bookkeeping a player does
+  on paper. But paper is not the right model here: the number written may itself
+  be wrong, and correcting it the ordinary way (writing a different one over the
+  top) left the swept notes gone for good, with undo the only route back and only
+  if you noticed in time. Notes a placement rules out are **struck through in
+  red** instead, and a correction simply re-marks them.
 
-**Undo takes back one move, whole.** Because a single placement can sweep notes
-out of a dozen squares, an undo that only restored the square that was tapped
-would be a trap. Each action snapshots the board it replaced, so one press puts
-everything back. Actions that change nothing — tapping a pre-filled square,
-erasing an empty one — record nothing, so undo never appears to do nothing.
+**Undo takes back one move, whole.** Each action snapshots the board it replaced,
+so one press puts everything back rather than the one square that was tapped.
+Actions that change nothing — tapping a pre-filled square, erasing an empty one —
+record nothing, so undo never appears to do nothing.
+
+Undo is no longer the only way back from a placement, which is the point of the
+rule above: it is there for taking a move back, not for repairing damage the move
+should never have done.
 
 ## 7. Hints
 

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -344,6 +344,14 @@
       "nakedPair": {
         "row": "These two squares can only hold {{first}} and {{second}}, in one order or the other, so no other square in this row can have either.",
         "col": "These two squares can only hold {{first}} and {{second}}, in one order or the other, so no other square in this column can have either."
+      },
+      "hiddenPair": {
+        "row": "In this row, {{first}} and {{second}} fit nowhere but these two squares, so nothing else can go in either of them.",
+        "col": "In this column, {{first}} and {{second}} fit nowhere but these two squares, so nothing else can go in either of them."
+      },
+      "xWing": {
+        "row": "{{value}} fits in only two squares of each of these two rows, and they stand in the same columns. Whichever way round it falls, both columns are spoken for — so {{value}} can go nowhere else in them.",
+        "col": "{{value}} fits in only two squares of each of these two columns, and they stand in the same rows. Whichever way round it falls, both rows are spoken for — so {{value}} can go nowhere else in them."
       }
     }
   }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -352,6 +352,14 @@
       "xWing": {
         "row": "{{value}} fits in only two squares of each of these two rows, and they stand in the same columns. Whichever way round it falls, both columns are spoken for — so {{value}} can go nowhere else in them.",
         "col": "{{value}} fits in only two squares of each of these two columns, and they stand in the same rows. Whichever way round it falls, both rows are spoken for — so {{value}} can go nowhere else in them."
+      },
+      "nakedTriple": {
+        "row": "These three squares hold only {{first}}, {{second}} and {{third}} between them, so no other square in this row can take any of the three.",
+        "col": "These three squares hold only {{first}}, {{second}} and {{third}} between them, so no other square in this column can take any of the three."
+      },
+      "hiddenTriple": {
+        "row": "In this row, {{first}}, {{second}} and {{third}} fit nowhere but these three squares, so nothing else can go in any of them.",
+        "col": "In this column, {{first}}, {{second}} and {{third}} fit nowhere but these three squares, so nothing else can go in any of them."
       }
     }
   }

--- a/public/locales/nl/common.json
+++ b/public/locales/nl/common.json
@@ -337,6 +337,14 @@
       "nakedPair": {
         "row": "Deze twee vakjes kunnen alleen {{first}} en {{second}} zijn, in de ene of de andere volgorde, dus geen ander vakje in deze rij kan er een van hebben.",
         "col": "Deze twee vakjes kunnen alleen {{first}} en {{second}} zijn, in de ene of de andere volgorde, dus geen ander vakje in deze kolom kan er een van hebben."
+      },
+      "hiddenPair": {
+        "row": "In deze rij passen {{first}} en {{second}} nergens anders dan in deze twee vakjes, dus er kan niets anders in.",
+        "col": "In deze kolom passen {{first}} en {{second}} nergens anders dan in deze twee vakjes, dus er kan niets anders in."
+      },
+      "xWing": {
+        "row": "{{value}} past in elk van deze twee rijen maar in twee vakjes, en die staan in dezelfde kolommen. Hoe het ook uitpakt, beide kolommen zijn bezet — dus {{value}} kan nergens anders in die kolommen.",
+        "col": "{{value}} past in elk van deze twee kolommen maar in twee vakjes, en die staan in dezelfde rijen. Hoe het ook uitpakt, beide rijen zijn bezet — dus {{value}} kan nergens anders in die rijen."
       }
     }
   }

--- a/public/locales/nl/common.json
+++ b/public/locales/nl/common.json
@@ -345,6 +345,14 @@
       "xWing": {
         "row": "{{value}} past in elk van deze twee rijen maar in twee vakjes, en die staan in dezelfde kolommen. Hoe het ook uitpakt, beide kolommen zijn bezet — dus {{value}} kan nergens anders in die kolommen.",
         "col": "{{value}} past in elk van deze twee kolommen maar in twee vakjes, en die staan in dezelfde rijen. Hoe het ook uitpakt, beide rijen zijn bezet — dus {{value}} kan nergens anders in die rijen."
+      },
+      "nakedTriple": {
+        "row": "Deze drie vakjes hebben samen alleen {{first}}, {{second}} en {{third}}, dus geen ander vakje in deze rij kan er een van hebben.",
+        "col": "Deze drie vakjes hebben samen alleen {{first}}, {{second}} en {{third}}, dus geen ander vakje in deze kolom kan er een van hebben."
+      },
+      "hiddenTriple": {
+        "row": "In deze rij passen {{first}}, {{second}} en {{third}} nergens anders dan in deze drie vakjes, dus er kan niets anders in.",
+        "col": "In deze kolom passen {{first}}, {{second}} en {{third}} nergens anders dan in deze drie vakjes, dus er kan niets anders in."
       }
     }
   }

--- a/src/mods/core/app/PuzzleFamilyShell.tsx
+++ b/src/mods/core/app/PuzzleFamilyShell.tsx
@@ -24,6 +24,8 @@ type Props = {
   hint?: string
   /** How long a still board waits before the hint button asks to be pressed (see hintIdleDelay). */
   idleMs?: number
+  /** Fired when the player asks for the hint — families use it to aim the board at what it names. */
+  onHintRevealed?: () => void
   /** The rules of this puzzle, shown under the board — scrolled to, never popped up. */
   rules?: ReactNode
   children: (api: PuzzleShellApi) => ReactNode
@@ -32,7 +34,17 @@ type Props = {
 // The chrome every puzzle family wears: back, reset, hint (with its cooldown and idle nudge), the
 // completed banner, and the rules below the board. Families supply the board and their own hint text;
 // none of them reimplement the controls (docs/instructions/puzzle-screens.md §3).
-export const PuzzleFamilyShell = ({ onSolved, onCancel, solved, onReset, hint, idleMs, rules, children }: Props) => {
+export const PuzzleFamilyShell = ({
+  onSolved,
+  onCancel,
+  solved,
+  onReset,
+  hint,
+  idleMs,
+  onHintRevealed,
+  rules,
+  children,
+}: Props) => {
   const { t } = useTranslation("common")
   const [solvedBanner, setSolvedBanner] = useState(false)
   const [scheduleSolve, cancelSolve] = useTimeout()
@@ -90,7 +102,10 @@ export const PuzzleFamilyShell = ({ onSolved, onCancel, solved, onReset, hint, i
           )}
           {hint && (
             <button
-              onClick={reveal}
+              onClick={() => {
+                reveal()
+                onHintRevealed?.()
+              }}
               disabled={cooling}
               className={clsx("relative overflow-hidden rounded px-2 py-1 text-sm", {
                 "bg-amber-700 text-amber-100 hover:bg-amber-600": !cooling && !nudging,

--- a/src/mods/puzzle/app/futoshiki/FutoshikiBoard.stories.tsx
+++ b/src/mods/puzzle/app/futoshiki/FutoshikiBoard.stories.tsx
@@ -9,7 +9,7 @@ import {
   setFutoshikiValue,
   toggleFutoshikiNote,
 } from "@/mods/puzzle/game/futoshiki/futoshikiState"
-import { futoshikiConflicts } from "@/mods/puzzle/game/futoshiki/futoshikiStatus"
+import { futoshikiConflicts, strandedNotes } from "@/mods/puzzle/game/futoshiki/futoshikiStatus"
 import { buildFutoshikiHint } from "./futoshikiHint"
 import { FutoshikiBoard } from "./FutoshikiBoard"
 
@@ -47,7 +47,11 @@ export const Starter: Story = { args: staticArgs(starter) }
 
 export const Wizard: Story = { args: staticArgs(wizard) }
 
-/** Pencilled options in some squares, a number written into another, and one square picked. */
+/**
+ * Pencilled options in some squares, a number written into another, and one square picked. The 2
+ * written into the middle column strikes the pencilled 2 above it through in red rather than rubbing
+ * it out — correcting that 2 would bring the note back.
+ */
 export const WithNotes: Story = {
   args: staticArgs(starter),
   render: () => {
@@ -56,12 +60,14 @@ export const WithNotes: Story = {
     state = toggleFutoshikiNote(state, 0, 0, 3)
     state = toggleFutoshikiNote(state, 1, 1, 2)
     state = toggleFutoshikiNote(state, 1, 1, 4)
-    state = setFutoshikiValue(state, 2, 2, 2)
+    state = setFutoshikiValue(state, 2, 1, 2)
+    const values = futoshikiValues(state)
     return (
       <FutoshikiBoard
         puzzle={starter}
         cells={state.cells}
-        conflicts={futoshikiConflicts(starter, futoshikiValues(state))}
+        conflicts={futoshikiConflicts(starter, values)}
+        stranded={strandedNotes(starter, values, futoshikiNotes(state))}
         selected={{ row: 1, col: 1 }}
         onSelect={() => {}}
       />

--- a/src/mods/puzzle/app/futoshiki/FutoshikiBoard.tsx
+++ b/src/mods/puzzle/app/futoshiki/FutoshikiBoard.tsx
@@ -1,7 +1,7 @@
 import clsx from "clsx"
 import type { FC } from "react"
 import type { FutoshikiCell } from "@/mods/puzzle/game/futoshiki/futoshikiState"
-import type { FutoshikiConflicts } from "@/mods/puzzle/game/futoshiki/futoshikiStatus"
+import { futoshikiNoteKey, type FutoshikiConflicts } from "@/mods/puzzle/game/futoshiki/futoshikiStatus"
 import {
   futoshikiCellKey,
   type FutoshikiCellRef,
@@ -12,6 +12,8 @@ type Props = {
   puzzle: FutoshikiPuzzleData
   cells: FutoshikiCell[][]
   conflicts: FutoshikiConflicts
+  /** Note keys ("row,col,value") a number placed elsewhere in the line has ruled out. */
+  stranded?: ReadonlySet<string>
   selected?: FutoshikiCellRef
   /** Cell keys ("row,col") the current hint talks about. */
   highlighted?: ReadonlySet<string>
@@ -42,7 +44,13 @@ const cellCls = (cell: FutoshikiCell, state: { lit: boolean; selected: boolean; 
     "ring-2 ring-red-500": state.conflicted && !state.selected && !state.lit,
   })
 
-const NoteGrid: FC<{ notes: number[]; size: number }> = ({ notes, size }) => (
+const NoteGrid: FC<{
+  notes: number[]
+  size: number
+  row: number
+  col: number
+  stranded?: ReadonlySet<string>
+}> = ({ notes, size, row, col, stranded }) => (
   <span
     className="grid size-full place-items-center p-[6%] text-[20cqw] leading-none"
     style={{ gridTemplateColumns: `repeat(${Math.ceil(Math.sqrt(size))}, minmax(0, 1fr))` }}
@@ -52,7 +60,12 @@ const NoteGrid: FC<{ notes: number[]; size: number }> = ({ notes, size }) => (
         that would otherwise announce an empty square as "1 2 3 4". */}
     {Array.from({ length: size }, (_, index) => index + 1).map(value =>
       notes.includes(value) ? (
-        <span key={value} className="text-sky-300">
+        <span
+          key={value}
+          // Struck rather than deleted: the note is still the player's, and the number that ruled it
+          // out may itself be wrong and get corrected.
+          className={stranded?.has(futoshikiNoteKey(row, col, value)) ? "text-red-400/80 line-through" : "text-sky-300"}
+        >
           {value}
         </span>
       ) : (
@@ -114,7 +127,16 @@ const SignLayer: FC<{ puzzle: FutoshikiPuzzleData; conflicts: FutoshikiConflicts
 
 // Sized off its container and the viewport height, never off a pixel constant: the board has to fit a
 // phone screen without pan or zoom (docs/instructions/puzzle-screens.md §1).
-export const FutoshikiBoard: FC<Props> = ({ puzzle, cells, conflicts, selected, highlighted, litSigns, onSelect }) => {
+export const FutoshikiBoard: FC<Props> = ({
+  puzzle,
+  cells,
+  conflicts,
+  stranded,
+  selected,
+  highlighted,
+  litSigns,
+  onSelect,
+}) => {
   const { size } = puzzle
   return (
     <div className="relative aspect-square w-full max-w-[min(56vh,26rem)] select-none">
@@ -140,7 +162,7 @@ export const FutoshikiBoard: FC<Props> = ({ puzzle, cells, conflicts, selected, 
                 })}
               >
                 {cell.value === undefined ? (
-                  <NoteGrid notes={cell.notes} size={size} />
+                  <NoteGrid notes={cell.notes} size={size} row={rowIndex} col={colIndex} stranded={stranded} />
                 ) : (
                   <span
                     className={clsx("text-[58cqw] font-semibold", {

--- a/src/mods/puzzle/app/futoshiki/FutoshikiBoard.tsx
+++ b/src/mods/puzzle/app/futoshiki/FutoshikiBoard.tsx
@@ -34,9 +34,12 @@ const cellCls = (cell: FutoshikiCell, state: { lit: boolean; selected: boolean; 
     "border-stone-600 bg-stone-800 text-stone-500": !cell.given && !state.conflicted,
     // A pre-filled number is part of the puzzle, not of the answer — it reads as stone, not as ink.
     "border-stone-500 bg-stone-700 text-amber-200": cell.given && !state.conflicted,
-    "border-red-600 bg-red-950/70 text-red-300": state.conflicted,
+    // A repeat has to be loud. A dark wash behind a white digit was the whole tell before, and on a
+    // dark board at arm's length it read as no tell at all.
+    "border-red-500 bg-red-900 text-red-200": state.conflicted,
     "ring-2 ring-sky-300": state.selected,
     "ring-2 ring-amber-300": state.lit && !state.selected,
+    "ring-2 ring-red-500": state.conflicted && !state.selected && !state.lit,
   })
 
 const NoteGrid: FC<{ notes: number[]; size: number }> = ({ notes, size }) => (
@@ -125,6 +128,7 @@ export const FutoshikiBoard: FC<Props> = ({ puzzle, cells, conflicts, selected, 
         {cells.map((row, rowIndex) =>
           row.map((cell, colIndex) => {
             const key = futoshikiCellKey(rowIndex, colIndex)
+            const conflicted = conflicts.cells.has(key)
             return (
               <button
                 key={key}
@@ -132,13 +136,20 @@ export const FutoshikiBoard: FC<Props> = ({ puzzle, cells, conflicts, selected, 
                 className={cellCls(cell, {
                   lit: highlighted?.has(key) ?? false,
                   selected: selected?.row === rowIndex && selected?.col === colIndex,
-                  conflicted: conflicts.cells.has(key),
+                  conflicted,
                 })}
               >
                 {cell.value === undefined ? (
                   <NoteGrid notes={cell.notes} size={size} />
                 ) : (
-                  <span className={clsx("text-[58cqw] font-semibold", !cell.given && "text-stone-100")}>
+                  <span
+                    className={clsx("text-[58cqw] font-semibold", {
+                      // The digit takes the conflict colour too: forcing ink-white here was what
+                      // swallowed the warning, since the square's own red never reached the number.
+                      "text-stone-100": !cell.given && !conflicted,
+                      "text-red-100": conflicted,
+                    })}
+                  >
                     {cell.value}
                   </span>
                 )}

--- a/src/mods/puzzle/app/futoshiki/FutoshikiPuzzle.tsx
+++ b/src/mods/puzzle/app/futoshiki/FutoshikiPuzzle.tsx
@@ -16,7 +16,7 @@ import {
   toggleFutoshikiNote,
   undoFutoshikiMove,
 } from "@/mods/puzzle/game/futoshiki/futoshikiState"
-import { futoshikiConflicts, isFutoshikiSolved } from "@/mods/puzzle/game/futoshiki/futoshikiStatus"
+import { futoshikiConflicts, isFutoshikiSolved, strandedNotes } from "@/mods/puzzle/game/futoshiki/futoshikiStatus"
 import { PuzzleFamilyShell } from "@/mods/core/app/PuzzleFamilyShell"
 import { hintIdleDelay } from "@/mods/core/app/useHintAvailability"
 import type { Difficulty } from "@/data/difficultyLevels"
@@ -44,6 +44,7 @@ export const FutoshikiPuzzle: FC<Props> = ({ puzzle, difficulty, onSolved, onCan
 
   const values = useMemo(() => futoshikiValues(state), [state])
   const conflicts = useMemo(() => futoshikiConflicts(puzzle, values), [puzzle, values])
+  const stranded = useMemo(() => strandedNotes(puzzle, values, futoshikiNotes(state)), [puzzle, values, state])
   const hint = useMemo(
     () => buildFutoshikiHint(puzzle, futoshikiValues(state), futoshikiNotes(state), solution, techniqueCap),
     [puzzle, state, solution, techniqueCap]
@@ -84,6 +85,7 @@ export const FutoshikiPuzzle: FC<Props> = ({ puzzle, difficulty, onSolved, onCan
             puzzle={puzzle}
             cells={state.cells}
             conflicts={conflicts}
+            stranded={stranded}
             selected={selected}
             highlighted={hintVisible ? hint?.cells : undefined}
             litSigns={hintVisible ? hint?.constraints : undefined}

--- a/src/mods/puzzle/app/futoshiki/FutoshikiPuzzle.tsx
+++ b/src/mods/puzzle/app/futoshiki/FutoshikiPuzzle.tsx
@@ -40,7 +40,7 @@ export const FutoshikiPuzzle: FC<Props> = ({ puzzle, difficulty, onSolved, onCan
   const { t } = useTranslation("common")
   const { size, solution, techniqueCap } = puzzle
   const [state, setState] = useState(() => createFutoshikiState(puzzle))
-  const { selected, pencil, selectCell, togglePencil, clearSelection } = useFutoshikiEntry()
+  const { selected, pencil, selectCell, focusCell, togglePencil, clearSelection } = useFutoshikiEntry()
 
   const values = useMemo(() => futoshikiValues(state), [state])
   const conflicts = useMemo(() => futoshikiConflicts(puzzle, values), [puzzle, values])
@@ -73,6 +73,9 @@ export const FutoshikiPuzzle: FC<Props> = ({ puzzle, difficulty, onSolved, onCan
       }}
       hint={hint && t(`futoshiki.hint.${hint.key}`, hint.params)}
       idleMs={hintIdleDelay(difficulty)}
+      // Reading a hint and then hunting for the square it means is the whole gap between advice and
+      // acting on it, so asking for one aims the board and the pad at that square.
+      onHintRevealed={() => hint && focusCell(hint.focus.row, hint.focus.col)}
       rules={<FutoshikiRules />}
     >
       {({ reportInput, hintVisible }) => (

--- a/src/mods/puzzle/app/futoshiki/futoshikiHint.spec.ts
+++ b/src/mods/puzzle/app/futoshiki/futoshikiHint.spec.ts
@@ -52,6 +52,18 @@ describe("buildFutoshikiHint", () => {
     expect(["signBound", "signVsValue", "nakedSingle", "hiddenSingle"]).toContain(hint!.key.split(".")[0])
   })
 
+  it("names the square its reason decides, so the board can put the cursor there", () => {
+    const hint = buildFutoshikiHint(puzzle, blankGrid(3), noNotes(3), solution, "xWing")
+    expect(hint?.focus).toEqual({ row: 0, col: 0 })
+    expect(hint!.cells.has("0,0")).toBe(true)
+  })
+
+  it("points a mistake at the square holding it", () => {
+    const values = blankGrid(3)
+    values[1][1] = 1
+    expect(buildFutoshikiHint(puzzle, values, noNotes(3), solution, "xWing")?.focus).toEqual({ row: 1, col: 1 })
+  })
+
   it("says nothing once the board is finished", () => {
     expect(buildFutoshikiHint(puzzle, solution, noNotes(3), solution, "nakedPair")).toBeUndefined()
   })

--- a/src/mods/puzzle/app/futoshiki/futoshikiHint.ts
+++ b/src/mods/puzzle/app/futoshiki/futoshikiHint.ts
@@ -5,6 +5,7 @@ import {
   nextFutoshikiStep,
   type FutoshikiNotes,
   type FutoshikiPuzzleData,
+  type FutoshikiCellRef,
   type FutoshikiStep,
   type FutoshikiValues,
   type TechniqueId,
@@ -17,6 +18,8 @@ export type FutoshikiHint = {
   cells: ReadonlySet<string>
   /** Signs the reason points at, so "the sign says this one is smaller" has something to point to. */
   constraints: ReadonlySet<number>
+  /** The square the reason is about — where the cursor goes, so the pad is already aimed at it. */
+  focus: FutoshikiCellRef
 }
 
 // Several techniques read as a different sentence each way round ("nothing bigger fits" vs "nothing
@@ -30,6 +33,7 @@ const asHint = (step: FutoshikiStep): FutoshikiHint => ({
   params: step.params,
   cells: new Set(step.cells.map(cell => futoshikiCellKey(cell.row, cell.col))),
   constraints: new Set(step.constraint === undefined ? [] : [step.constraint]),
+  focus: step.cells[0],
 })
 
 /**
@@ -54,6 +58,7 @@ export const buildFutoshikiHint = (
       params: {},
       cells: new Set([futoshikiCellKey(mistake.row, mistake.col)]),
       constraints: new Set<number>(),
+      focus: { row: mistake.row, col: mistake.col },
     }
 
   const step = nextFutoshikiStep(puzzle, createFutoshikiBoard(puzzle, values, notes), cap)

--- a/src/mods/puzzle/app/futoshiki/useFutoshikiEntry.spec.ts
+++ b/src/mods/puzzle/app/futoshiki/useFutoshikiEntry.spec.ts
@@ -28,6 +28,15 @@ describe("useFutoshikiEntry", () => {
     expect(result.current.selected).toEqual({ row: 0, col: 2 })
   })
 
+  it("aims at a square without toggling it off, so a hint can land on the picked one", () => {
+    const { result } = renderHook(() => useFutoshikiEntry())
+    act(() => result.current.selectCell(1, 2))
+    act(() => result.current.focusCell(1, 2))
+    expect(result.current.selected).toEqual({ row: 1, col: 2 })
+    act(() => result.current.focusCell(3, 0))
+    expect(result.current.selected).toEqual({ row: 3, col: 0 })
+  })
+
   it("switches between writing answers and pencilling notes", () => {
     const { result } = renderHook(() => useFutoshikiEntry())
     expect(result.current.pencil).toBe(false)

--- a/src/mods/puzzle/app/futoshiki/useFutoshikiEntry.ts
+++ b/src/mods/puzzle/app/futoshiki/useFutoshikiEntry.ts
@@ -16,9 +16,13 @@ export const useFutoshikiEntry = () => {
     []
   )
 
+  // Not selectCell: that toggles a second tap off, and a hint landing on the square already picked
+  // would then unpick it.
+  const focusCell = useCallback((row: number, col: number) => setSelected({ row, col }), [])
+
   const togglePencil = useCallback(() => setPencil(current => !current), [])
 
   const clearSelection = useCallback(() => setSelected(undefined), [])
 
-  return { selected, pencil, selectCell, togglePencil, clearSelection }
+  return { selected, pencil, selectCell, focusCell, togglePencil, clearSelection }
 }

--- a/src/mods/puzzle/game/futoshiki/futoshikiConfig.ts
+++ b/src/mods/puzzle/game/futoshiki/futoshikiConfig.ts
@@ -12,5 +12,5 @@ export const FUTOSHIKI_CONFIG: Record<Difficulty, { size: number } & FutoshikiOp
   junior: { size: 5, techniqueCap: "signChain" },
   expert: { size: 6, techniqueCap: "signChain" },
   master: { size: 6, techniqueCap: "signPair" },
-  wizard: { size: 7, techniqueCap: "nakedPair" },
+  wizard: { size: 7, techniqueCap: "xWing" },
 }

--- a/src/mods/puzzle/game/futoshiki/futoshikiConfig.ts
+++ b/src/mods/puzzle/game/futoshiki/futoshikiConfig.ts
@@ -1,16 +1,16 @@
 import type { Difficulty } from "@/data/difficultyLevels"
 import type { FutoshikiOptions } from "./generateFutoshiki"
 
-// Tier settings, from docs/game-design/puzzles/futoshiki.md §5. Two dials, and the cap is the honest
-// one: it is what a board may DEMAND of the player. The prune fraction decides how many signs survive,
-// which is the same dial seen from the board's side — a heavily signed grid reads itself out, a thin
-// one has to be reasoned into. 7 wide is the ceiling, matching Puzzle Express: with the signs laid
-// over the gutters rather than given tracks of their own, seven squares still measure a thumb across
-// inside a 360px modal, and an eighth would not.
+// Tier settings, from docs/game-design/puzzles/futoshiki.md §5. Two dials, and the cap is the one that
+// carries the difficulty: it is what a board may DEMAND of the player. How many signs a board ends up
+// showing follows from it rather than being set here — a weak ladder cannot spare many, a strong one
+// strips the board bare. 7 wide is the ceiling, matching Puzzle Express: with the signs laid over the
+// gutters rather than given tracks of their own, seven squares still measure a thumb across inside a
+// 360px modal, and an eighth would not.
 export const FUTOSHIKI_CONFIG: Record<Difficulty, { size: number } & FutoshikiOptions> = {
-  starter: { size: 4, techniqueCap: "signVsValue", pruneFraction: 0.35 },
-  junior: { size: 5, techniqueCap: "signChain", pruneFraction: 0.7 },
-  expert: { size: 6, techniqueCap: "signChain", pruneFraction: 0.8 },
-  master: { size: 6, techniqueCap: "signPair", pruneFraction: 1 },
-  wizard: { size: 7, techniqueCap: "nakedPair", pruneFraction: 1 },
+  starter: { size: 4, techniqueCap: "signVsValue" },
+  junior: { size: 5, techniqueCap: "signChain" },
+  expert: { size: 6, techniqueCap: "signChain" },
+  master: { size: 6, techniqueCap: "signPair" },
+  wizard: { size: 7, techniqueCap: "nakedPair" },
 }

--- a/src/mods/puzzle/game/futoshiki/futoshikiState.spec.ts
+++ b/src/mods/puzzle/game/futoshiki/futoshikiState.spec.ts
@@ -3,7 +3,6 @@ import {
   canUndoFutoshiki,
   clearFutoshikiCell,
   createFutoshikiState,
-  futoshikiNotes,
   futoshikiValues,
   setFutoshikiValue,
   toggleFutoshikiNote,
@@ -46,22 +45,27 @@ describe("setFutoshikiValue", () => {
     expect(canUndoFutoshiki(state)).toBe(false)
   })
 
-  it("takes the number off the notes of every square it can no longer go in", () => {
+  it("leaves every note where it is — a placement is not allowed to spend the player's work", () => {
     let state = createFutoshikiState(puzzle)
     state = toggleFutoshikiNote(state, 1, 2, 3)
     state = toggleFutoshikiNote(state, 2, 1, 3)
-    state = toggleFutoshikiNote(state, 2, 2, 3)
     state = setFutoshikiValue(state, 1, 1, 3)
-    expect(state.cells[1][2].notes).toEqual([])
-    expect(state.cells[2][1].notes).toEqual([])
-    // Not in the same row or column, so that note still stands.
-    expect(state.cells[2][2].notes).toEqual([3])
+    expect(state.cells[1][2].notes).toEqual([3])
+    expect(state.cells[2][1].notes).toEqual([3])
   })
 
-  it("clears the square's own notes, since it is no longer undecided", () => {
+  it("keeps the square's own notes, so taking the number back out uncovers them again", () => {
     let state = toggleFutoshikiNote(createFutoshikiState(puzzle), 1, 1, 1)
     state = setFutoshikiValue(state, 1, 1, 3)
-    expect(state.cells[1][1].notes).toEqual([])
+    expect(state.cells[1][1].notes).toEqual([1])
+    expect(setFutoshikiValue(state, 1, 1, 3).cells[1][1]).toEqual({ value: undefined, notes: [1], given: false })
+  })
+
+  it("survives a correction: writing a different number over a wrong one keeps the notes intact", () => {
+    let state = toggleFutoshikiNote(createFutoshikiState(puzzle), 1, 2, 3)
+    state = setFutoshikiValue(state, 1, 1, 3)
+    state = setFutoshikiValue(state, 1, 1, 2)
+    expect(state.cells[1][2].notes).toEqual([3])
   })
 })
 
@@ -102,14 +106,6 @@ describe("undoFutoshikiMove", () => {
     state = undoFutoshikiMove(state)
     expect(state.cells[1][1].value).toBeUndefined()
     expect(canUndoFutoshiki(state)).toBe(false)
-  })
-
-  it("puts back every note a written number swept away — one press, the whole move", () => {
-    let state = toggleFutoshikiNote(createFutoshikiState(puzzle), 1, 2, 3)
-    state = toggleFutoshikiNote(state, 2, 1, 3)
-    state = undoFutoshikiMove(setFutoshikiValue(state, 1, 1, 3))
-    expect(futoshikiNotes(state)[1][2]).toEqual([3])
-    expect(futoshikiNotes(state)[2][1]).toEqual([3])
   })
 
   it("walks back move by move, in the order they were made", () => {

--- a/src/mods/puzzle/game/futoshiki/futoshikiState.ts
+++ b/src/mods/puzzle/game/futoshiki/futoshikiState.ts
@@ -30,26 +30,20 @@ const recordMove = (state: FutoshikiState) => {
   if (state.past.length > UNDO_LIMIT) state.past.shift()
 }
 
-// Writing a number in takes it off the pencilled options everywhere it can no longer go. That is the
-// bookkeeping a player does by hand on paper, and undo puts all of it back in one press.
-const clearPeerNotes = (cells: FutoshikiCell[][], row: number, col: number, value: number) => {
-  for (let i = 0; i < cells.length; i++) {
-    for (const cell of [cells[row][i], cells[i][col]]) {
-      const at = cell.notes.indexOf(value)
-      if (at !== -1) cell.notes.splice(at, 1)
-    }
-  }
-}
-
-/** Writes a number into a cell; the same number again takes it back out. */
+/**
+ * Writes a number into a cell; the same number again takes it back out.
+ *
+ * Notes are left exactly as they were, here and everywhere else. Sweeping the pencilled options a
+ * placement rules out looked like the bookkeeping a player does on paper, but it threw away work that
+ * only undo could return: correcting a number the ordinary way — writing a different one over it —
+ * left the swept notes gone for good. The board marks stranded notes instead (futoshikiStatus), so a
+ * correction simply re-marks them.
+ */
 export const setFutoshikiValue = produce((state: FutoshikiState, row: number, col: number, value: number) => {
   const cell = state.cells[row][col]
   if (cell.given) return
   recordMove(state)
-  const next = cell.value === value ? undefined : value
-  cell.value = next
-  cell.notes = []
-  if (next !== undefined) clearPeerNotes(state.cells, row, col, next)
+  cell.value = cell.value === value ? undefined : value
 })
 
 /** Pencils a number in or rubs it out. A cell holding a number has nothing to weigh up. */

--- a/src/mods/puzzle/game/futoshiki/futoshikiStatus.spec.ts
+++ b/src/mods/puzzle/game/futoshiki/futoshikiStatus.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { futoshikiConflicts, isFutoshikiSolved } from "./futoshikiStatus"
+import { futoshikiConflicts, isFutoshikiSolved, strandedNotes } from "./futoshikiStatus"
 import type { FutoshikiPuzzleData, FutoshikiValues } from "./techniques"
 
 const puzzle: FutoshikiPuzzleData = {
@@ -76,5 +76,53 @@ describe("isFutoshikiSolved", () => {
     ]
     expect(futoshikiConflicts(puzzle, flipped).cells.size).toBe(0)
     expect(isFutoshikiSolved(puzzle, flipped)).toBe(false)
+  })
+})
+
+describe("strandedNotes", () => {
+  const notesOf = (entries: Record<string, number[]>) =>
+    Array.from({ length: 3 }, (_, row) => Array.from({ length: 3 }, (_, col) => entries[`${row},${col}`] ?? []))
+
+  it("marks a note the same number placed in its row has ruled out", () => {
+    const values: FutoshikiValues = [
+      [1, undefined, undefined],
+      [undefined, undefined, undefined],
+      [undefined, undefined, undefined],
+    ]
+    expect([...strandedNotes(puzzle, values, notesOf({ "0,2": [1, 2] }))]).toEqual(["0,2,1"])
+  })
+
+  it("marks a note the same number placed in its column has ruled out", () => {
+    const values: FutoshikiValues = [
+      [1, undefined, undefined],
+      [undefined, undefined, undefined],
+      [undefined, undefined, undefined],
+    ]
+    expect([...strandedNotes(puzzle, values, notesOf({ "2,0": [1] }))]).toEqual(["2,0,1"])
+  })
+
+  it("leaves a note alone when the number that ruled it out is taken back off the board", () => {
+    const notes = notesOf({ "0,2": [1] })
+    const placed: FutoshikiValues = [
+      [1, undefined, undefined],
+      [undefined, undefined, undefined],
+      [undefined, undefined, undefined],
+    ]
+    expect(strandedNotes(puzzle, placed, notes).size).toBe(1)
+    const corrected: FutoshikiValues = [
+      [2, undefined, undefined],
+      [undefined, undefined, undefined],
+      [undefined, undefined, undefined],
+    ]
+    expect(strandedNotes(puzzle, corrected, notes).size).toBe(0)
+  })
+
+  it("says nothing about notes under a square that already holds a number", () => {
+    const values: FutoshikiValues = [
+      [1, 2, undefined],
+      [undefined, undefined, undefined],
+      [undefined, undefined, undefined],
+    ]
+    expect(strandedNotes(puzzle, values, notesOf({ "0,1": [1] })).size).toBe(0)
   })
 })

--- a/src/mods/puzzle/game/futoshiki/futoshikiStatus.ts
+++ b/src/mods/puzzle/game/futoshiki/futoshikiStatus.ts
@@ -1,4 +1,10 @@
-import { constraintEnds, futoshikiCellKey, type FutoshikiPuzzleData, type FutoshikiValues } from "./techniques"
+import {
+  constraintEnds,
+  futoshikiCellKey,
+  type FutoshikiNotes,
+  type FutoshikiPuzzleData,
+  type FutoshikiValues,
+} from "./techniques"
 
 export type FutoshikiConflicts = {
   /** Cell keys showing a number that repeats in its row or column. */
@@ -39,4 +45,34 @@ export const isFutoshikiSolved = (puzzle: FutoshikiPuzzleData, values: Futoshiki
   if (!values.every(row => row.every(value => value !== undefined))) return false
   const conflicts = futoshikiConflicts(puzzle, values)
   return conflicts.cells.size === 0 && conflicts.constraints.size === 0
+}
+
+/** A pencilled number and the square holding it, as `"row,col,value"`. */
+export const futoshikiNoteKey = (row: number, col: number, value: number): string => `${row},${col},${value}`
+
+/**
+ * Pencilled numbers that a number written somewhere else in their row or column has since ruled out.
+ * The board dims and reddens these rather than deleting them: a note is the player's own record of
+ * their reasoning, and a placement — which may itself be wrong and get corrected — has no business
+ * erasing it.
+ */
+export const strandedNotes = (
+  puzzle: FutoshikiPuzzleData,
+  values: FutoshikiValues,
+  notes: FutoshikiNotes
+): ReadonlySet<string> => {
+  const stranded = new Set<string>()
+  for (let row = 0; row < puzzle.size; row++)
+    for (let col = 0; col < puzzle.size; col++) {
+      if (values[row][col] !== undefined) continue
+      const taken = new Set<number>()
+      for (let i = 0; i < puzzle.size; i++) {
+        const inRow = values[row][i]
+        const inCol = values[i][col]
+        if (inRow !== undefined) taken.add(inRow)
+        if (inCol !== undefined) taken.add(inCol)
+      }
+      for (const value of notes[row][col]) if (taken.has(value)) stranded.add(futoshikiNoteKey(row, col, value))
+    }
+  return stranded
 }

--- a/src/mods/puzzle/game/futoshiki/generateFutoshiki.spec.ts
+++ b/src/mods/puzzle/game/futoshiki/generateFutoshiki.spec.ts
@@ -39,6 +39,23 @@ describe("generateFutoshiki", () => {
         }
     })
 
+    it("shows no sign the player cannot spend — every one is load-bearing", () => {
+      for (const board of boards)
+        for (let index = 0; index < board.constraints.length; index++) {
+          const without = board.constraints.filter((_, other) => other !== index)
+          expect(
+            solveFutoshikiByTechniques({ size, givens: board.givens, constraints: without }, board.techniqueCap).settled
+          ).toBe(false)
+        }
+    })
+
+    it("keeps the signs rather than the pre-filled numbers — the signs are the puzzle", () => {
+      for (const board of boards)
+        expect(board.constraints.length).toBeGreaterThan(
+          board.givens.flat().filter(value => value !== undefined).length
+        )
+    })
+
     it("keeps something to work out: no board is more answer than puzzle", () => {
       for (const board of boards) {
         const filled = board.givens.flat().filter(value => value !== undefined).length

--- a/src/mods/puzzle/game/futoshiki/generateFutoshiki.ts
+++ b/src/mods/puzzle/game/futoshiki/generateFutoshiki.ts
@@ -17,8 +17,6 @@ export type FutoshikiPuzzle = FutoshikiPuzzleData & {
 export type FutoshikiOptions = {
   /** The strongest deduction a board may demand (design doc §5). */
   techniqueCap?: TechniqueId
-  /** Share of the signs generation tries to take away. Fewer signs left, harder board. */
-  pruneFraction?: number
 }
 
 // Generation is build-then-thin, per docs/game-design/puzzles/futoshiki.md §3: draw a Latin square,
@@ -27,6 +25,9 @@ export type FutoshikiOptions = {
 // the one that ships is too — and that also settles uniqueness, since each step along the way was
 // forced. No separate solution counter has to run.
 const MAX_ATTEMPTS = 40
+
+// Pruning reaches a fixpoint in two sweeps on every tier measured; the third is the guard, not the plan.
+const MAX_PRUNE_SWEEPS = 6
 
 const solutionSquare = (size: number, random: () => number): number[][] => {
   const grid = Array.from({ length: size }, () => new Array<number>(size).fill(0))
@@ -80,7 +81,7 @@ const cellsWhere = (
   givens.flatMap((cells, row) => cells.flatMap((value, col) => (wanted(value) ? [{ row, col }] : [])))
 
 export const generateFutoshiki = (size: number, seed: number, options: FutoshikiOptions = {}): FutoshikiPuzzle => {
-  const { techniqueCap = "nakedPair", pruneFraction = 1 } = options
+  const { techniqueCap = "nakedPair" } = options
   for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
     const random = mulberry32(seed * 7919 + attempt)
     const solution = solutionSquare(size, random)
@@ -102,19 +103,10 @@ export const generateFutoshiki = (size: number, seed: number, options: Futoshiki
     }
     if (!settled.settled) continue
 
-    const order = shuffle(
-      signs.map((_, index) => index),
-      random
-    ).slice(0, Math.round(signs.length * pruneFraction))
-    let constraints = signs
-    for (const index of order) {
-      const trial = constraints.filter(sign => sign !== signs[index])
-      if (trial.length === constraints.length) continue
-      if (solveFutoshikiByTechniques({ size, givens, constraints: trial }, techniqueCap).settled) constraints = trial
-    }
-
-    // Thinning the signs often makes an earlier concession redundant, so the pre-filled numbers get
-    // the same treatment — a board should show only what it still needs to be solvable.
+    // Pre-filled numbers go first, and that ordering is the whole point: signs and givens can each
+    // stand in for the other, so whichever is thinned first survives. The signs ARE this family — a
+    // 4x4 carrying one sign and three given numbers is a Latin square with a decoration, and teaches
+    // nothing about what a sign means.
     let kept = givens
     for (const cell of shuffle(
       cellsWhere(givens, value => value !== undefined),
@@ -122,7 +114,22 @@ export const generateFutoshiki = (size: number, seed: number, options: Futoshiki
     )) {
       const trial = kept.map(cells => [...cells])
       trial[cell.row][cell.col] = undefined
-      if (solveFutoshikiByTechniques({ size, givens: trial, constraints }, techniqueCap).settled) kept = trial
+      if (solveFutoshikiByTechniques({ size, givens: trial, constraints: signs }, techniqueCap).settled) kept = trial
+    }
+
+    // Then every sign the board turns out not to need, to a fixpoint: taking one away can make
+    // another removable, so a single pass leaves redundant signs standing. A sign the player cannot
+    // spend is worse than no sign — it hides which ones the deduction actually turns on.
+    let constraints = signs
+    for (let sweep = 0; sweep < MAX_PRUNE_SWEEPS; sweep++) {
+      const before = constraints.length
+      for (const sign of shuffle(constraints, random)) {
+        const trial = constraints.filter(other => other !== sign)
+        if (trial.length === constraints.length) continue
+        if (solveFutoshikiByTechniques({ size, givens: kept, constraints: trial }, techniqueCap).settled)
+          constraints = trial
+      }
+      if (constraints.length === before) break
     }
 
     return { size, givens: kept, constraints, solution, techniqueCap }

--- a/src/mods/puzzle/game/futoshiki/techniques.spec.ts
+++ b/src/mods/puzzle/game/futoshiki/techniques.spec.ts
@@ -209,6 +209,58 @@ describe("nextFutoshikiStep", () => {
     ])
   })
 
+  it("hands three squares to the three numbers they hold between them", () => {
+    // No two of the first three squares share a candidate pair, so no naked pair reaches this first,
+    // and the rest of the row is wide open so no hidden pair does either.
+    const all = [1, 2, 3, 4, 5, 6]
+    const board = boardOfCandidates([
+      [[1, 2], [2, 3], [1, 3], all, all, all],
+      [all, all, all, all, all, all],
+      [all, all, all, all, all, all],
+      [all, all, all, all, all, all],
+      [all, all, all, all, all, all],
+      [all, all, all, all, all, all],
+    ])
+    const step = nextFutoshikiStep(puzzleOf(6, []), board, "nakedTriple")
+    expect(step).toMatchObject({
+      technique: "nakedTriple",
+      variant: "row",
+      params: { first: 1, second: 2, third: 3 },
+    })
+    expect(step?.decisions).toEqual([
+      { kind: "eliminate", row: 0, col: 3, values: [1, 2, 3] },
+      { kind: "eliminate", row: 0, col: 4, values: [1, 2, 3] },
+      { kind: "eliminate", row: 0, col: 5, values: [1, 2, 3] },
+    ])
+  })
+
+  it("hands three squares to the three numbers that fit nowhere else in the line", () => {
+    // 1, 2 and 3 fit only the first three squares, so those squares are theirs — but every square
+    // still holds four candidates, so no triple or pair read from the squares' side fires first.
+    const rest = [4, 5, 6, 7]
+    const all = [1, 2, 3, 4, 5, 6, 7]
+    const board = boardOfCandidates([
+      [[1, 2, 3, 4], [1, 2, 3, 5], [1, 2, 3, 6], rest, rest, rest, rest],
+      [all, all, all, all, all, all, all],
+      [all, all, all, all, all, all, all],
+      [all, all, all, all, all, all, all],
+      [all, all, all, all, all, all, all],
+      [all, all, all, all, all, all, all],
+      [all, all, all, all, all, all, all],
+    ])
+    const step = nextFutoshikiStep(puzzleOf(7, []), board, "hiddenTriple")
+    expect(step).toMatchObject({
+      technique: "hiddenTriple",
+      variant: "row",
+      params: { first: 1, second: 2, third: 3 },
+    })
+    expect(step?.decisions).toEqual([
+      { kind: "eliminate", row: 0, col: 0, values: [4] },
+      { kind: "eliminate", row: 0, col: 1, values: [5] },
+      { kind: "eliminate", row: 0, col: 2, values: [6] },
+    ])
+  })
+
   it("respects the technique cap — a board says nothing a lower ladder cannot reach", () => {
     const puzzle = puzzleOf(4, [
       { row: 0, col: 0, direction: "right", relation: "<" },
@@ -288,18 +340,21 @@ describe("firstFutoshikiMistake", () => {
 })
 
 describe("every technique", () => {
-  // Generating forty real boards is seconds of honest work, so this one carries its own timeout
-  // rather than being thinned to fit the default: the strongest technique only surfaces on a wizard
-  // board, and six seeds a tier is the point where it reliably does.
+  // The top tier is swept deeper than the rest: the five hardest rungs only ever appear on a 7x7, and
+  // the rarest of them first turns up at seed 14, so a shallow sweep would report it dead. Generating
+  // this many real boards is seconds of honest work, so the test carries its own timeout rather than
+  // being thinned to fit the default — thinning it is exactly what would hide a dead technique.
+  const seedsFor = (difficulty: (typeof difficulties)[number]) => (difficulty === "wizard" ? 16 : 8)
+
   it("is reachable — each one fires on a real board", () => {
     const fired = new Set<string>()
     for (const difficulty of difficulties) {
       const { size, ...options } = FUTOSHIKI_CONFIG[difficulty]
-      for (let seed = 1; seed <= 8; seed++) {
+      for (let seed = 1; seed <= seedsFor(difficulty); seed++) {
         const board = generateFutoshiki(size, seed, options)
         for (const step of solveFutoshikiByTechniques(board, board.techniqueCap).steps) fired.add(step.technique)
       }
     }
     expect([...TECHNIQUES].filter(technique => !fired.has(technique))).toEqual([])
-  }, 30_000)
+  }, 60_000)
 })

--- a/src/mods/puzzle/game/futoshiki/techniques.spec.ts
+++ b/src/mods/puzzle/game/futoshiki/techniques.spec.ts
@@ -39,6 +39,16 @@ const spentBelow = (puzzle: FutoshikiPuzzleData, technique: TechniqueId): Futosh
 const stepFor = (puzzle: FutoshikiPuzzleData, technique: TechniqueId) =>
   nextFutoshikiStep(puzzle, spentBelow(puzzle, technique), technique)
 
+// The last two rungs only matter on a board too sparse for the cheaper ones to finish, which no small
+// grid of pre-filled numbers reproduces — every such grid falls to a single or a sign first. So these
+// two are handed the candidate state directly, and their place in the ladder is covered instead by
+// "respects the technique cap" and by the reachability sweep over real boards.
+const boardOfCandidates = (candidates: number[][][]): FutoshikiBoard => ({
+  size: candidates.length,
+  values: blankGrid(candidates.length),
+  candidates: candidates.map(row => row.map(values => new Set(values))),
+})
+
 describe("nextFutoshikiStep", () => {
   it("writes in the only number a square has left", () => {
     // Three of the four numbers already sit in this square's row and column.
@@ -134,6 +144,68 @@ describe("nextFutoshikiStep", () => {
     expect(step?.decisions).toEqual([
       { kind: "eliminate", row: 0, col: 2, values: [1, 2] },
       { kind: "eliminate", row: 0, col: 3, values: [1, 2] },
+    ])
+  })
+
+  it("hands a pair of squares to the two numbers that fit nowhere else in the line", () => {
+    // In row 0 only the first two squares can still take a 1 or a 2, so between them they own both —
+    // and nothing else may stay in either. Neither square is down to two candidates, so no naked pair
+    // reaches this first.
+    const all = [1, 2, 3, 4, 5]
+    const board = boardOfCandidates([
+      [
+        [1, 2, 3],
+        [1, 2, 4],
+        [3, 4, 5],
+        [3, 4, 5],
+        [3, 4, 5],
+      ],
+      [all, all, all, all, all],
+      [all, all, all, all, all],
+      [all, all, all, all, all],
+      [all, all, all, all, all],
+    ])
+    const step = nextFutoshikiStep(puzzleOf(5, []), board, "hiddenPair")
+    expect(step).toMatchObject({ technique: "hiddenPair", variant: "row", params: { first: 1, second: 2 } })
+    expect(step?.decisions).toEqual([
+      { kind: "eliminate", row: 0, col: 0, values: [3] },
+      { kind: "eliminate", row: 0, col: 1, values: [4] },
+    ])
+  })
+
+  it("spends a number pinned to the same two columns in two separate rows", () => {
+    // 1 fits only columns 0 and 1 in row 0, and only columns 0 and 1 in row 1. Whichever way round it
+    // falls, both columns are spoken for — so 1 leaves those columns in every other row.
+    const all = [1, 2, 3, 4]
+    const board = boardOfCandidates([
+      [
+        [1, 2, 3],
+        [1, 2, 3],
+        [2, 3, 4],
+        [2, 3, 4],
+      ],
+      [
+        [1, 3, 4],
+        [1, 3, 4],
+        [2, 3, 4],
+        [2, 3, 4],
+      ],
+      [all, all, all, all],
+      [all, all, all, all],
+    ])
+    const step = nextFutoshikiStep(puzzleOf(4, []), board, "xWing")
+    expect(step).toMatchObject({ technique: "xWing", variant: "row", params: { value: 1 } })
+    expect(step?.cells).toEqual([
+      { row: 0, col: 0 },
+      { row: 0, col: 1 },
+      { row: 1, col: 0 },
+      { row: 1, col: 1 },
+    ])
+    expect(step?.decisions).toEqual([
+      { kind: "eliminate", row: 2, col: 0, values: [1] },
+      { kind: "eliminate", row: 3, col: 0, values: [1] },
+      { kind: "eliminate", row: 2, col: 1, values: [1] },
+      { kind: "eliminate", row: 3, col: 1, values: [1] },
     ])
   })
 

--- a/src/mods/puzzle/game/futoshiki/techniques.ts
+++ b/src/mods/puzzle/game/futoshiki/techniques.ts
@@ -12,6 +12,8 @@ export const TECHNIQUES = [
   "signPair",
   "nakedPair",
   "hiddenPair",
+  "nakedTriple",
+  "hiddenTriple",
   "xWing",
 ] as const
 
@@ -51,7 +53,7 @@ export type FutoshikiStep = {
   cells: FutoshikiCellRef[]
   /** Index into the puzzle's constraints, for the reasons that point at a sign. */
   constraint?: number
-  params: { value?: number; chain?: number; bound?: number; first?: number; second?: number }
+  params: { value?: number; chain?: number; bound?: number; first?: number; second?: number; third?: number }
   decisions: FutoshikiDecision[]
 }
 
@@ -437,6 +439,75 @@ const IMPLEMENTATIONS: Record<TechniqueId, Technique> = {
             },
           ]
         })
+      )
+    }),
+
+  // Three squares holding only three numbers between them, however those three fall inside the trio.
+  nakedTriple: (_puzzle, board) =>
+    linesOf(board.size).flatMap(line => {
+      const open = line.cells.filter(cell => {
+        const held = board.candidates[cell.row][cell.col].size
+        return held >= 2 && held <= 3
+      })
+      return open.flatMap((first, i) =>
+        open.slice(i + 1).flatMap((second, j) =>
+          open.slice(i + j + 2).flatMap(third => {
+            const trio = [first, second, third]
+            const union = new Set(trio.flatMap(cell => [...board.candidates[cell.row][cell.col]]))
+            if (union.size !== 3) return []
+            const values = [...union].sort((a, b) => a - b)
+            const decisions = line.cells
+              .filter(cell => !trio.some(held => sameCell(cell, held)))
+              .flatMap(cell => eliminate(board, cell, values))
+            if (!decisions.length) return []
+            return [
+              {
+                technique: "nakedTriple" as const,
+                variant: line.kind,
+                cells: trio,
+                params: { first: values[0], second: values[1], third: values[2] },
+                decisions,
+              },
+            ]
+          })
+        )
+      )
+    }),
+
+  // Three numbers with nowhere else in the line to go, so between them they own three squares.
+  hiddenTriple: (_puzzle, board) =>
+    linesOf(board.size).flatMap(line => {
+      const placed = new Set(line.cells.map(cell => board.values[cell.row][cell.col]))
+      const open = range(board.size).filter(value => !placed.has(value))
+      const hostsOf = (value: number) => line.cells.filter(cell => board.candidates[cell.row][cell.col].has(value))
+      return open.flatMap((first, i) =>
+        open.slice(i + 1).flatMap((second, j) =>
+          open.slice(i + j + 2).flatMap(third => {
+            const values = [first, second, third]
+            const hosts = values.map(hostsOf)
+            if (hosts.some(found => found.length < 2 || found.length > 3)) return []
+            const union = new Map(hosts.flat().map(cell => [futoshikiCellKey(cell.row, cell.col), cell] as const))
+            if (union.size !== 3) return []
+            const cells = [...union.values()]
+            const decisions = cells.flatMap(cell =>
+              eliminate(
+                board,
+                cell,
+                range(board.size).filter(value => !values.includes(value))
+              )
+            )
+            if (!decisions.length) return []
+            return [
+              {
+                technique: "hiddenTriple" as const,
+                variant: line.kind,
+                cells,
+                params: { first, second, third },
+                decisions,
+              },
+            ]
+          })
+        )
       )
     }),
 

--- a/src/mods/puzzle/game/futoshiki/techniques.ts
+++ b/src/mods/puzzle/game/futoshiki/techniques.ts
@@ -11,6 +11,8 @@ export const TECHNIQUES = [
   "signChain",
   "signPair",
   "nakedPair",
+  "hiddenPair",
+  "xWing",
 ] as const
 
 export type TechniqueId = (typeof TECHNIQUES)[number]
@@ -404,6 +406,82 @@ const IMPLEMENTATIONS: Record<TechniqueId, Technique> = {
       return steps
     }),
 
+  // Two numbers with nowhere else in the line to go own the pair of squares that can host them —
+  // the mirror of a naked pair, read from the numbers' side instead of the squares'.
+  hiddenPair: (_puzzle, board) =>
+    linesOf(board.size).flatMap(line => {
+      const placed = new Set(line.cells.map(cell => board.values[cell.row][cell.col]))
+      const open = range(board.size).filter(value => !placed.has(value))
+      const hostsOf = (value: number) => line.cells.filter(cell => board.candidates[cell.row][cell.col].has(value))
+      return open.flatMap((first, i) =>
+        open.slice(i + 1).flatMap(second => {
+          const hosts = hostsOf(first)
+          const others = hostsOf(second)
+          if (hosts.length !== 2 || others.length !== 2) return []
+          if (!hosts.every(cell => others.some(other => sameCell(cell, other)))) return []
+          const decisions = hosts.flatMap(cell =>
+            eliminate(
+              board,
+              cell,
+              range(board.size).filter(value => value !== first && value !== second)
+            )
+          )
+          if (!decisions.length) return []
+          return [
+            {
+              technique: "hiddenPair" as const,
+              variant: line.kind,
+              cells: hosts,
+              params: { first, second },
+              decisions,
+            },
+          ]
+        })
+      )
+    }),
+
+  // A number pinned to the same two lanes in two separate lines: whichever way round it falls, both
+  // lanes are spent, so it leaves the rest of them. The one reason here that spans four squares.
+  xWing: (_puzzle, board) => {
+    const { size } = board
+    const steps: FutoshikiStep[] = []
+    for (const orientation of ["row", "col"] as const) {
+      const at = (line: number, lane: number): FutoshikiCellRef =>
+        orientation === "row" ? { row: line, col: lane } : { row: lane, col: line }
+      const laneOf = (cell: FutoshikiCellRef) => (orientation === "row" ? cell.col : cell.row)
+      for (const value of range(size)) {
+        const hosts = Array.from({ length: size }, (_, line) =>
+          Array.from({ length: size }, (_, lane) => at(line, lane)).filter(cell =>
+            board.candidates[cell.row][cell.col].has(value)
+          )
+        )
+        for (let first = 0; first < size; first++) {
+          if (hosts[first].length !== 2) continue
+          for (let second = first + 1; second < size; second++) {
+            if (hosts[second].length !== 2) continue
+            const lanes = hosts[first].map(laneOf)
+            const others = hosts[second].map(laneOf)
+            if (lanes[0] !== others[0] || lanes[1] !== others[1]) continue
+            const decisions = lanes.flatMap(lane =>
+              Array.from({ length: size }, (_, line) => line)
+                .filter(line => line !== first && line !== second)
+                .flatMap(line => eliminate(board, at(line, lane), [value]))
+            )
+            if (!decisions.length) continue
+            steps.push({
+              technique: "xWing",
+              variant: orientation,
+              cells: [...hosts[first], ...hosts[second]],
+              params: { value },
+              decisions,
+            })
+          }
+        }
+      }
+    }
+    return steps
+  },
+
   // Two cells in a line down to the same two numbers own that pair between them, whichever way round.
   nakedPair: (_puzzle, board) =>
     linesOf(board.size).flatMap(line => {
@@ -478,9 +556,17 @@ export const applyFutoshikiTechniques = (
   const allowed = TECHNIQUES.slice(0, techniqueRank(cap) + 1)
   const steps: FutoshikiStep[] = []
   for (let pass = 0; pass < MAX_PASSES; pass++) {
-    const harvest = allowed
-      .map(technique => IMPLEMENTATIONS[technique](puzzle, board, chains))
-      .find(found => found.length)
+    // Short-circuit deliberately: only the cheapest technique that fires is spent, and the dear ones
+    // at the end of the ladder are the whole reason. Mapping the ladder and then taking the first
+    // non-empty result ran every technique on every pass, x-wing included.
+    let harvest: FutoshikiStep[] | undefined
+    for (const technique of allowed) {
+      const found = IMPLEMENTATIONS[technique](puzzle, board, chains)
+      if (found.length) {
+        harvest = found
+        break
+      }
+    }
     if (!harvest) break
     for (const step of harvest) {
       const live = step.decisions.filter(decision => stillChanges(board, decision))


### PR DESCRIPTION
Clean branch from `main`. **Supersedes #198** — its two commits replay here unchanged as the first two of five, so this is one PR rather than two that fight over `techniques.ts`.

## Carried from #198

<details>
<summary><b>1. Signs that did nothing</b> — starter showed 16 signs of which 13–16 were individually removable</summary>

The `pruneFraction` knob only *attempted* to remove a share of signs (0.35 at starter), and pruning ran a single pass when removing one sign can make another removable. Knob deleted, pruning sweeps to a fixpoint. Pruning givens now runs *before* signs, since whichever is thinned first survives and the signs are the family.

Starter: **16 → 3–6 signs**. Zero removable on any tier, asserted per tier.
</details>

<details>
<summary><b>2. Wizard permitted the whole ladder and demanded none of it</b></summary>

Caps are inclusive, so wizard already allowed everything — it just never needed it, bottoming out at the same step as master. Rather than gate generation (~1050ms/board), the ladder grew hidden pair and x-wing. Also fixed an eager `.map` that ran every technique on every pass; short-circuiting took wizard generation from 1340ms to 225ms.
</details>

## 3. If we can explain it, we use it

Two more rungs — **naked triple** and **hidden triple** — admitted on the bar that their reason is one checkable sentence, not on "a board is stuck without it".

Both earn their keep. Over thirty 7×7 boards: x-wing 14 firings, naked pair 24, hidden pair 22, **naked triple 4, hidden triple 2**.

That rarity nearly cost a live technique. At 8 seeds per tier hidden triple never fired, and the tidy conclusion was "subsumed, drop it". It first appears at **wizard seed 14**. The reachability sweep now runs deeper on the top tier, because a shallow sweep reports a live technique dead and invites deleting it.

The design doc states the rule both ways now: explainable goes in, never-fires comes out, with the sweep as the thing that tells them apart. Swordfish, XY-wing and colouring are recorded as candidates under the same bar rather than as "not needed yet".

## 4. The cursor follows the hint

Asking for a hint moves the selection to the square it names, so the number pad is already aimed there. Reading the advice then hunting for the square it means was the whole gap between a hint and acting on one.

`PuzzleFamilyShell` gained an optional `onHintRevealed`; other families untouched. `focusCell` is deliberately not `selectCell` — the latter toggles a second tap off, so a hint landing on the already-picked square would have unpicked it.

## 5. A repeat you can actually see

Already "implemented" and invisible: conflicting squares did get a red background and red text, but one line later the digit was forced `text-stone-100`, so **the square's colour never reached the number**. On a dark board all that survived was a dark wash behind a white digit.

Fixed: the digit takes the warning colour, the fill is a real red, and the selection/hint/conflict rings no longer race for the same square (they shared specificity, so the winner was down to CSS source order).

## 6. Notes that survive a correction

Writing a number swept it out of the pencilled options across its row and column. That looked like paper bookkeeping, but paper is the wrong model here: **the number written may itself be wrong**, and correcting it the ordinary way — writing a different one over the top — left the swept notes gone for good. Undo was the only route back, and only if you caught it before the next move.

Notes now stay exactly where they are, in the square and its peers. A note a placed number rules out is **struck through in red** instead, so a correction re-marks it with nothing to restore. The square's own notes survive too, so taking a number back out uncovers them rather than finding the square wiped.

Verified end to end: pencil 2 and 5, write a 2 in the same row → the 2 alone goes red and struck; correct that 2 to a 3 → the note returns on its own.

Undo is unchanged, but it is no longer the only way back from a placement — which is the point. It is for taking a move back, not for repairing damage the move should not have done.

## Tests

`yarn test` — 155 files, **1602 tests**, all pass. `check-types`, `lint` (0 errors), `build` clean.

New here: `strandedNotes` specs (row, column, restored on correction, silent under a filled square), rewritten state specs asserting notes survive both a placement and a correction, naked/hidden triple technique specs, hint-focus specs, and the per-tier sign invariants carried from #198.

The pair/triple/x-wing specs are handed a candidate state directly — no small grid of givens reproduces the position they matter in, because the cheaper rungs finish it first; their ladder position is covered by the cap spec and the reachability sweep.

## Recorded, not built: offline seeds

Design doc §11 carries the direction for generation cost — run generation offline, verify, and ship known-good seeds per family and tier with the build, so play time is a lookup plus a deterministic replay. Generation is already seeded and deterministic, which is the precondition. It also unlocks gates too slow to run in front of a player, like requiring every wizard board to demand its cap. Prior art credited to Block Sort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193QA7bSzsPcZrTNaJv1SwF