### PR TITLE
Mirror / lightbeam: a beam puzzle that can actually be reasoned out

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,13 +160,13 @@ Run all tests: `yarn test`
 
 Before considering any task complete, run through this checklist:
 
-| #   | Check            | Requirement                                                                                                                                                                                           |
-| --- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 1   | **Tests**        | Every new behavior has a co-located spec. Run `yarn test` — all pass. See [`docs/instructions/testing.md`](docs/instructions/testing.md).                                                             |
-| 2   | **Types**        | `yarn check-types` exits clean.                                                                                                                                                                       |
-| 3   | **Lint**         | `yarn lint` exits clean (includes Tailwind class order).                                                                                                                                              |
-| 4   | **Translations** | Any new user-facing string has both `en/` and `nl/` entries.                                                                                                                                          |
-| 5   | **Changelog**    | Any player-visible change has an entry in `CHANGELOG.md [Unreleased]` — a one-line bullet, one fact, ~20 words, no rationale. See [`docs/instructions/changelog.md`](docs/instructions/changelog.md). |
+| #   | Check            | Requirement                                                                                                                                                                                                                                                     |
+| --- | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | **Tests**        | Every new behavior has a co-located spec. Run `yarn test` — all pass. See [`docs/instructions/testing.md`](docs/instructions/testing.md).                                                                                                                       |
+| 2   | **Types**        | `yarn check-types` exits clean.                                                                                                                                                                                                                                 |
+| 3   | **Lint**         | `yarn lint` exits clean (includes Tailwind class order).                                                                                                                                                                                                        |
+| 4   | **Translations** | Any new user-facing string has both `en/` and `nl/` entries.                                                                                                                                                                                                    |
+| 5   | **Changelog**    | Any player-visible change has an entry in `CHANGELOG.md [Unreleased]` — a one-line bullet, one fact, ~20 words, no rationale. **A whole feature is one entry, not an inventory of it.** See [`docs/instructions/changelog.md`](docs/instructions/changelog.md). |
 
 Steps 1–3 are always required. Steps 4–5 apply only when the change touches user-facing strings or player-visible behavior.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- A light puzzle: bend the sunlight from the disc to the shrine, past stone that swallows it and edges that lose it.
+- Tap a mirror to turn it, or a sliding piece to move it — every square a piece can reach taps the same piece, and tapping round again puts it back.
+- The beam is drawn wherever it currently goes and marked where it ends, so every change shows its own consequence.
+- A sliding piece shows a faint ghost of itself on the spots it can move to, so you can see whether a mirror or a block of stone would arrive.
+- Hints explain the next step in words — the light dies in that stone, the shrine can only be lit from one side, or this piece can be left alone entirely.
+- Light puzzles turn up in pyramids and tombs from the first tier, growing from 5×5 up to 7×7.
+
 ## 0.35.1 - 2026-08-17
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- A light puzzle: bend the sunlight from the disc to the shrine, past stone that swallows it and edges that lose it.
-- Tap a mirror to turn it, or a sliding piece to move it — every square a piece can reach taps the same piece, and tapping round again puts it back.
-- The beam is drawn wherever it currently goes and marked where it ends, so every change shows its own consequence.
-- A sliding piece shows a faint ghost of itself on the spots it can move to, so you can see whether a mirror or a block of stone would arrive.
-- Hints explain the next step in words — the light dies in that stone, the shrine can only be lit from one side, or this piece can be left alone entirely.
-- Light puzzles turn up in pyramids and tombs from the first tier, growing from 7×7 up to 9×9.
-- Pieces you can tap are never placed side by side, so a bigger board never means a fiddlier one — each piece keeps a thumb's worth of room even where the squares are small.
-- Every light puzzle is built around one or two goals drawn for it — a long winding beam, a board full of pieces that turn out not to matter, stone to shift out of the way, or wrong turns that vanish into the dark instead of visibly dying. Two boards on the same tier now feel like different puzzles rather than the same one reshuffled.
+- A light puzzle: bend the sunlight from the disc to the shrine.
 
 ## 0.35.1 - 2026-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The beam is drawn wherever it currently goes and marked where it ends, so every change shows its own consequence.
 - A sliding piece shows a faint ghost of itself on the spots it can move to, so you can see whether a mirror or a block of stone would arrive.
 - Hints explain the next step in words — the light dies in that stone, the shrine can only be lit from one side, or this piece can be left alone entirely.
-- Light puzzles turn up in pyramids and tombs from the first tier, growing from 5×5 up to 7×7.
+- Light puzzles turn up in pyramids and tombs from the first tier, growing from 7×7 up to 9×9.
+- Pieces you can tap are never placed side by side, so a bigger board never means a fiddlier one — each piece keeps a thumb's worth of room even where the squares are small.
 - Every light puzzle is built around one or two goals drawn for it — a long winding beam, a board full of pieces that turn out not to matter, stone to shift out of the way, or wrong turns that vanish into the dark instead of visibly dying. Two boards on the same tier now feel like different puzzles rather than the same one reshuffled.
 
 ## 0.35.1 - 2026-08-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A sliding piece shows a faint ghost of itself on the spots it can move to, so you can see whether a mirror or a block of stone would arrive.
 - Hints explain the next step in words — the light dies in that stone, the shrine can only be lit from one side, or this piece can be left alone entirely.
 - Light puzzles turn up in pyramids and tombs from the first tier, growing from 5×5 up to 7×7.
+- Every light puzzle is built around one or two goals drawn for it — a long winding beam, a board full of pieces that turn out not to matter, stone to shift out of the way, or wrong turns that vanish into the dark instead of visibly dying. Two boards on the same tier now feel like different puzzles rather than the same one reshuffled.
 
 ## 0.35.1 - 2026-08-17
 

--- a/docs/game-design/PUZZLE_FAMILIES.md
+++ b/docs/game-design/PUZZLE_FAMILIES.md
@@ -334,7 +334,8 @@ Family doc: `docs/game-design/puzzles/lightbeam.md`.
 - **Knobs:** technique cap · **shadow count** (decoys placed in the path a wrong
   setting would take — this is what makes the cap bite; without it every tier solves
   by "the light visibly dies there") · route turn count · decoy count ·
-  set-vs-movable mirror ratio · grid size (5×5 → 7×7).
+  set-vs-movable mirror ratio. **Not** grid size, which is capacity rather than difficulty —
+  it decides whether the route and the pieces fit, not how hard they are.
 - **Scaling:** good, and cheap. 3 → 8.4 movable pieces and 8 → 371 configurations
   across the tiers. Two thirds of master and wizard boards demand the exhaustive
   rung; starter demands nothing beyond a visible dead end.
@@ -346,6 +347,11 @@ Family doc: `docs/game-design/puzzles/lightbeam.md`.
   The whole configuration space is enumerated on every gate: at nine pieces that is
   a few hundred walks over at most 49 cells, so this is the one family in the
   catalogue that can afford exact enumeration rather than a sampling verifier.
+- **Grid:** 7×7 → 9×9, past the ceiling §5's shared grid engine implies. That ceiling exists
+  because every cell of a Sudoku or Sumplete grid is tappable, so cell size is tap-target
+  size. Here only the movable pieces are tappable and generation never lets two of them
+  touch, so a piece owns the empty squares around it: at 9 wide a cell is 36px and its tap
+  target 46px, with no two targets meeting.
 - **UI:** medium. One gesture, tap-to-cycle, and **no pad, no eraser and no undo** —
   a cycle is its own inverse, so there is nothing to take back. The board draws the
   beam wherever it currently goes and marks where it ends, which is the family's

--- a/docs/game-design/PUZZLE_FAMILIES.md
+++ b/docs/game-design/PUZZLE_FAMILIES.md
@@ -317,34 +317,45 @@ puzzle nodes at every tier alongside cross-sum's tableau and Sumplete.
 - **UI:** easy.
 - **Role:** spine-ish (outputs a value) but low ceiling — a flavour family.
 
-### 4.15 Mirror / lightbeam — _(new, spec locked, not yet built)_
+### 4.15 Mirror / lightbeam — _(have)_
 
-- **Skill:** spatial reasoning, route-tracing, elimination of irrelevant pieces.
-- **Operates:** a beam enters from a fixed edge cell in a fixed direction and must
-  reach a target edge cell. Two movable tile types sit on the grid:
-  - **Rotate tile** — fixed position, tap-cycles between two diagonal
-    orientations (`/` ↔ `\`), deflecting the beam 90° off either approach face
-    (geometric default — no single-sided-vs-double-sided variant).
-  - **Slide tile** — fixed mirror angle, tap-cycles between 2–3 discrete stops
-    along an authored track (one fixed row or column per tile).
-    A third tile type, **wall**, is a pure blocker — the beam is absorbed/dead on
-    contact, no decoration-only variant for this family.
-- **Knobs:** grid size · wall count · free-vs-fixed mirror ratio (fixed mirrors
-  are pre-set "givens," like Sudoku clues) · count of off-path decoy tiles the
-  player must reason are irrelevant.
-- **Scaling:** should be good — position × orientation combinatorics grow fast
-  with tile count, similar shape to the grid-logic families.
-- **Generation:** build the solved beam path backward first (route source →
-  target, drop a rotate/slide tile at each turn with the orientation/position
-  the turn requires), scatter decoys and walls off that path, then **run a
-  uniqueness verifier** — brute-force every position×orientation combination
-  across movable tiles and confirm exactly one reaches the target before
-  accepting the puzzle. Required, not optional: with only 2–3 states per tile
-  a misplaced decoy can accidentally open a second valid route.
-- **UI:** medium — same tap-to-cycle gesture language as Sumplete/rotate, just
-  applied to orientation or track position instead of a 3-state keep/delete
-  toggle. No drag needed (slide is discrete stops, not free-drag).
-- **Role:** side (no value output in v1).
+Family doc: `docs/game-design/puzzles/lightbeam.md`.
+
+- **Skill:** spatial reasoning, route-tracing, and **elimination of irrelevant
+  pieces** — the last of which no other family trains, and which is the one
+  conclusion in the catalogue that reads "this piece does not matter".
+- **Operates:** light leaves a sun-disc on one edge in a fixed direction and must
+  reach a shrine set in the frame. A mirror bends it a quarter turn, stone swallows
+  it, the board edge loses it. Seven piece types, all shipped in v1: sun-disc,
+  shrine, set mirror and wall (fixed) · turn mirror, sliding mirror and sliding wall
+  (the player's). The sliding wall is the only piece whose move is _clearing_ a path
+  rather than bending one — every other piece answers "which way does the light
+  turn", and it answers "does the light get through at all".
+- **Knobs:** technique cap · **shadow count** (decoys placed in the path a wrong
+  setting would take — this is what makes the cap bite; without it every tier solves
+  by "the light visibly dies there") · route turn count · decoy count ·
+  set-vs-movable mirror ratio · grid size (5×5 → 7×7).
+- **Scaling:** good, and cheap. 3 → 8.4 movable pieces and 8 → 371 configurations
+  across the tiers. Two thirds of master and wizard boards demand the exhaustive
+  rung; starter demands nothing beyond a visible dead end.
+- **Generation:** route the beam first, then wall off the ways each movable piece
+  could be set wrong, then gate on **path uniqueness** — every configuration that
+  lights the shrine must trace the _same route_. "Exactly one winning configuration"
+  would be the wrong test, because a decoy has a free setting by definition. Then
+  gate on the ladder reaching it, and thin the walls to a fixpoint under the cap.
+  The whole configuration space is enumerated on every gate: at nine pieces that is
+  a few hundred walks over at most 49 cells, so this is the one family in the
+  catalogue that can afford exact enumeration rather than a sampling verifier.
+- **UI:** medium. One gesture, tap-to-cycle, and **no pad, no eraser and no undo** —
+  a cycle is its own inverse, so there is nothing to take back. The board draws the
+  beam wherever it currently goes and marks where it ends, which is the family's
+  live feedback and the reason it needs no words.
+- **Role:** **side** (the answer is a route, not a value).
+- **Found while building it:** a beam from the disc can never enter a loop. A 90°
+  mirror maps `(cell, direction)` one-to-one, so every beam state has exactly one
+  predecessor and the disc's first has none — a ring of mirrors loops only if the
+  light starts inside it. Loop detection stays in the trace as the guard that keeps
+  the walk total, and becomes load-bearing the day a prism lands.
 - **Deferred:** prism/color-split tiles (splitting one beam into multiple
   colored beams, each needing its own target) — a genuinely different puzzle
   shape (multi-beam, color-matching), not a v1 knob. **The Talos Principle**
@@ -705,12 +716,13 @@ so it can be used when authoring density knobs).
 | Glyph Latin-square     | 1–6 min, **high variance**        | **High**                                                                                                                       |
 | Kakuro                 | 2–8 min                           | **High**                                                                                                                       |
 | Nonogram               | 3–15+ min, **very high variance** | **Very High**                                                                                                                  |
-| Mirror/lightbeam       | not yet measured (unbuilt)        | **TBD — estimate Low–Med**, pending real solve-time data once built                                                            |
+| Mirror/lightbeam       | built, not yet measured           | **TBD — estimate Low–Med**, the beam redraws on every tap so a wrong route is visible at once, which should stall less         |
 | Sokoban                | not yet measured (unbuilt)        | **TBD — estimate High**, Sokoban solve time is notoriously unbounded even at small grid sizes                                  |
 | Rush Hour              | not yet measured (unbuilt)        | **TBD — estimate Med**, classic Rush Hour puzzles are usually a few minutes at most                                            |
 
-Once mirror/lightbeam, Sokoban, Rush Hour, and hidato are built, replace the TBD
-rows with real telemetry (§8) rather than trusting the estimate.
+Once Sokoban, Rush Hour and hidato are built, and lightbeam has been played enough
+to measure, replace the TBD rows with real telemetry (§8) rather than trusting the
+estimate.
 
 ---
 

--- a/docs/game-design/puzzles/lightbeam.md
+++ b/docs/game-design/puzzles/lightbeam.md
@@ -300,81 +300,84 @@ carry-forward (`PUZZLE_FAMILIES.md` P3).
   here too, and this family wants it less: enumeration is cheap, so generation is
   fast without it.
 
-### 11.1 Waypoints — the next thing to build
+### 11.1 Switch nodes — the next thing to build
 
-A cell the beam **must** pass through. Transparent: it neither blocks nor turns.
+A **node** is a fixed, transparent cell wired to one movable piece. Light crossing it
+lights the wire, and the piece it drives moves. The wire is drawn.
 
-Its value is not the extra win condition, it is what it does to the solver. The
-forced-run deductions currently grow from exactly two places — forward from the disc
-(T0) and backward from the shrine (T1) — and they are weakest where they meet, in the
-middle of a long route, which is precisely where wizard is thinnest. **A waypoint is a
-second shrine for the purposes of those deductions:** run the same four-approach
-feasibility test on it, and when the frame and the walls kill three of them, a run
-through the middle of the board is forced. That reuses `walkBackward` untouched, and
-its reason is a sentence you can check by eye — _"the light has to get through here,
-and this is the only line it can come along."_
+This started as two separate ideas — a waypoint the beam must cross, and a switch that
+moves things — and they are better as one. **A node is a point you must touch before you
+can solve, and it earns that "must" from the geometry rather than from a rule:** the door
+it opens is standing in the route's way, so the light has to reach the node first. Nothing
+declares the requirement. That is what makes it worth building.
 
-Uniqueness gets easier, not harder: requiring waypoint coverage shrinks the winning
-set, so gate 5 has less to rule out.
+#### Why the unified form beats a waypoint
 
-Two constraints it imposes:
+A plain waypoint needs its own win condition — shrine lit _and_ every waypoint covered.
+That drags in three things this family has so far done without: counting, per-waypoint
+visible state, and the failure mode where **the beam is at the shrine but you are not
+done**. A node needs none of them. The rule stays "light the shrine", and no rules text
+is added at all, which is the P2 discipline (`PUZZLE_FAMILIES.md`) rather than a
+concession to it.
 
-- **The shrine must not light until every waypoint is covered.** Otherwise the board
-  lies, and "the beam is at the shrine but you are not done" is a new failure mode this
-  family has so far avoided entirely.
-- **Waypoints need the same thinning pass as walls** (§5 step 7). One sitting on a
-  stretch T0 already forces teaches nothing — that is the unspendable-wall problem
-  again.
+It is also self-policing where a waypoint was not. A waypoint sitting on a stretch T0
+already forces teaches nothing, so waypoints would have needed their own thinning pass
+(§5 step 7). A node whose door is not actually blocking the route is simply a **decoy**,
+and the gates already classify it as one — no new machinery.
 
-It composes well with the shadow pieces: a shadow branch that _picks up_ a waypoint is
-a much nastier decoy, because the wrong setting now looks productive.
+#### The rung it buys: a forced-order fact
 
-### 11.2 Switch nodes and wiring — a variant, not a knob
+Every fact in the ladder today is either "these cells carry the beam" or "that setting is
+impossible". A node adds a third kind: _"the light has to get through here, this door is
+shut, so it must reach that node first."_ **Order**, which nothing in the catalogue
+trains.
 
-A waypoint with a consequence: light crossing the node lights a **drawn wire** to a
-piece, which then turns or moves.
+It is monotone — a door once open stays open — so it slots into the existing fixpoint loop
+exactly as the `forced` segment set does. And it seeds deduction **from the middle of the
+board**, which is the real prize: T0 grows forward from the disc and T1 backward from the
+shrine, and they are weakest where they meet, in the middle of a long route, which is
+precisely where wizard is thinnest.
 
-**The wiring is what makes this admissible at all.** Every reason in the ladder today
-is local — "face it that way and the light dies in that stone" is checkable because the
-stone is _there_. A switch that can move the stone breaks that, and the reason collapses
-into "I tried the alternatives and they failed", the rung ranked last for teaching
-nothing. A visible wire puts locality back: you can see what each node drives and trace
-it with a finger, so the reason survives with one hop of indirection.
+#### The paradox stops being a restriction
 
-**Decoys then exist at three levels**, and the third is new to the catalogue:
+A switch that moves a wall _behind_ the beam is the trap: the beam that reached the switch
+no longer reaches it. Under the unified form that case does not arise — the node is early
+on the route and the door is late, by construction — so the door always opens **ahead** of
+the light and the drawn beam is never a picture of something that has since stopped being
+true.
+
+That leaves the semantics simple: walk forward, apply a node's effect the moment the light
+crosses it, keep walking. One pass, deterministic, still a pure function of the
+configuration, so the exact enumeration every gate depends on survives untouched.
+
+#### Decoys at three levels
+
+The wiring is what keeps this admissible. Every reason in the ladder is local — "face it
+that way and the light dies in that stone" is checkable because the stone is _there_ — and
+a switch that can move the stone would break that, collapsing the reason into "I tried the
+alternatives and they failed", the rung ranked last for teaching nothing. A drawn wire
+puts locality back: you can see what each node drives and follow it with a finger, so the
+reason survives with one hop of indirection.
+
+Then "this does not matter" gets three depths, the third new to the catalogue:
 
 1. A node the light can never cross, so its wire never fires — today's T4, one level up.
 2. A node that fires into a piece the light never touches anyway: real wire, irrelevant
    consequence.
 3. A node that fires, moves a piece that **is** on the route, and still changes nothing.
 
-**The paradox does not go away.** A switch that moves a wall _behind_ the beam means the
-beam that reached the switch no longer reaches it. Wiring makes that legible but not
-consistent. The options are a fixpoint (zero or several solutions, both fatal for a
-puzzle with one answer), iterate-until-stable (oscillation renders as a blinking board),
-or latching by history (order-dependent, no longer a pure function of the
-configuration). The one that keeps everything is to **restrict the effect to opening a
-way ahead of the light, never behind it**: the door opens in front of the beam and you
-watch it happen, wrong configurations die at the still-closed wall, and the new reason
-is an **ordering** one — _"the light gets here before it has opened this"_ — which
-nothing else in the catalogue trains. Generation builds it by construction: route the
-beam, put the wall late on the route, put the switch early.
+#### What to check before believing it
 
-Implementation notes, for whoever picks this up:
+- **Yield, not logic.** Opening a door creates routes that were not there before, so
+  path-uniqueness (gate 5) has more to reject. Measure first.
+- **The loop-detection seen-set must be keyed by node-state, or cleared on each firing.**
+  Otherwise a legitimate re-traverse of a cell reads as a loop. Termination is safe either
+  way: nodes only ever fire once, so the trace is at most (nodes + 1) bounded walks.
+- **The drawing is the likeliest thing to kill this, not the reasoning.** The board already
+  carries cells, a two-pass beam, piece glyphs, movable rings, dashed tracks with ghost
+  pieces, and end markers — at 45px a cell on a 7×7. A wire layer crossing all of that is
+  where it turns to soup. Prototype the board visually _before_ writing any logic, which is
+  the reverse of the order the rest of this family was built in.
 
-- Latching with in-flight mutation terminates: switches only ever flip on, so the trace
-  is at most (switches + 1) bounded walks.
-- **The loop-detection seen-set must be keyed by switch-state, or cleared on each flip.**
-  Otherwise a legitimate re-traverse of a cell reads as a loop.
-- Yield is the open question, not the logic. Opening a wall creates routes that were not
-  there before, so path-uniqueness has more to reject. Measure before believing it.
-
-**The thing most likely to kill this is the drawing, not the reasoning.** The board
-already carries cells, a two-pass beam, piece glyphs, movable rings, dashed tracks with
-ghost pieces, and end markers — at 45px a cell on a 7×7. A wire layer crossing all of
-that is where it turns to soup. Prototype the board visually _before_ writing any of the
-logic, which is the reverse of the order the rest of this family was built in.
-
-Filed as a **variant rather than a knob**: same pieces, same gesture, same trace, but
-multi-level indirection is a different shape of puzzle — nearer the timed variant above
-than a dial. Build 11.1 first, and only after the base family has actually been played.
+A node is fixed scenery with no state and nothing to tap, so the control scheme stays at
+exactly one gesture. Build it only after the base family has actually been played.

--- a/docs/game-design/puzzles/lightbeam.md
+++ b/docs/game-design/puzzles/lightbeam.md
@@ -380,4 +380,66 @@ Then "this does not matter" gets three depths, the third new to the catalogue:
   the reverse of the order the rest of this family was built in.
 
 A node is fixed scenery with no state and nothing to tap, so the control scheme stays at
-exactly one gesture. Build it only after the base family has actually been played.
+exactly one gesture.
+
+#### A node can also be the thing to avoid
+
+The effect does not have to help. A node wired to **close** a way — dropping stone in front
+of the shrine — turns the mechanic inside out at no cost: the semantics are unchanged
+(effects land ahead of the light either way, so the drawn beam stays honest, and the light
+simply stops at the new stone), but the reasoning is new. The ladder has no form of
+_avoidance_ today, and this one is local with one hop of indirection: _"that setting sends
+the light through the node, which drops stone in front of the shrine, so it cannot be that
+setting."_
+
+It composes nastily with the shadow pieces (§6.1): a wrong branch that trips a harmful node
+is a trap twice over.
+
+That is the real argument for the node — not one extra trick but a **machine you have to
+understand before you can drive it**. Which nodes to light, and which to steer clear of.
+
+### 11.2 Puzzle goals — pick two dials and turn them hard
+
+Every tier currently turns every dial a little. Read the wizard row of `LIGHTBEAM_CONFIG`:
+five turns, one set mirror, two sliding mirrors, one sliding wall, one decoy, three shadows.
+Every wizard board is the **average** wizard board.
+
+A **goal pool** fixes that: generation draws one or two goals per board and turns those
+dials hard, leaving the rest slack. Boards then have character instead of mean settings —
+and with 158 lightbeam nodes in the world, that is likely a bigger variety win than any new
+piece type. It also adds the axis the family is missing: difficulty (cap, size) is one
+thing, **what kind of problem this board is** is another, and they are currently welded
+together.
+
+The pool, and what each is built from:
+
+| Goal                    | Built from                    | Tests                      | Needs   |
+| ----------------------- | ----------------------------- | -------------------------- | ------- |
+| **Long chain**          | turns high, decoys 0          | route-tracing              | nothing |
+| **Sort the wheat**      | decoys high, turns low        | which pieces matter (T4)   | nothing |
+| **Clear the way**       | sliding walls on the route    | does the light get through | nothing |
+| **Blind alleys**        | shadows high                  | the exhaustive rung (T5)   | nothing |
+| **Order of operations** | a node whose door blocks late | ordering                   | §11.1   |
+| **Steer clear**         | a harmful node on a wrong ray | avoidance                  | §11.1   |
+
+**Four of the six need no new mechanic** — they are a re-scheduling of knobs that already
+exist. That version is cheap, and it is worth building **before** the family is playtested
+rather than after: judging the current build means judging one recipe five times, whereas
+with goals you would be judging the spread, which is the thing actually worth knowing.
+
+Two things it has to get right:
+
+- **A fallback ladder.** If the chosen pair will not generate inside the attempt budget,
+  drop to one goal, then to none — and `log` which, because a silent fallback that always
+  fires makes the whole pool decorative. This is the same discipline as "no silent caps".
+- **The gates stay untouched.** A goal shapes what gets _placed_; it never shapes what gets
+  _accepted_. Path uniqueness and the ladder still decide, so no goal can smuggle through a
+  board that needs a guess.
+
+It softens the tier table in §6: piece and configuration counts become per-goal ranges
+rather than the flat means measured there, and `generateLightbeam.spec.ts`'s monotonicity
+assertion would have to hold in aggregate over a tier rather than board by board.
+
+Worth noting for later: nothing about this is specific to lightbeam — Futoshiki could draw
+technique-flavour goals the same way. Build it here first and only generalise if a second
+family actually wants it; a shared abstraction on one caller would be the premature kind.

--- a/docs/game-design/puzzles/lightbeam.md
+++ b/docs/game-design/puzzles/lightbeam.md
@@ -170,13 +170,13 @@ deep inside a wizard pyramid**, so a starter board is not only ever seen by a
 beginner. Starter must therefore be _gentle_, not _empty_ — a board with a real
 route to find, just a short one with few pieces and a low technique cap.
 
-| Tier    | Grid | Baseline route             | Movable pieces | Configurations | Cap | Goals drawn                 |
-| ------- | ---- | -------------------------- | -------------- | -------------- | --- | --------------------------- |
-| starter | 5×5  | 2 bends                    | 3.0            | 8              | T2  | 1 of: long chain, clear way |
-| junior  | 5×5  | 3 bends                    | 3.9            | 15             | T3  | 1 of those + blind alleys   |
-| expert  | 6×6  | 3 bends                    | 5.4            | 45             | T4  | 2 of all four               |
-| master  | 6×6  | 3 bends, 1 shadow          | 6.3            | 82             | T5  | 2 of all four               |
-| wizard  | 7×7  | 5 bends, 1 decoy, 1 shadow | 8.0            | 315            | T5  | 2 of all four               |
+| Tier    | Grid | Cell | Baseline route             | Movable pieces | Configurations | Cap | Goals drawn                 |
+| ------- | ---- | ---- | -------------------------- | -------------- | -------------- | --- | --------------------------- |
+| starter | 7×7  | 46px | 2 bends                    | 3.0            | 8              | T2  | 1 of: long chain, clear way |
+| junior  | 7×7  | 46px | 3 bends                    | 3.9            | 15             | T3  | 1 of those + blind alleys   |
+| expert  | 8×8  | 40px | 3 bends                    | 5.3            | 42             | T4  | 2 of all four               |
+| master  | 8×8  | 40px | 3 bends, 1 shadow          | 5.9            | 70             | T5  | 2 of all four               |
+| wizard  | 9×9  | 36px | 5 bends, 1 decoy, 1 shadow | 7.9            | 288            | T5  | 2 of all four               |
 
 Piece and configuration counts are measured means over 40 seeds a tier, not
 intentions, and they are the totals _after_ a board's goals are applied (§7). The
@@ -218,14 +218,24 @@ Knobs, in order of how much they actually move difficulty:
 - **Turn count on the route** — how many mirrors the beam must bounce off.
 - **Decoy count** — pieces the player must reason are irrelevant.
 - **Set-vs-movable mirror ratio** — set mirrors are scaffolding, like givens.
-- **Grid size** — footprint, and how long each run is.
 
-7×7 is the ceiling for the same reason the other grid families cap there: inside
-the encounter modal a 360px screen leaves the board about 320px, and 44px tap
-targets do not survive an eighth column. There are no gutters to reclaim here, so
-a cell is simply `board / N`. Measured in the encounter modal at 360×640: the board
-comes out 318px, so a wizard cell is **45px** — over the bar, and an eighth column
-would be 40px.
+### 6.2 Grid size is capacity, not difficulty
+
+**Grid size is not on that list, and an earlier version of this doc was wrong to put it
+there.** It barely moves how hard a board is: the configuration space is driven by piece
+count, and the reasoning by the cap. What size actually decides is whether the board has
+_room_ — for the route's length, for the pieces, and for the empty shoulders that keep two
+tappable pieces off each other (§9). It is a canvas, and it is sized by what has to fit.
+
+That is measurable rather than arguable. Adding the spacing rule at the old 5×5 and 6×6
+sizes made **every starter board fall back to no goal at all**, because there was nowhere
+to put anything; the same rule at 7×7 and up costs nothing. Size did not change the
+difficulty — it changed whether a board could be built.
+
+It also means this family goes past the 7-wide ceiling the other grid families stop at.
+Theirs is a real ceiling: every cell there is tappable, so cell size _is_ tap-target size.
+Here only the pieces are tappable, so the ceiling is legibility instead, and 36px still
+reads a mirror's diagonal clearly.
 
 ## 7. Puzzle goals — pick two dials and turn them hard
 
@@ -347,6 +357,12 @@ Beyond the shared screen bar:
   stops short does not read as a rendering fault.
 - Movable pieces read as movable at a glance, and a sliding piece's track is
   visible.
+- **No two tappable pieces ever touch**, and a piece's hit area reaches into the empty
+  squares around it. Measured in the encounter modal at 360×640: the board is 318px, so a
+  9-wide cell is 36px and its tap target 46px — over the 44px bar with no two targets
+  meeting, because the nearest other piece is two squares away. This is what buys the wider
+  grid, and it is a generation gate (`piecesAreSpaced`) rather than a rendering trick: before
+  it existed essentially every board had touching pieces, up to ten pairs on one wizard grid.
 - Both mirror orientations read as visibly different objects, not a subtle
   rotation, at 44px.
 

--- a/docs/game-design/puzzles/lightbeam.md
+++ b/docs/game-design/puzzles/lightbeam.md
@@ -1,0 +1,224 @@
+# Mirror / Lightbeam
+
+Family doc. The catalogue entry lives in `docs/game-design/PUZZLE_FAMILIES.md`
+§4.15; the screen bar every family must clear lives in
+`docs/instructions/puzzle-screens.md`. This doc holds what is specific to
+lightbeam: its pieces, how the beam is traced, its deduction ladder, its
+generation gates, and how difficulty is dialled.
+
+Family id: `lightbeam`.
+
+## 1. Rules
+
+Light enters the grid from a fixed sun-disc on one edge, travelling in a fixed
+direction. It runs straight until something stops or turns it. Get it to the
+shrine.
+
+- A **mirror** turns the beam 90°, off either face. `/` and `\` are its two
+  orientations.
+- A **wall** absorbs the beam. Light stops dead.
+- Some pieces the player can change; some are part of the puzzle and cannot.
+
+That is the whole rule, and the board states it without a word: the beam is drawn
+wherever it currently goes, so every change shows its own consequence.
+
+## 2. The pieces
+
+All of them ship in the first version. Playtesting a beam puzzle with only half
+its vocabulary would tell us about a different puzzle.
+
+| Piece            | Fixed or movable | States    | What it does                                    |
+| ---------------- | ---------------- | --------- | ----------------------------------------------- |
+| **Sun-disc**     | fixed            | —         | Emits the beam, one cell on an edge, one facing |
+| **Shrine**       | fixed            | —         | The target. Lights when the beam arrives        |
+| **Set mirror**   | fixed            | —         | A given, like a Sudoku clue                      |
+| **Wall**         | fixed            | —         | Absorbs the beam                                 |
+| **Turn mirror**  | movable          | 2         | Tap cycles `/` ↔ `\`, position fixed             |
+| **Sliding mirror** | movable        | 2–3       | Fixed angle, tap cycles between authored stops   |
+| **Sliding wall**  | movable         | 2–3       | Tap cycles between stops — moved out of the way, or into it |
+
+The sliding wall is the one piece whose move is **clearing a path** rather than
+bending one. That is worth having precisely because it is a different verb: every
+other piece answers "which way does the light turn", and this one answers "does
+the light get through at all".
+
+## 3. Board model and beam tracing
+
+State is a flat array: one integer per movable piece, its chosen state. Nothing
+else. That makes reset trivial, comparison cheap, and the whole configuration
+space enumerable (§5).
+
+Tracing walks from the sun-disc, cell by cell:
+
+- off the grid → the beam **escapes**
+- a wall, or the sun-disc itself → the beam is **absorbed**
+- a mirror → the beam **turns**; `/` maps right↔up and left↔down, `\` maps
+  right↔down and left↔up
+- the shrine → **lit**, and the puzzle is solved
+- a `(cell, direction)` pair seen before → the beam **loops** forever
+
+**Loops turn out to be unreachable, and that was worth finding out.** A 90° mirror maps
+`(cell, direction)` one-to-one, so every beam state has exactly one predecessor, and the
+disc's first state has none. The beam from the disc therefore walks a path and can never
+join a ring: a ring of four mirrors does carry light round forever, but only if the light
+starts inside it. So the board never has to draw a looping beam, and the player never has
+to be told what one means.
+
+Loop detection stays in the trace anyway, as the thing that keeps the walk total — and it
+becomes load-bearing the moment a piece bends light by anything other than a quarter turn,
+which is exactly what the deferred prism (§11) does. `beam.spec.ts` proves both halves: the
+ring loops when the light starts inside it, and the disc's beam never loops.
+
+## 4. The deduction ladder
+
+This is the part that decides whether the family belongs in this game at all. A
+beam puzzle's natural solving mode is trial: flip a mirror, look, flip another.
+That is not deduction, and `puzzle-screens.md` §5 requires a generated board to be
+reachable by deduction alone, with hints drawn from the techniques rather than
+from the answer.
+
+There is a real ladder here, and generation is gated on it:
+
+| #      | Technique          | Fires when                                                             | Decides                        |
+| ------ | ------------------ | ---------------------------------------------------------------------- | ------------------------------ |
+| **T0** | Forced entry run   | The run from the sun-disc crosses only cells nothing movable can change | Those cells carry the beam     |
+| **T1** | Forced exit run    | Same, traced backwards from the shrine                                 | Those cells carry the beam     |
+| **T2** | Dead end           | One state of a piece sends the beam to a wall or edge with no unsettled piece left on the way | That state is impossible       |
+| **T3** | Only one feeds it  | Exactly one piece-state can send the beam along the forced exit run     | That state is forced           |
+| **T4** | Never reached      | No configuration puts the beam on this piece at all                    | Its state is free — a decoy    |
+| **T5** | Only one survives  | Every arrangement of the remaining pieces fails, save with this one in this state | That state is forced   |
+
+T0/T1 are facts; T2–T5 are eliminations; propagation between them is the fixpoint
+loop, as in the other families.
+
+### 4.1 Why T5 is ranked last
+
+T5 subsumes T2 and T3 — a solver could be T0/T1/T5 alone. It is ranked last for
+the same reason Sumplete ranks its candidate-intersection last: its reason is "I
+tried the alternatives and they all fail", which teaches nothing. T2's reason is a
+sentence a child repeats back and can check by eye: _"face it that way and the
+light dies in the wall, with no mirror left to save it."_
+
+### 4.2 T4 is the point, not a footnote
+
+The catalogue names "elimination of irrelevant pieces" as this family's skill. T4
+_is_ that skill, and it is the only technique in any family whose conclusion is
+"this piece does not matter". It makes decoys a first-class part of the puzzle
+rather than clutter, and it gives the hint engine something genuinely useful to
+say: _"the light never reaches this one, whatever you do."_
+
+## 5. Generation
+
+The configuration space is the product of the movable pieces' state counts —
+`2^rotate · stops^sliding`. At nine pieces that is under 20 000 traces, each a walk
+over at most 49 cells. **This family can afford exact enumeration**, which Sumplete
+and Futoshiki cannot, and the gates below spend that freely.
+
+1. Route a beam from sun-disc to shrine, dropping a mirror at each turn.
+2. Fix some of those mirrors as givens, make the rest movable, and set the movable
+   ones to a **wrong** starting state so the board opens unsolved.
+3. Scatter walls, decoy mirrors and sliding pieces off the path.
+4. **Gate — the path is unique.** Enumerate every configuration; every one that
+   lights the shrine must trace the *same path*. Decoys may be free (that is what
+   makes them decoys), but the route may not be ambiguous.
+5. **Gate — deduction reaches it.** The ladder, capped per tier, must settle every
+   piece on the path. A board that stalls needs a guess and is discarded.
+6. **Gate — the board opens unsolved**, and no single tap solves it at tiers above
+   starter.
+
+Gate 4 is the honest form of uniqueness for this family. "Exactly one winning
+configuration" would be the wrong test: a decoy has a free state, so a board with
+decoys has many winning configurations and only one winning *route*.
+
+## 6. Difficulty
+
+Every tier gets a full configuration — this family is not gated to a debut tier.
+Where it appears is authored per node (`encounter: "lightbeam"`), and the tag
+allocator may also draw it anywhere from starter up.
+
+That matters more than it looks: **a starter corridor can sit behind a ward gate
+deep inside a wizard pyramid**, so a starter board is not only ever seen by a
+beginner. Starter must therefore be *gentle*, not *empty* — a board with a real
+route to find, just a short one with few pieces and a low technique cap.
+
+| Tier    | Grid | Movable pieces | Cap | Vocabulary                     |
+| ------- | ---- | -------------- | --- | ------------------------------ |
+| starter | 5×5  | 2–3            | T2  | Turn mirrors, walls            |
+| junior  | 5×5  | 3–4            | T3  | + sliding mirrors              |
+| expert  | 6×6  | 4–6            | T4  | + sliding walls, first decoys  |
+| master  | 6×6  | 6–7            | T5  | Decoy density up               |
+| wizard  | 7×7  | 7–9            | T5  | Longer chains, more decoys     |
+
+Knobs, in order of how much they actually move difficulty:
+
+- **Technique cap** — what a board may _demand_. The honest dial, as everywhere.
+- **Turn count on the route** — how many mirrors the beam must bounce off.
+- **Decoy count** — pieces the player must reason are irrelevant.
+- **Set-vs-movable mirror ratio** — set mirrors are scaffolding, like givens.
+- **Grid size** — footprint, and how long each run is.
+
+7×7 is the ceiling for the same reason the other grid families cap there: inside
+the encounter modal a 360px screen leaves the board about 320px, and 44px tap
+targets do not survive an eighth column. There are no gutters to reclaim here, so
+a cell is simply `board / N`.
+
+## 7. Controls
+
+One gesture: **tap a piece to cycle it**. Turn mirrors cycle orientation, sliding
+pieces cycle to their next stop. Fixed pieces ignore taps. No drag, matching the
+rest of the game.
+
+A sliding piece draws its track faintly, so where it *can* go is visible before it
+is tapped rather than discovered by tapping.
+
+**No undo.** A cycle is its own inverse — tap round again and the piece is back —
+so the Futoshiki argument for undo (a placement destroying work elsewhere) does
+not apply. Nothing a tap does here is unrecoverable.
+
+**Hints stay**, and cost almost nothing: the solver is mandatory for gate 5, so a
+hint is the same `nextStep` call the generator already makes. Dropping them would
+save two locale blocks and forfeit the only thing that teaches a player who cannot
+yet see the deduction — leaving them to flip pieces at random, which is the failure
+mode this family has to avoid. A hint lights the piece it names **and the beam
+segment its reason is about**; "the light dies here" means nothing without showing
+where.
+
+## 8. Board requirements
+
+Beyond the shared screen bar:
+
+- **The beam is always drawn**, from the sun-disc to wherever it currently ends.
+  This is the family's live feedback, the equivalent of the balance scale's tilt.
+- **The beam's end is marked** — absorbed, escaped, or looping — so a beam that
+  stops short does not read as a rendering fault.
+- Movable pieces read as movable at a glance, and a sliding piece's track is
+  visible.
+- Both mirror orientations read as visibly different objects, not a subtle
+  rotation, at 44px.
+
+## 9. Theming
+
+Already written into the lore: `story-and-time-brainstorm.md` puts mirrors at the
+**Lighthouse of Alexandria** journey and names a **"Letting the Sun In"** theme,
+alongside the sundial and water clock. This family is the centre of that sun-god
+cluster.
+
+The component emits logical state only — `sunDisc | shrine | mirror(a|b) | wall`,
+plus the traced path and its end reason. Colour, texture and glyph live in the
+skin.
+
+## 10. Value output
+
+Side family — the answer is a route, not a number, so it does not feed
+carry-forward (`PUZZLE_FAMILIES.md` P3).
+
+## 11. Deferred
+
+- **Prisms and colour splitting.** The catalogue already rules this a different
+  puzzle shape rather than a knob, and points at The Talos Principle as prior art.
+- **"Light the shrine at the fifth hour."** `story-and-time-brainstorm.md` proposes
+  a timed variant reusing these exact pieces once a tick/scrub control exists —
+  the obelisk shadow sweeping one column per hour. Same pieces, new problem.
+- **Offline seed tables.** The direction recorded in `futoshiki.md` §11 applies
+  here too, and this family wants it less: enumeration is cheap, so generation is
+  fast without it.

--- a/docs/game-design/puzzles/lightbeam.md
+++ b/docs/game-design/puzzles/lightbeam.md
@@ -27,15 +27,15 @@ wherever it currently goes, so every change shows its own consequence.
 All of them ship in the first version. Playtesting a beam puzzle with only half
 its vocabulary would tell us about a different puzzle.
 
-| Piece            | Fixed or movable | States    | What it does                                    |
-| ---------------- | ---------------- | --------- | ----------------------------------------------- |
-| **Sun-disc**     | fixed            | —         | Emits the beam, one cell on an edge, one facing |
-| **Shrine**       | fixed            | —         | The target. Lights when the beam arrives        |
-| **Set mirror**   | fixed            | —         | A given, like a Sudoku clue                      |
-| **Wall**         | fixed            | —         | Absorbs the beam                                 |
-| **Turn mirror**  | movable          | 2         | Tap cycles `/` ↔ `\`, position fixed             |
-| **Sliding mirror** | movable        | 2–3       | Fixed angle, tap cycles between authored stops   |
-| **Sliding wall**  | movable         | 2–3       | Tap cycles between stops — moved out of the way, or into it |
+| Piece              | Fixed or movable | States | What it does                                                |
+| ------------------ | ---------------- | ------ | ----------------------------------------------------------- |
+| **Sun-disc**       | fixed            | —      | Emits the beam, one cell on an edge, one facing             |
+| **Shrine**         | fixed            | —      | The target. Lights when the beam arrives                    |
+| **Set mirror**     | fixed            | —      | A given, like a Sudoku clue                                 |
+| **Wall**           | fixed            | —      | Absorbs the beam                                            |
+| **Turn mirror**    | movable          | 2      | Tap cycles `/` ↔ `\`, position fixed                        |
+| **Sliding mirror** | movable          | 2–3    | Fixed angle, tap cycles between authored stops              |
+| **Sliding wall**   | movable          | 2–3    | Tap cycles between stops — moved out of the way, or into it |
 
 The sliding wall is the one piece whose move is **clearing a path** rather than
 bending one. That is worth having precisely because it is a different verb: every
@@ -79,14 +79,14 @@ from the answer.
 
 There is a real ladder here, and generation is gated on it:
 
-| #      | Technique          | Fires when                                                             | Decides                        |
-| ------ | ------------------ | ---------------------------------------------------------------------- | ------------------------------ |
-| **T0** | Forced entry run   | The run from the sun-disc crosses only cells nothing movable can change | Those cells carry the beam     |
-| **T1** | Forced exit run    | Same, traced backwards from the shrine                                 | Those cells carry the beam     |
-| **T2** | Dead end           | One state of a piece sends the beam to a wall or edge with no unsettled piece left on the way | That state is impossible       |
-| **T3** | Only one feeds it  | Exactly one piece-state can send the beam along the forced exit run     | That state is forced           |
-| **T4** | Never reached      | No configuration puts the beam on this piece at all                    | Its state is free — a decoy    |
-| **T5** | Only one survives  | Every arrangement of the remaining pieces fails, save with this one in this state | That state is forced   |
+| #      | Technique         | Fires when                                                                                    | Decides                     |
+| ------ | ----------------- | --------------------------------------------------------------------------------------------- | --------------------------- |
+| **T0** | Forced entry run  | The run from the sun-disc crosses only cells nothing movable can change                       | Those cells carry the beam  |
+| **T1** | Forced exit run   | Same, traced backwards from the shrine                                                        | Those cells carry the beam  |
+| **T2** | Dead end          | One state of a piece sends the beam to a wall or edge with no unsettled piece left on the way | That state is impossible    |
+| **T3** | Only one feeds it | Exactly one piece-state can send the beam along the forced exit run                           | That state is forced        |
+| **T4** | Never reached     | No configuration puts the beam on this piece at all                                           | Its state is free — a decoy |
+| **T5** | Only one survives | Every arrangement of the remaining pieces fails, save with this one in this state             | That state is forced        |
 
 T0/T1 are facts; T2–T5 are eliminations; propagation between them is the fixpoint
 loop, as in the other families.
@@ -114,21 +114,50 @@ The configuration space is the product of the movable pieces' state counts —
 over at most 49 cells. **This family can afford exact enumeration**, which Sumplete
 and Futoshiki cannot, and the gates below spend that freely.
 
-1. Route a beam from sun-disc to shrine, dropping a mirror at each turn.
+1. Route a beam from sun-disc to shrine, dropping a mirror at each turn. Legs never
+   revisit a cell, so the route never crosses itself — a crossing traces fine but
+   puts two reasons on one square, and every technique points at a square. The final
+   leg runs to the frame, which sets the shrine in the wall: an edge shrine has at
+   most three approaches and the frame kills most of those, which is what lets T1
+   fire at all.
 2. Fix some of those mirrors as givens, make the rest movable, and set the movable
    ones to a **wrong** starting state so the board opens unsolved.
-3. Scatter walls, decoy mirrors and sliding pieces off the path.
-4. **Gate — the path is unique.** Enumerate every configuration; every one that
-   lights the shrine must trace the *same path*. Decoys may be free (that is what
+3. **Wall off the wrong settings.** For each movable piece, the light under its wrong
+   setting has to run out — off the frame, or into a wall — before it meets anything
+   else the player controls. That is what makes T2's reason available, and the piece
+   it settles is what lets the entry run reach the next one. This chain is the whole
+   starter board.
+4. **Drop shadow pieces** (§6) into the very stretch a wrong setting would light, and
+   scatter decoys where no setting can light at all.
+5. **Gate — the path is unique.** Enumerate every configuration; every one that
+   lights the shrine must trace the _same path_. Decoys may be free (that is what
    makes them decoys), but the route may not be ambiguous.
-5. **Gate — deduction reaches it.** The ladder, capped per tier, must settle every
+6. **Gate — deduction reaches it.** The ladder, capped per tier, must settle every
    piece on the path. A board that stalls needs a guess and is discarded.
-6. **Gate — the board opens unsolved**, and no single tap solves it at tiers above
-   starter.
+7. **Thin the walls to a fixpoint** under the cap, re-running gates 5 and 6 on every
+   removal. A wall the player cannot spend hides which obstacles the deduction turns
+   on — the same argument that prunes Futoshiki's signs.
+8. **Gate — the board opens unsolved**, and no single tap solves it.
 
-Gate 4 is the honest form of uniqueness for this family. "Exactly one winning
+Gate 5 is the honest form of uniqueness for this family. "Exactly one winning
 configuration" would be the wrong test: a decoy has a free state, so a board with
-decoys has many winning configurations and only one winning *route*.
+decoys has many winning configurations and only one winning _route_.
+
+### 5.1 Fixed walls barely survive
+
+Step 7 turns out to remove almost all of them: measured over 40 seeds a tier, a
+shipped board carries **0.0–0.1 fixed walls**. Two reasons, and both are fine:
+
+- Step 3 only adds a wall when the wrong ray would otherwise rejoin the route. On
+  boards this size a wrong turn usually just runs off the frame, which is already a
+  dead end, so no wall was needed in the first place.
+- Where one was needed, step 7 keeps it, because removing it opens a second route.
+
+So _"the light dies in stone"_ is a real reason the player hears — 17–34 times per 40
+boards at expert and above — but the stone is almost always a **sliding wall the
+player is holding in the way**, not scenery. That is a better board than one dressed
+with walls nobody can spend, and it means the tier table's vocabulary column below
+lists what a tier can _contain_, not what it will be decorated with.
 
 ## 6. Difficulty
 
@@ -138,20 +167,47 @@ allocator may also draw it anywhere from starter up.
 
 That matters more than it looks: **a starter corridor can sit behind a ward gate
 deep inside a wizard pyramid**, so a starter board is not only ever seen by a
-beginner. Starter must therefore be *gentle*, not *empty* — a board with a real
+beginner. Starter must therefore be _gentle_, not _empty_ — a board with a real
 route to find, just a short one with few pieces and a low technique cap.
 
-| Tier    | Grid | Movable pieces | Cap | Vocabulary                     |
-| ------- | ---- | -------------- | --- | ------------------------------ |
-| starter | 5×5  | 2–3            | T2  | Turn mirrors, walls            |
-| junior  | 5×5  | 3–4            | T3  | + sliding mirrors              |
-| expert  | 6×6  | 4–6            | T4  | + sliding walls, first decoys  |
-| master  | 6×6  | 6–7            | T5  | Decoy density up               |
-| wizard  | 7×7  | 7–9            | T5  | Longer chains, more decoys     |
+| Tier    | Grid | Movable pieces | Configurations | Cap | Vocabulary                    |
+| ------- | ---- | -------------- | -------------- | --- | ----------------------------- |
+| starter | 5×5  | 3.0            | 8              | T2  | Turn mirrors                  |
+| junior  | 5×5  | 3.7            | 14             | T3  | + sliding mirrors, 1 shadow   |
+| expert  | 6×6  | 5.8            | 57             | T4  | + sliding walls, first decoys |
+| master  | 6×6  | 6.6            | 105            | T5  | 2 shadows                     |
+| wizard  | 7×7  | 8.4            | 371            | T5  | Longer chains, 3 shadows      |
+
+Piece and configuration counts are measured means over 40 seeds a tier, not
+intentions. The ramp is asserted in `generateLightbeam.spec.ts` — the first pass at
+this table read right and played wrong, with junior boards _smaller_ than starter
+ones.
+
+### 6.1 The cap does not bite on its own
+
+This is the one thing about the family that had to be discovered rather than
+designed. Built as §5 steps 1–3 describe, **every board is a chain of T2 and nothing
+more**: every wrong setting has a wall or a frame edge waiting for it, so the light
+visibly dies and the stronger rungs never have to fire. A wizard board would then
+solve exactly like a starter one, only longer — the cap would be a label.
+
+**Shadow pieces** are the fix, and they work from the other end. A shadow is a decoy
+placed deliberately in the stretch a wrong setting would light. With something
+unsettled standing in the way, the light does not visibly die — it disappears into a
+piece nobody has pinned down yet. T2 has nothing to say, and ruling that setting out
+takes T3 or T5. The shadow is still a genuine decoy (no winning beam touches it), so
+T4 still frees it, and it is still the player's job to work out that it never
+mattered.
+
+Measured effect at wizard, over 40 seeds: with no shadows, T5 fires on 3 boards; with
+three, on 28, and T2 alone carries only 14. That is the difference between a tier
+table and a tier.
 
 Knobs, in order of how much they actually move difficulty:
 
 - **Technique cap** — what a board may _demand_. The honest dial, as everywhere.
+- **Shadow count** — what makes it demand it. Useless without the cap, and the cap is
+  decorative without it.
 - **Turn count on the route** — how many mirrors the beam must bounce off.
 - **Decoy count** — pieces the player must reason are irrelevant.
 - **Set-vs-movable mirror ratio** — set mirrors are scaffolding, like givens.
@@ -160,7 +216,9 @@ Knobs, in order of how much they actually move difficulty:
 7×7 is the ceiling for the same reason the other grid families cap there: inside
 the encounter modal a 360px screen leaves the board about 320px, and 44px tap
 targets do not survive an eighth column. There are no gutters to reclaim here, so
-a cell is simply `board / N`.
+a cell is simply `board / N`. Measured in the encounter modal at 360×640: the board
+comes out 318px, so a wizard cell is **45px** — over the bar, and an eighth column
+would be 40px.
 
 ## 7. Controls
 
@@ -168,20 +226,39 @@ One gesture: **tap a piece to cycle it**. Turn mirrors cycle orientation, slidin
 pieces cycle to their next stop. Fixed pieces ignore taps. No drag, matching the
 rest of the game.
 
-A sliding piece draws its track faintly, so where it *can* go is visible before it
-is tapped rather than discovered by tapping.
+**Every square a piece can stand in is tappable**, its vacant stops included, and all
+of them cycle the same piece. Tapping where you want it to go is the same gesture as
+tapping the piece, and it doubles the target.
+
+A sliding piece draws its track faintly, and the track carries a **ghost of the
+piece** rather than just an outline. An empty dashed square says only "something can
+come here", which leaves the player to find out what by tapping — and whether the
+thing that arrives bends the light or swallows it is the entire difference between the
+two sliding pieces.
 
 **No undo.** A cycle is its own inverse — tap round again and the piece is back —
 so the Futoshiki argument for undo (a placement destroying work elsewhere) does
 not apply. Nothing a tap does here is unrecoverable.
 
-**Hints stay**, and cost almost nothing: the solver is mandatory for gate 5, so a
-hint is the same `nextStep` call the generator already makes. Dropping them would
-save two locale blocks and forfeit the only thing that teaches a player who cannot
-yet see the deduction — leaving them to flip pieces at random, which is the failure
-mode this family has to avoid. A hint lights the piece it names **and the beam
-segment its reason is about**; "the light dies here" means nothing without showing
-where.
+**Hints stay**, and cost almost nothing: the solver is mandatory for gate 6, so a
+hint is the same solve the generator already runs. Dropping them would save two locale
+blocks and forfeit the only thing that teaches a player who cannot yet see the
+deduction — leaving them to flip pieces at random, which is the failure mode this
+family has to avoid. A hint lights the piece it names **and the beam segment its
+reason is about**; "the light dies here" means nothing without showing where.
+
+### 7.1 A hint here is not a correction
+
+Every other family's hint can start with "that number is wrong". Here **every setting
+is a legal setting**, so there is nothing to be wrong about in that sense. A hint is
+instead _the first reason the player has not yet acted on_: the deduction is replayed
+from a blank board, and the hint is the earliest step whose conclusion the board in
+front of them contradicts. Follow it and the hint moves on by itself.
+
+T4 gets the second pass, and only when nothing is actually set wrong — otherwise the
+game would be telling the player to ignore a piece while the route is still broken.
+That makes it the one hint in the whole catalogue whose advice is to leave something
+alone.
 
 ## 8. Board requirements
 

--- a/docs/game-design/puzzles/lightbeam.md
+++ b/docs/game-design/puzzles/lightbeam.md
@@ -299,3 +299,82 @@ carry-forward (`PUZZLE_FAMILIES.md` P3).
 - **Offline seed tables.** The direction recorded in `futoshiki.md` §11 applies
   here too, and this family wants it less: enumeration is cheap, so generation is
   fast without it.
+
+### 11.1 Waypoints — the next thing to build
+
+A cell the beam **must** pass through. Transparent: it neither blocks nor turns.
+
+Its value is not the extra win condition, it is what it does to the solver. The
+forced-run deductions currently grow from exactly two places — forward from the disc
+(T0) and backward from the shrine (T1) — and they are weakest where they meet, in the
+middle of a long route, which is precisely where wizard is thinnest. **A waypoint is a
+second shrine for the purposes of those deductions:** run the same four-approach
+feasibility test on it, and when the frame and the walls kill three of them, a run
+through the middle of the board is forced. That reuses `walkBackward` untouched, and
+its reason is a sentence you can check by eye — _"the light has to get through here,
+and this is the only line it can come along."_
+
+Uniqueness gets easier, not harder: requiring waypoint coverage shrinks the winning
+set, so gate 5 has less to rule out.
+
+Two constraints it imposes:
+
+- **The shrine must not light until every waypoint is covered.** Otherwise the board
+  lies, and "the beam is at the shrine but you are not done" is a new failure mode this
+  family has so far avoided entirely.
+- **Waypoints need the same thinning pass as walls** (§5 step 7). One sitting on a
+  stretch T0 already forces teaches nothing — that is the unspendable-wall problem
+  again.
+
+It composes well with the shadow pieces: a shadow branch that _picks up_ a waypoint is
+a much nastier decoy, because the wrong setting now looks productive.
+
+### 11.2 Switch nodes and wiring — a variant, not a knob
+
+A waypoint with a consequence: light crossing the node lights a **drawn wire** to a
+piece, which then turns or moves.
+
+**The wiring is what makes this admissible at all.** Every reason in the ladder today
+is local — "face it that way and the light dies in that stone" is checkable because the
+stone is _there_. A switch that can move the stone breaks that, and the reason collapses
+into "I tried the alternatives and they failed", the rung ranked last for teaching
+nothing. A visible wire puts locality back: you can see what each node drives and trace
+it with a finger, so the reason survives with one hop of indirection.
+
+**Decoys then exist at three levels**, and the third is new to the catalogue:
+
+1. A node the light can never cross, so its wire never fires — today's T4, one level up.
+2. A node that fires into a piece the light never touches anyway: real wire, irrelevant
+   consequence.
+3. A node that fires, moves a piece that **is** on the route, and still changes nothing.
+
+**The paradox does not go away.** A switch that moves a wall _behind_ the beam means the
+beam that reached the switch no longer reaches it. Wiring makes that legible but not
+consistent. The options are a fixpoint (zero or several solutions, both fatal for a
+puzzle with one answer), iterate-until-stable (oscillation renders as a blinking board),
+or latching by history (order-dependent, no longer a pure function of the
+configuration). The one that keeps everything is to **restrict the effect to opening a
+way ahead of the light, never behind it**: the door opens in front of the beam and you
+watch it happen, wrong configurations die at the still-closed wall, and the new reason
+is an **ordering** one — _"the light gets here before it has opened this"_ — which
+nothing else in the catalogue trains. Generation builds it by construction: route the
+beam, put the wall late on the route, put the switch early.
+
+Implementation notes, for whoever picks this up:
+
+- Latching with in-flight mutation terminates: switches only ever flip on, so the trace
+  is at most (switches + 1) bounded walks.
+- **The loop-detection seen-set must be keyed by switch-state, or cleared on each flip.**
+  Otherwise a legitimate re-traverse of a cell reads as a loop.
+- Yield is the open question, not the logic. Opening a wall creates routes that were not
+  there before, so path-uniqueness has more to reject. Measure before believing it.
+
+**The thing most likely to kill this is the drawing, not the reasoning.** The board
+already carries cells, a two-pass beam, piece glyphs, movable rings, dashed tracks with
+ghost pieces, and end markers — at 45px a cell on a 7×7. A wire layer crossing all of
+that is where it turns to soup. Prototype the board visually _before_ writing any of the
+logic, which is the reverse of the order the rest of this family was built in.
+
+Filed as a **variant rather than a knob**: same pieces, same gesture, same trace, but
+multi-level indirection is a different shape of puzzle — nearer the timed variant above
+than a dial. Build 11.1 first, and only after the base family has actually been played.

--- a/docs/game-design/puzzles/lightbeam.md
+++ b/docs/game-design/puzzles/lightbeam.md
@@ -66,7 +66,7 @@ to be told what one means.
 
 Loop detection stays in the trace anyway, as the thing that keeps the walk total — and it
 becomes load-bearing the moment a piece bends light by anything other than a quarter turn,
-which is exactly what the deferred prism (§11) does. `beam.spec.ts` proves both halves: the
+which is exactly what the deferred prism (§12) does. `beam.spec.ts` proves both halves: the
 ring loops when the light starts inside it, and the disc's beam never loops.
 
 ## 4. The deduction ladder
@@ -170,18 +170,25 @@ deep inside a wizard pyramid**, so a starter board is not only ever seen by a
 beginner. Starter must therefore be _gentle_, not _empty_ — a board with a real
 route to find, just a short one with few pieces and a low technique cap.
 
-| Tier    | Grid | Movable pieces | Configurations | Cap | Vocabulary                    |
-| ------- | ---- | -------------- | -------------- | --- | ----------------------------- |
-| starter | 5×5  | 3.0            | 8              | T2  | Turn mirrors                  |
-| junior  | 5×5  | 3.7            | 14             | T3  | + sliding mirrors, 1 shadow   |
-| expert  | 6×6  | 5.8            | 57             | T4  | + sliding walls, first decoys |
-| master  | 6×6  | 6.6            | 105            | T5  | 2 shadows                     |
-| wizard  | 7×7  | 8.4            | 371            | T5  | Longer chains, 3 shadows      |
+| Tier    | Grid | Baseline route             | Movable pieces | Configurations | Cap | Goals drawn                 |
+| ------- | ---- | -------------------------- | -------------- | -------------- | --- | --------------------------- |
+| starter | 5×5  | 2 bends                    | 3.0            | 8              | T2  | 1 of: long chain, clear way |
+| junior  | 5×5  | 3 bends                    | 3.9            | 15             | T3  | 1 of those + blind alleys   |
+| expert  | 6×6  | 3 bends                    | 5.4            | 45             | T4  | 2 of all four               |
+| master  | 6×6  | 3 bends, 1 shadow          | 6.3            | 82             | T5  | 2 of all four               |
+| wizard  | 7×7  | 5 bends, 1 decoy, 1 shadow | 8.0            | 315            | T5  | 2 of all four               |
 
 Piece and configuration counts are measured means over 40 seeds a tier, not
-intentions. The ramp is asserted in `generateLightbeam.spec.ts` — the first pass at
-this table read right and played wrong, with junior boards _smaller_ than starter
-ones.
+intentions, and they are the totals _after_ a board's goals are applied (§7). The
+ramp is asserted in `generateLightbeam.spec.ts`, in aggregate over a tier rather
+than board by board — with goals drawn per board, one starter grid can legitimately
+out-measure one junior grid, and it is the tier that has to grow.
+
+It has been got wrong twice, both times in a way that read right in the table and
+played wrong: first with junior boards _smaller_ than starter ones, then again when
+the goal pool let two goals add four pieces on top of baselines that already
+carried some, putting five pieces on a starter board and collapsing expert, master
+and wizard into one ten-piece blur.
 
 ### 6.1 The cap does not bite on its own
 
@@ -220,7 +227,77 @@ a cell is simply `board / N`. Measured in the encounter modal at 360×640: the b
 comes out 318px, so a wizard cell is **45px** — over the bar, and an eighth column
 would be 40px.
 
-## 7. Controls
+## 7. Puzzle goals — pick two dials and turn them hard
+
+Before this existed, every tier turned every dial a little. The wizard row read: five turns
+AND a set mirror AND two sliding mirrors AND a sliding wall AND a decoy AND three shadows —
+so every wizard board was the **average** wizard board.
+
+A **goal pool** fixes that. `LIGHTBEAM_CONFIG` now holds a lean baseline, and generation
+draws one or two goals per board and turns those dials hard. Boards get character instead
+of mean settings, and it adds the axis the family was missing: difficulty (cap, size) is one
+thing, **what kind of problem this board is** is another, and they were welded together.
+
+With 158 lightbeam nodes in the world, that is a bigger variety win than any new piece type
+would be — and it needed no new piece at all. The four shipped goals are a re-scheduling of
+dials the generator already had.
+
+| Goal                    | Turns up                      | Tests                      | Built |
+| ----------------------- | ----------------------------- | -------------------------- | ----- |
+| **Long chain**          | `turns +2`, `setMirrors +1`   | route-tracing              | yes   |
+| **Sort the wheat**      | `decoys +2`                   | which pieces matter (T4)   | yes   |
+| **Clear the way**       | `slidingWalls +1`             | does the light get through | yes   |
+| **Blind alleys**        | `shadows +1`                  | the exhaustive rung (T5)   | yes   |
+| **Order of operations** | a node whose door blocks late | ordering                   | §12.1 |
+| **Steer clear**         | a harmful node on a wrong ray | avoidance                  | §12.1 |
+
+### 7.1 Three rules that keep it honest
+
+**A goal only ever turns a dial up.** That is what lets two of them apply in either order
+and both still mean what they say. The first draft had each goal flatten the dials it did
+not care about, so drawing two silently cancelled the first.
+
+**The tier sets the route; a goal sets what is in the way.** So a goal adds one or two
+pieces, never four, and the tier still decides how big a board is. `longChain` gives two
+more bends but one more _given_ mirror, because the length is the character, not the piece
+count. Getting this wrong put five pieces on a starter board that wanted three (§6).
+
+**The gates stay untouched.** A goal shapes what gets _placed_, never what gets _accepted_:
+path uniqueness and the ladder still decide, so no goal can smuggle through a board that
+needs a guess.
+
+### 7.2 The fallback ladder, and why the board carries its goals
+
+Two goals at once can be a pair no board satisfies, so when the attempt budget runs out a
+goal is dropped and it tries again, down to the bare baseline.
+
+The board then **records the goals it was actually built to**, as data on the puzzle rather
+than a log line. A fallback that fires quietly would make the whole pool decorative while
+every other measurement still looked fine, so `goals.spec.ts` asserts the ladder never
+fires at the shipped config, and the playtest bench can show what a board was meant to be.
+
+That assertion earned its keep immediately. The first measured run fell back on **30% of
+wizard boards**, and the cause was not the goals at all: `buildRoute` drew each leg's length
+from 1..size-2 regardless of how many legs it had to fit, so it ate the grid in three
+strides and a long route almost never fitted. The leg budget now scales with the turn
+count — and wizard's worst-case generation went from 332ms to 50ms as a side effect.
+
+### 7.3 Which goals a tier may draw
+
+A fairness question, not a taste one. `sortTheWheat` piles on decoys, and a decoy is only
+fair once `neverReached` can prove it irrelevant — so expert and up. `blindAlleys` piles on
+shadows, which need at least the shrine-side elimination to unpick — so junior and up.
+
+One consequence worth knowing at playtest: a junior board demands the shrine-side
+elimination **when it is a blind-alleys board**, which is about a third of them. That is the
+goal system working as designed rather than a gap — the goal decides the reasoning, and the
+cap only says how far a board is allowed to go.
+
+Nothing about the mechanism is lightbeam-specific: Futoshiki could draw technique-flavour
+goals the same way. Left here until a second family actually wants it — a shared abstraction
+on one caller would be the premature kind.
+
+## 8. Controls
 
 One gesture: **tap a piece to cycle it**. Turn mirrors cycle orientation, sliding
 pieces cycle to their next stop. Fixed pieces ignore taps. No drag, matching the
@@ -247,7 +324,7 @@ deduction — leaving them to flip pieces at random, which is the failure mode t
 family has to avoid. A hint lights the piece it names **and the beam segment its
 reason is about**; "the light dies here" means nothing without showing where.
 
-### 7.1 A hint here is not a correction
+### 8.1 A hint here is not a correction
 
 Every other family's hint can start with "that number is wrong". Here **every setting
 is a legal setting**, so there is nothing to be wrong about in that sense. A hint is
@@ -260,7 +337,7 @@ game would be telling the player to ignore a piece while the route is still brok
 That makes it the one hint in the whole catalogue whose advice is to leave something
 alone.
 
-## 8. Board requirements
+## 9. Board requirements
 
 Beyond the shared screen bar:
 
@@ -273,7 +350,7 @@ Beyond the shared screen bar:
 - Both mirror orientations read as visibly different objects, not a subtle
   rotation, at 44px.
 
-## 9. Theming
+## 10. Theming
 
 Already written into the lore: `story-and-time-brainstorm.md` puts mirrors at the
 **Lighthouse of Alexandria** journey and names a **"Letting the Sun In"** theme,
@@ -284,12 +361,12 @@ The component emits logical state only — `sunDisc | shrine | mirror(a|b) | wal
 plus the traced path and its end reason. Colour, texture and glyph live in the
 skin.
 
-## 10. Value output
+## 11. Value output
 
 Side family — the answer is a route, not a number, so it does not feed
 carry-forward (`PUZZLE_FAMILIES.md` P3).
 
-## 11. Deferred
+## 12. Deferred
 
 - **Prisms and colour splitting.** The catalogue already rules this a different
   puzzle shape rather than a knob, and points at The Talos Principle as prior art.
@@ -300,7 +377,7 @@ carry-forward (`PUZZLE_FAMILIES.md` P3).
   here too, and this family wants it less: enumeration is cheap, so generation is
   fast without it.
 
-### 11.1 Switch nodes — the next thing to build
+### 12.1 Switch nodes — the next thing to build
 
 A **node** is a fixed, transparent cell wired to one movable piece. Light crossing it
 lights the wire, and the piece it drives moves. The wire is drawn.
@@ -397,49 +474,3 @@ is a trap twice over.
 
 That is the real argument for the node — not one extra trick but a **machine you have to
 understand before you can drive it**. Which nodes to light, and which to steer clear of.
-
-### 11.2 Puzzle goals — pick two dials and turn them hard
-
-Every tier currently turns every dial a little. Read the wizard row of `LIGHTBEAM_CONFIG`:
-five turns, one set mirror, two sliding mirrors, one sliding wall, one decoy, three shadows.
-Every wizard board is the **average** wizard board.
-
-A **goal pool** fixes that: generation draws one or two goals per board and turns those
-dials hard, leaving the rest slack. Boards then have character instead of mean settings —
-and with 158 lightbeam nodes in the world, that is likely a bigger variety win than any new
-piece type. It also adds the axis the family is missing: difficulty (cap, size) is one
-thing, **what kind of problem this board is** is another, and they are currently welded
-together.
-
-The pool, and what each is built from:
-
-| Goal                    | Built from                    | Tests                      | Needs   |
-| ----------------------- | ----------------------------- | -------------------------- | ------- |
-| **Long chain**          | turns high, decoys 0          | route-tracing              | nothing |
-| **Sort the wheat**      | decoys high, turns low        | which pieces matter (T4)   | nothing |
-| **Clear the way**       | sliding walls on the route    | does the light get through | nothing |
-| **Blind alleys**        | shadows high                  | the exhaustive rung (T5)   | nothing |
-| **Order of operations** | a node whose door blocks late | ordering                   | §11.1   |
-| **Steer clear**         | a harmful node on a wrong ray | avoidance                  | §11.1   |
-
-**Four of the six need no new mechanic** — they are a re-scheduling of knobs that already
-exist. That version is cheap, and it is worth building **before** the family is playtested
-rather than after: judging the current build means judging one recipe five times, whereas
-with goals you would be judging the spread, which is the thing actually worth knowing.
-
-Two things it has to get right:
-
-- **A fallback ladder.** If the chosen pair will not generate inside the attempt budget,
-  drop to one goal, then to none — and `log` which, because a silent fallback that always
-  fires makes the whole pool decorative. This is the same discipline as "no silent caps".
-- **The gates stay untouched.** A goal shapes what gets _placed_; it never shapes what gets
-  _accepted_. Path uniqueness and the ladder still decide, so no goal can smuggle through a
-  board that needs a guess.
-
-It softens the tier table in §6: piece and configuration counts become per-goal ranges
-rather than the flat means measured there, and `generateLightbeam.spec.ts`'s monotonicity
-assertion would have to hold in aggregate over a tier rather than board by board.
-
-Worth noting for later: nothing about this is specific to lightbeam — Futoshiki could draw
-technique-flavour goals the same way. Build it here first and only generalise if a second
-family actually wants it; a shared abstraction on one caller would be the premature kind.

--- a/docs/instructions/changelog.md
+++ b/docs/instructions/changelog.md
@@ -38,13 +38,51 @@ Write for the player, not the developer. Entries must be readable by someone who
 - **Bad**: "Add `useDetector` hook with compass and consumable modes to `DetectorPanel`."
 - **Good**: "A compass tool shows which pyramid levels still contain pieces of a hieroglyph you are looking for."
 
+## Size: a whole feature is ONE entry
+
+The commonest mistake, and the one to check for first. **A new mechanic, screen or puzzle family gets a
+single bullet naming it — not an inventory of everything inside it.** The reader wants to know the feature
+exists; they will find out how it works by using it.
+
+**Too much** — one puzzle family logged as eight facts:
+
+```markdown
+- A light puzzle: bend the sunlight from the disc to the shrine, past stone that swallows it.
+- Tap a mirror to turn it, or a sliding piece to move it.
+- The beam is drawn wherever it currently goes and marked where it ends.
+- A sliding piece shows a faint ghost of itself on the spots it can move to.
+- Hints explain the next step in words.
+- Light puzzles turn up in pyramids and tombs from the first tier, growing from 7×7 up to 9×9.
+- Pieces you can tap are never placed side by side.
+- Every light puzzle is built around one or two goals drawn for it.
+```
+
+**Right**:
+
+```markdown
+- A light puzzle: bend the sunlight from the disc to the shrine.
+```
+
+Everything cut there is real and worth writing down — it belongs in the commit message, the PR and the
+family's design doc, which is where someone looking for it will go. The changelog is not the place it
+lives.
+
+The test: **would the player have called these separate changes?** They met one new puzzle, not eight
+features. Controls, feedback, hints, difficulty range and generation are how a feature is built, not
+things the player gained one by one.
+
+This cuts the other way from "split compound changes" below, and the two are settled by the same question.
+Three unrelated changes that arrived together are three entries. One feature described from three angles
+is one entry.
+
 ## Length: quick bullets, not prose
 
 A changelog is scanned, not read. **One fact per bullet, one line, roughly 20 words.** If a bullet needs
 a second sentence, it is usually two bullets.
 
 - **Split compound changes.** "The mosaic is five scenes… and each scene belongs to a difficulty… and you
-  place them yourself" is three entries.
+  place them yourself" is three entries — three separate things the player gained. Not to be confused with
+  one feature restated from several angles, which is one entry (see above).
 - **State the change, not the reasoning.** Why it was done, how it works, and what it is like under the
   hood belong in the commit message and the PR — never here.
 - **Only contrast with the old behaviour when the change is otherwise unreadable**, and then in a clause,

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -362,5 +362,29 @@
         "col": "In this column, {{first}}, {{second}} and {{third}} fit nowhere but these three squares, so nothing else can go in any of them."
       }
     }
+  },
+  "lightbeam": {
+    "rules": {
+      "goal": "Get the sunlight from the disc to the shrine.",
+      "mirrors": "A mirror bends the light a quarter turn, off either of its faces.",
+      "walls": "A block of stone swallows the light. So does the edge of the board.",
+      "tap": "Tap a piece to change it: a mirror turns, a sliding piece moves to its next spot. Pieces with a plain edge are part of the puzzle and cannot be moved."
+    },
+    "hint": {
+      "entryRun": "Start where the light already goes: it runs straight from the disc until it meets the first piece you can change. Those squares carry the light whatever you do.",
+      "exitRun": "Look at the shrine. Only one side of it can be lit at all — every other way in is blocked or faces off the board — so the light has to arrive along that line.",
+      "deadEnd": {
+        "wall": "Set this way, the light runs straight into stone with nothing left to save it. So it cannot be set this way.",
+        "edge": "Set this way, the light runs off the edge of the board with nothing left to catch it. So it cannot be set this way.",
+        "loop": "Set this way, the light never gets anywhere — it circles for ever. So it cannot be set this way."
+      },
+      "feedsExit": {
+        "wall": "Work back from the shrine. Set this way, nothing can deliver the light along the only line that reaches it — it dies in stone on the way.",
+        "edge": "Work back from the shrine. Set this way, the light would have to come from outside the board to reach it.",
+        "loop": "Work back from the shrine. Set this way, the light that would have to reach it only circles for ever instead."
+      },
+      "neverReached": "Leave this one alone. The light cannot reach it however the rest is set, so nothing you do to it matters.",
+      "onlySurvivor": "Try every setting of this one in turn and all but one leave the shrine dark. That one is the answer."
+    }
   }
 }

--- a/public/locales/nl/common.json
+++ b/public/locales/nl/common.json
@@ -355,5 +355,29 @@
         "col": "In deze kolom passen {{first}}, {{second}} en {{third}} nergens anders dan in deze drie vakjes, dus er kan niets anders in."
       }
     }
+  },
+  "lightbeam": {
+    "rules": {
+      "goal": "Breng het zonlicht van de schijf naar het schrijn.",
+      "mirrors": "Een spiegel buigt het licht een kwartslag, langs elk van zijn kanten.",
+      "walls": "Een blok steen slokt het licht op. De rand van het bord ook.",
+      "tap": "Tik op een stuk om het te veranderen: een spiegel draait, een schuivend stuk gaat naar zijn volgende plek. Stukken met een effen rand horen bij de puzzel en kun je niet verzetten."
+    },
+    "hint": {
+      "entryRun": "Begin waar het licht al komt: het loopt recht vanaf de schijf tot het eerste stuk dat je kunt veranderen. Die vakjes dragen het licht, wat je ook doet.",
+      "exitRun": "Kijk naar het schrijn. Maar één kant ervan kan verlicht worden — elke andere weg erheen is dicht of kijkt het bord uit — dus het licht moet langs die lijn aankomen.",
+      "deadEnd": {
+        "wall": "Zo gezet loopt het licht recht in de steen, en er is niets meer dat het kan redden. Dus zo kan het niet staan.",
+        "edge": "Zo gezet loopt het licht het bord uit, en er is niets meer dat het kan opvangen. Dus zo kan het niet staan.",
+        "loop": "Zo gezet komt het licht nergens — het blijft eeuwig rondgaan. Dus zo kan het niet staan."
+      },
+      "feedsExit": {
+        "wall": "Werk terug vanaf het schrijn. Zo gezet kan niets het licht over de enige lijn erheen brengen — het sterft onderweg in de steen.",
+        "edge": "Werk terug vanaf het schrijn. Zo gezet zou het licht van buiten het bord moeten komen om er te kunnen zijn.",
+        "loop": "Werk terug vanaf het schrijn. Zo gezet gaat het licht dat er zou moeten komen alleen eeuwig rond."
+      },
+      "neverReached": "Laat deze staan. Het licht kan er niet bij komen, hoe de rest ook staat, dus wat je ermee doet maakt niets uit.",
+      "onlySurvivor": "Probeer elke stand van deze om de beurt: op één na laten ze het schrijn allemaal donker. Die ene is het antwoord."
+    }
   }
 }

--- a/src/app/dev/PuzzleLab.tsx
+++ b/src/app/dev/PuzzleLab.tsx
@@ -9,6 +9,23 @@ import { allowedDifficulties, themesFor } from "./puzzleLabOptions"
 
 const selectClass = "rounded-md border border-red-400 bg-stone-900 px-2 py-1 text-sm text-white"
 
+/**
+ * The generator's own decisions about the board on screen, for whichever families record any.
+ *
+ * Read off the generated puzzle rather than declared per family, because these are debug facts and the bench
+ * is the only place they are wanted — a family that starts recording one gets it here for free, and one that
+ * records none says nothing.
+ */
+const benchNotes = (puzzle: unknown): string[] => {
+  if (typeof puzzle !== "object" || puzzle === null) return []
+  const { goals, techniqueCap, size } = puzzle as { goals?: unknown; techniqueCap?: unknown; size?: unknown }
+  return [
+    typeof size === "number" ? `${size}×${size}` : undefined,
+    typeof techniqueCap === "string" ? `cap ${techniqueCap}` : undefined,
+    Array.isArray(goals) ? (goals.length ? `goals ${goals.join(" + ")}` : "goals — (baseline)") : undefined,
+  ].filter((note): note is string => note !== undefined)
+}
+
 // Playtesting bench for puzzle families: pick family + theme + tier, play the real screen without
 // walking a pyramid to a room that happens to serve it. Renders through the same EncounterModal and
 // plugin Component real gameplay uses, so what is judged here is what ships.
@@ -91,6 +108,12 @@ export const PuzzleLab: FC = () => {
           }}
         />
       </div>
+      {/* What the generator decided, for the families that decide anything. Without this the bench can
+          only say a board felt different, not which of its knobs was turned — and for a family that draws
+          per-board goals (lightbeam), telling the spread apart from noise is the whole point of playing it. */}
+      {playing && puzzle !== undefined && benchNotes(puzzle).length > 0 && (
+        <p className="mt-2 text-center text-xs text-red-300">{benchNotes(puzzle).join(" · ")}</p>
+      )}
       {playing && puzzle !== undefined && (
         <EncounterModal>
           <Component

--- a/src/data/generatedWorld.ts
+++ b/src/data/generatedWorld.ts
@@ -3,7 +3,7 @@
 // World seed: 42195837
 import type { SiteConfig } from "../game/siteTypes"
 
-export const worldContentHash = 334382860
+export const worldContentHash = 1825317443
 
 export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
   starter_1: [
@@ -43,7 +43,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "tomb-key", wardKeyId: "junior_a_1" },
             endReward: { type: "hieroglyphFragment", hieroglyphId: "art2", pieceIndex: 0 },
             rewards: [{ type: "money", amount: 2 }],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 0,
@@ -66,11 +66,11 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "mosaicPiece", tier: "starter" },
             rewards: [{ type: "money", amount: 2 }],
-            encounter: "sumplete",
+            encounter: "lightbeam",
           },
         ],
         entrance: { stairId: "starter_1:0:floor0:side0" },
-        encounter: "futoshiki",
+        encounter: "lightbeam",
         mainEndReward: { type: "mosaicPiece", tier: "starter" },
         rewards: [
           { type: "money", amount: 2 },
@@ -104,7 +104,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "tomb-key", wardKeyId: "starter_a_1" },
             endReward: { type: "mosaicPiece", tier: "starter" },
             rewards: [{ type: "money", amount: 2 }],
-            encounter: "sumplete",
+            encounter: "lightbeam",
           },
         ],
         encounter: "sumplete",
@@ -145,7 +145,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
               { type: "consumable", consumable: "trapTool" },
               { type: "consumable", consumable: "bandage" },
             ],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 1,
@@ -179,7 +179,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "mosaicPiece", tier: "junior" },
             rewards: [{ type: "money", amount: 2 }],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 4,
@@ -191,7 +191,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
           },
         ],
         entrance: { stairId: "starter_2:0:floor0:side0" },
-        encounter: "futoshiki",
+        encounter: "lightbeam",
         mainEndReward: { type: "mosaicPiece", tier: "junior" },
         rewards: [
           { type: "money", amount: 1 },
@@ -230,7 +230,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             encounter: "futoshiki",
           },
         ],
-        encounter: "futoshiki",
+        encounter: "lightbeam",
         mainEndReward: { type: "mosaicPiece", tier: "starter" },
         rewards: [{ type: "money", amount: 2 }],
       },
@@ -258,7 +258,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
           },
         ],
         entrance: { stairId: "starter_2:1:floor0:side0" },
-        encounter: "futoshiki",
+        encounter: "lightbeam",
         mainEndReward: { type: "hieroglyphFragment", hieroglyphId: "p3", pieceIndex: 0 },
         rewards: [
           { type: "consumable", consumable: "bandage" },
@@ -313,10 +313,10 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             endReward: { type: "mosaicPiece", tier: "starter" },
             rewards: [{ type: "money", amount: 2 }],
             hidden: true,
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
         ],
-        encounter: "sumplete",
+        encounter: "lightbeam",
         mainEndReward: { type: "mapPiece", tombId: "starter_treasure_tomb" },
         rewards: [
           { type: "money", amount: 1 },
@@ -347,7 +347,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "tomb-key", wardKeyId: "starter_a_3" },
             endReward: { type: "mosaicPiece", tier: "starter" },
             rewards: [{ type: "money", amount: 2 }],
-            encounter: "balance-scale",
+            encounter: "futoshiki",
           },
           {
             pathPuzzles: 0,
@@ -371,7 +371,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             encounter: "sumplete",
           },
         ],
-        encounter: "balance-scale",
+        encounter: "futoshiki",
         mainEndReward: { type: "mosaicPiece", tier: "starter" },
         rewards: [
           { type: "money", amount: 1 },
@@ -427,7 +427,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             endReward: { type: "mosaicPiece", tier: "starter" },
             rewards: [{ type: "money", amount: 1 }],
             hidden: true,
-            encounter: "sumplete",
+            encounter: "lightbeam",
           },
         ],
         encounter: "balance-scale",
@@ -465,7 +465,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "tomb-key", wardKeyId: "starter_a_2" },
             endReward: { type: "hieroglyphFragment", hieroglyphId: "art5", pieceIndex: 2 },
             rewards: [{ type: "money", amount: 1 }],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 0,
@@ -515,7 +515,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "tomb-key", wardKeyId: "starter_a_1" },
             endReward: { type: "hieroglyphFragment", hieroglyphId: "p8", pieceIndex: 0 },
             rewards: [{ type: "money", amount: 3 }],
-            encounter: "sumplete",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 1,
@@ -545,10 +545,10 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             endReward: { type: "mosaicPiece", tier: "starter" },
             rewards: [{ type: "money", amount: 1 }],
             hidden: true,
-            encounter: "sumplete",
+            encounter: "lightbeam",
           },
         ],
-        encounter: "futoshiki",
+        encounter: "lightbeam",
         mainEndReward: { type: "mapPiece", tombId: "starter_treasure_tomb" },
         rewards: [
           { type: "money", amount: 3 },
@@ -600,7 +600,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             endReward: { type: "mosaicPiece", tier: "starter" },
             rewards: [{ type: "money", amount: 1 }],
             hidden: true,
-            encounter: "balance-scale",
+            encounter: "futoshiki",
           },
         ],
         encounter: "sumplete",
@@ -662,7 +662,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             encounter: "sumplete",
           },
         ],
-        encounter: "futoshiki",
+        encounter: "lightbeam",
         mainEndReward: { type: "hieroglyphFragment", hieroglyphId: "a8", pieceIndex: 1 },
         rewards: [
           { type: "money", amount: 1 },
@@ -721,7 +721,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "money", amount: 2 },
             rewards: [{ type: "money", amount: 3 }],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 1,
@@ -730,7 +730,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             endReward: { type: "money", amount: 2 },
             rewards: [{ type: "money", amount: 2 }],
             hidden: true,
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
         ],
         encounter: "futoshiki",
@@ -831,7 +831,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "tomb-key", wardKeyId: "junior_a_2" },
             endReward: { type: "hieroglyphFragment", hieroglyphId: "art12", pieceIndex: 2 },
             rewards: [{ type: "money", amount: 3 }],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 1,
@@ -855,7 +855,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "mosaicPiece", tier: "junior" },
             rewards: [{ type: "money", amount: 1 }],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           { pathPuzzles: 0, difficulty: "junior", end: "treasure", endReward: { type: "mosaicPiece", tier: "junior" } },
           {
@@ -895,7 +895,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "mosaicPiece", tier: "junior" },
             rewards: [{ type: "money", amount: 3 }],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 1,
@@ -911,7 +911,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "mosaicPiece", tier: "junior" },
             rewards: [{ type: "money", amount: 1 }],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           { pathPuzzles: 0, difficulty: "junior", end: "treasure", endReward: { type: "mosaicPiece", tier: "junior" } },
           {
@@ -927,10 +927,10 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: { stairId: "junior_1:p2:wing0" },
             gate: { type: "tomb-key", wardKeyId: "junior_a_1" },
             rewards: [{ type: "money", amount: 1 }],
-            encounter: "balance-scale",
+            encounter: "futoshiki",
           },
         ],
-        encounter: "balance-scale",
+        encounter: "futoshiki",
         mainEndReward: { type: "hieroglyphFragment", hieroglyphId: "d2", pieceIndex: 1 },
         rewards: [
           { type: "money", amount: 2 },
@@ -967,7 +967,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "tomb-key", wardKeyId: "junior_a_1" },
             endReward: { type: "hieroglyphFragment", hieroglyphId: "art7", pieceIndex: 0 },
             rewards: [{ type: "money", amount: 3 }],
-            encounter: "balance-scale",
+            encounter: "futoshiki",
           },
           {
             pathPuzzles: 1,
@@ -975,7 +975,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "mosaicPiece", tier: "junior" },
             rewards: [{ type: "money", amount: 3 }],
-            encounter: "balance-scale",
+            encounter: "futoshiki",
           },
           {
             pathPuzzles: 1,
@@ -983,7 +983,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "mosaicPiece", tier: "junior" },
             rewards: [{ type: "money", amount: 1 }],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 1,
@@ -1025,7 +1025,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "tomb-key", wardKeyId: "junior_a_2" },
             endReward: { type: "hieroglyphFragment", hieroglyphId: "a13", pieceIndex: 1 },
             rewards: [{ type: "money", amount: 2 }],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 1,
@@ -1049,7 +1049,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "mosaicPiece", tier: "junior" },
             rewards: [{ type: "money", amount: 3 }],
-            encounter: "sumplete",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 1,
@@ -1105,7 +1105,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "tomb-key", wardKeyId: "junior_a_1" },
             endReward: { type: "hieroglyphFragment", hieroglyphId: "p9", pieceIndex: 0 },
             rewards: [{ type: "money", amount: 2 }],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 1,
@@ -1113,7 +1113,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "mosaicPiece", tier: "junior" },
             rewards: [{ type: "money", amount: 2 }],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 1,
@@ -1159,7 +1159,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
         exitOrStaircase: "exit",
         sideSections: [],
         entrance: { stairId: "junior_2:p2:wing0" },
-        encounter: "sumplete",
+        encounter: "lightbeam",
         mainEndReward: { type: "hieroglyphFragment", hieroglyphId: "d9", pieceIndex: 0 },
         rewards: [
           { type: "money", amount: 3 },
@@ -1217,7 +1217,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             encounter: "balance-scale",
           },
         ],
-        encounter: "futoshiki",
+        encounter: "lightbeam",
         mainEndReward: { type: "mosaicPiece", tier: "junior" },
         rewards: [
           { type: "money", amount: 2 },
@@ -1309,7 +1309,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "tomb-key", wardKeyId: "junior_a_3" },
             endReward: { type: "hieroglyphFragment", hieroglyphId: "art7", pieceIndex: 2 },
             rewards: [{ type: "money", amount: 1 }],
-            encounter: "balance-scale",
+            encounter: "futoshiki",
           },
           {
             pathPuzzles: 1,
@@ -1317,7 +1317,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "sellable", itemId: "sell_stone_3" },
             rewards: [{ type: "money", amount: 1 }],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 1,
@@ -1333,7 +1333,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "sellable", itemId: "sell_bronze_1" },
             rewards: [undefined],
-            encounter: "sumplete",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 1,
@@ -1365,7 +1365,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             encounter: "arithmetic-reflex",
           },
         ],
-        encounter: "sumplete",
+        encounter: "lightbeam",
         mainEndReward: { type: "hieroglyphFragment", hieroglyphId: "d15", pieceIndex: 1 },
         rewards: [
           { type: "money", amount: 2 },
@@ -1459,7 +1459,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             encounter: "sumplete",
           },
         ],
-        encounter: "futoshiki",
+        encounter: "lightbeam",
         mainEndReward: { type: "hieroglyphFragment", hieroglyphId: "p11", pieceIndex: 1 },
         rewards: [undefined, undefined, undefined, undefined, undefined],
       },
@@ -1495,7 +1495,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "sellable", itemId: "sell_bronze_5" },
             rewards: [undefined],
-            encounter: "balance-scale",
+            encounter: "futoshiki",
           },
           {
             pathPuzzles: 1,
@@ -1503,7 +1503,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "sellable", itemId: "sell_bronze_1" },
             rewards: [undefined],
-            encounter: "sumplete",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 1,
@@ -1597,7 +1597,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "money", amount: 2 },
             rewards: [undefined],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           { pathPuzzles: 0, difficulty: "junior", end: "treasure", endReward: { type: "money", amount: 2 } },
           {
@@ -1662,7 +1662,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             encounter: "arithmetic-reflex",
           },
         ],
-        encounter: "sumplete",
+        encounter: "lightbeam",
         mainEndReward: { type: "hieroglyphFragment", hieroglyphId: "art2", pieceIndex: 2 },
         rewards: [undefined, undefined, undefined, undefined],
       },
@@ -1687,7 +1687,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "tomb-key", wardKeyId: "junior_a_3" },
             endReward: { type: "hieroglyphFragment", hieroglyphId: "p9", pieceIndex: 2 },
             rewards: [undefined],
-            encounter: "balance-scale",
+            encounter: "futoshiki",
           },
           {
             pathPuzzles: 1,
@@ -1719,7 +1719,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "money", amount: 2 },
             rewards: [undefined],
-            encounter: "sumplete",
+            encounter: "lightbeam",
           },
           { pathPuzzles: 0, difficulty: "junior", end: "treasure", endReward: { type: "money", amount: 2 } },
           {
@@ -1730,7 +1730,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             hidden: true,
           },
         ],
-        encounter: "futoshiki",
+        encounter: "lightbeam",
         mainEndReward: { type: "hieroglyphFragment", hieroglyphId: "art12", pieceIndex: 3 },
         rewards: [undefined, undefined, undefined, undefined],
       },
@@ -1763,7 +1763,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "money", amount: 2 },
             rewards: [undefined],
-            encounter: "sumplete",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 1,
@@ -1832,7 +1832,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "money", amount: 2 },
             rewards: [undefined],
-            encounter: "balance-scale",
+            encounter: "futoshiki",
           },
           {
             pathPuzzles: 1,
@@ -1840,7 +1840,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "money", amount: 2 },
             rewards: [undefined],
-            encounter: "sumplete",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 1,
@@ -1867,7 +1867,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             encounter: "sumplete",
           },
         ],
-        encounter: "futoshiki",
+        encounter: "lightbeam",
         mainEndReward: { type: "money", amount: 2 },
         rewards: [undefined, undefined, undefined, undefined, undefined],
       },
@@ -1953,7 +1953,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
               { type: "money", amount: 3 },
               { type: "money", amount: 3 },
             ],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 4,
@@ -1971,7 +1971,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             encounter: "arithmetic-reflex",
           },
         ],
-        encounter: "futoshiki",
+        encounter: "lightbeam",
         mainEndReward: { type: "mapPiece", tombId: "expert_treasure_tomb_b" },
         rewards: [
           { type: "consumable", consumable: "bandage" },
@@ -1997,7 +1997,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
               { type: "money", amount: 2 },
               { type: "money", amount: 2 },
             ],
-            encounter: "sumplete",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 1,
@@ -2028,7 +2028,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
               { type: "money", amount: 3 },
               { type: "money", amount: 3 },
             ],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 2,
@@ -2095,7 +2095,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "tomb-key", wardKeyId: "expert_b_1" },
             endReward: { type: "hieroglyphFragment", hieroglyphId: "a5", pieceIndex: 3 },
             rewards: [{ type: "money", amount: 2 }],
-            encounter: "balance-scale",
+            encounter: "futoshiki",
           },
           {
             pathPuzzles: 2,
@@ -2128,7 +2128,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
               { type: "money", amount: 3 },
               { type: "money", amount: 2 },
             ],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 4,
@@ -2165,10 +2165,10 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
               { type: "money", amount: 3 },
               { type: "money", amount: 1 },
             ],
-            encounter: "sumplete",
+            encounter: "lightbeam",
           },
         ],
-        encounter: "balance-scale",
+        encounter: "futoshiki",
         packing: 1.6,
         mainEndReward: { type: "mosaicPiece", tier: "expert" },
         rewards: [
@@ -2199,7 +2199,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
         exitOrStaircase: "exit",
         sideSections: [],
         entrance: { stairId: "expert_1:p2:wing1" },
-        encounter: "futoshiki",
+        encounter: "lightbeam",
         mainEndReward: { type: "hieroglyphFragment", hieroglyphId: "a6", pieceIndex: 2 },
         rewards: [
           { type: "money", amount: 2 },
@@ -2270,7 +2270,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
               { type: "money", amount: 2 },
               { type: "money", amount: 2 },
             ],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 2,
@@ -2281,7 +2281,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
               { type: "money", amount: 2 },
               { type: "money", amount: 3 },
             ],
-            encounter: "sumplete",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 2,
@@ -2365,7 +2365,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "tomb-key", wardKeyId: "expert_b_1" },
             endReward: { type: "hieroglyphFragment", hieroglyphId: "a11", pieceIndex: 1 },
             rewards: [{ type: "money", amount: 3 }],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 2,
@@ -2547,7 +2547,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "mosaicPiece", tier: "expert" },
             rewards: [undefined, undefined],
-            encounter: "sumplete",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 2,
@@ -2589,7 +2589,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             encounter: "futoshiki",
           },
         ],
-        encounter: "sumplete",
+        encounter: "lightbeam",
         mainEndReward: { type: "hieroglyphFragment", hieroglyphId: "p12", pieceIndex: 0 },
         rewards: [
           { type: "consumable", consumable: "bandage" },
@@ -2606,7 +2606,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
         exitOrStaircase: "exit",
         sideSections: [],
         entrance: { stairId: "expert_2:p2:wing0" },
-        encounter: "futoshiki",
+        encounter: "lightbeam",
         mainEndReward: { type: "mosaicPiece", tier: "expert" },
         rewards: [undefined, undefined],
       },
@@ -2689,10 +2689,10 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
               { type: "money", amount: 2 },
               { type: "money", amount: 3 },
             ],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
         ],
-        encounter: "sumplete",
+        encounter: "lightbeam",
         packing: 1.6,
         mainEndReward: { type: "hieroglyphFragment", hieroglyphId: "art14", pieceIndex: 1 },
         rewards: [
@@ -2769,7 +2769,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "hieroglyphFragment", hieroglyphId: "art14", pieceIndex: 2 },
             rewards: [undefined, undefined],
-            encounter: "balance-scale",
+            encounter: "futoshiki",
           },
           {
             pathPuzzles: 4,
@@ -2816,7 +2816,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
               { type: "money", amount: 2 },
               { type: "money", amount: 3 },
             ],
-            encounter: "sumplete",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 1,
@@ -2841,7 +2841,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "sellable", itemId: "sell_silver_3" },
             rewards: [undefined, undefined],
-            encounter: "sumplete",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 4,
@@ -2909,7 +2909,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "tomb-key", wardKeyId: "junior_a_1" },
             endReward: { type: "hieroglyphFragment", hieroglyphId: "a2", pieceIndex: 3 },
             rewards: [undefined],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 2,
@@ -2985,7 +2985,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "tomb-key", wardKeyId: "expert_b_1" },
             endReward: { type: "hieroglyphFragment", hieroglyphId: "a7", pieceIndex: 2 },
             rewards: [undefined],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 2,
@@ -2993,7 +2993,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "money", amount: 2 },
             rewards: [undefined, undefined],
-            encounter: "balance-scale",
+            encounter: "futoshiki",
           },
           {
             pathPuzzles: 2,
@@ -3035,7 +3035,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
               { type: "money", amount: 2 },
               { type: "money", amount: 2 },
             ],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
         ],
         encounter: "sumplete",
@@ -3092,7 +3092,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "sellable", itemId: "sell_silver_4" },
             rewards: [undefined, undefined],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 2,
@@ -3100,7 +3100,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "sellable", itemId: "sell_silver_1" },
             rewards: [undefined, undefined],
-            encounter: "sumplete",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 2,
@@ -3124,7 +3124,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "sellable", itemId: "sell_silver_4" },
             rewards: [undefined, undefined],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 2,
@@ -3192,7 +3192,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "tomb-key", wardKeyId: "expert_b_1" },
             endReward: { type: "hieroglyphFragment", hieroglyphId: "p3", pieceIndex: 3 },
             rewards: [undefined],
-            encounter: "balance-scale",
+            encounter: "futoshiki",
           },
           {
             pathPuzzles: 1,
@@ -3209,7 +3209,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "hieroglyphFragment", hieroglyphId: "p12", pieceIndex: 2 },
             rewards: [undefined, undefined],
-            encounter: "sumplete",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 2,
@@ -3217,7 +3217,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "money", amount: 1 },
             rewards: [undefined, undefined],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 4,
@@ -3235,7 +3235,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             encounter: "arithmetic-reflex",
           },
         ],
-        encounter: "sumplete",
+        encounter: "lightbeam",
         mainEndReward: { type: "hieroglyphFragment", hieroglyphId: "art6", pieceIndex: 1 },
         rewards: [
           { type: "consumable", consumable: "bandage" },
@@ -3262,7 +3262,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
               { type: "money", amount: 1 },
               { type: "money", amount: 1 },
             ],
-            encounter: "balance-scale",
+            encounter: "futoshiki",
           },
           {
             pathPuzzles: 1,
@@ -3271,7 +3271,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "tomb-key", wardKeyId: "expert_b_2" },
             endReward: { type: "money", amount: 1 },
             rewards: [undefined],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 2,
@@ -3303,7 +3303,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "floor-key", color: "blue" },
             endReward: { type: "money", amount: 1 },
             rewards: [undefined],
-            encounter: "sumplete",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 2,
@@ -3355,7 +3355,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "tomb-key", wardKeyId: "expert_b_3" },
             endReward: { type: "money", amount: 1 },
             rewards: [undefined],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 2,
@@ -3422,7 +3422,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "tomb-key", wardKeyId: "expert_b_2" },
             endReward: { type: "hieroglyphFragment", hieroglyphId: "d3", pieceIndex: 3 },
             rewards: [undefined],
-            encounter: "sumplete",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 2,
@@ -3430,7 +3430,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "hieroglyphFragment", hieroglyphId: "a7", pieceIndex: 4 },
             rewards: [undefined, undefined],
-            encounter: "balance-scale",
+            encounter: "futoshiki",
           },
           {
             pathPuzzles: 2,
@@ -3484,7 +3484,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             encounter: "sumplete",
           },
         ],
-        encounter: "sumplete",
+        encounter: "lightbeam",
         corridorStraightness: 0.35,
         packing: 2,
         mainEndReward: { type: "hieroglyphFragment", hieroglyphId: "art3", pieceIndex: 2 },
@@ -3504,7 +3504,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
         exitOrStaircase: "exit",
         sideSections: [],
         entrance: { stairId: "expert_4:p3:wing0" },
-        encounter: "futoshiki",
+        encounter: "lightbeam",
         mainEndReward: { type: "hieroglyphFragment", hieroglyphId: "p5", pieceIndex: 4 },
         rewards: [
           { type: "money", amount: 2 },
@@ -3555,7 +3555,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "sellable", itemId: "sell_silver_5" },
             rewards: [undefined, undefined],
-            encounter: "sumplete",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 2,
@@ -3582,7 +3582,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             encounter: "futoshiki",
           },
         ],
-        encounter: "sumplete",
+        encounter: "lightbeam",
         mainEndReward: { type: "hieroglyphFragment", hieroglyphId: "a11", pieceIndex: 4 },
         rewards: [
           { type: "consumable", consumable: "bandage" },
@@ -3630,7 +3630,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "tomb-key", wardKeyId: "master_b_3" },
             endReward: { type: "mosaicPiece", tier: "master" },
             rewards: [{ type: "money", amount: 1 }],
-            encounter: "balance-scale",
+            encounter: "futoshiki",
           },
           {
             pathPuzzles: 1,
@@ -3656,7 +3656,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "hieroglyphFragment", hieroglyphId: "a3", pieceIndex: 0 },
             rewards: [{ type: "money", amount: 2 }],
-            encounter: "sumplete",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 1,
@@ -3675,7 +3675,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
               { type: "money", amount: 1 },
               { type: "money", amount: 2 },
             ],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 1,
@@ -3684,7 +3684,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "floor-key", color: "blue" },
             endReward: { type: "mosaicPiece", tier: "master" },
             rewards: [{ type: "money", amount: 2 }],
-            encounter: "sumplete",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 2,
@@ -3743,7 +3743,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "tomb-key", wardKeyId: "master_b_2" },
             endReward: { type: "hieroglyphFragment", hieroglyphId: "d6", pieceIndex: 0 },
             rewards: [{ type: "money", amount: 1 }],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 1,
@@ -3760,7 +3760,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "hieroglyphFragment", hieroglyphId: "a14", pieceIndex: 0 },
             rewards: [{ type: "money", amount: 2 }],
-            encounter: "sumplete",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 1,
@@ -3776,7 +3776,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "hieroglyphFragment", hieroglyphId: "a3", pieceIndex: 1 },
             rewards: [{ type: "money", amount: 2 }],
-            encounter: "balance-scale",
+            encounter: "futoshiki",
           },
           {
             pathPuzzles: 2,
@@ -3787,7 +3787,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
               { type: "money", amount: 3 },
               { type: "money", amount: 1 },
             ],
-            encounter: "balance-scale",
+            encounter: "futoshiki",
           },
           {
             pathPuzzles: 1,
@@ -3832,7 +3832,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
         exitOrStaircase: "exit",
         sideSections: [],
         entrance: { stairId: "master_1:p1:wing0" },
-        encounter: "futoshiki",
+        encounter: "lightbeam",
         mainEndReward: { type: "mosaicPiece", tier: "master" },
         rewards: [
           { type: "money", amount: 2 },
@@ -3870,7 +3870,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "floor-key", color: "red" },
             endReward: { type: "mosaicPiece", tier: "master" },
             rewards: [{ type: "money", amount: 2 }],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
             sideSections: [
               {
                 pathPuzzles: 1,
@@ -3890,7 +3890,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "tomb-key", wardKeyId: "master_b_2" },
             endReward: { type: "hieroglyphFragment", hieroglyphId: "a15", pieceIndex: 3 },
             rewards: [{ type: "money", amount: 3 }],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 1,
@@ -3898,7 +3898,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "mosaicPiece", tier: "master" },
             rewards: [{ type: "money", amount: 3 }],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 1,
@@ -3906,7 +3906,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "mosaicPiece", tier: "master" },
             rewards: [{ type: "money", amount: 1 }],
-            encounter: "sumplete",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 1,
@@ -3922,7 +3922,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "mosaicPiece", tier: "master" },
             rewards: [{ type: "money", amount: 3 }, undefined],
-            encounter: "sumplete",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 1,
@@ -3931,7 +3931,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "floor-key", color: "blue" },
             endReward: { type: "mosaicPiece", tier: "master" },
             rewards: [undefined],
-            encounter: "sumplete",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 2,
@@ -3950,7 +3950,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             encounter: "balance-scale",
           },
         ],
-        encounter: "balance-scale",
+        encounter: "futoshiki",
         mainEndReward: { type: "hieroglyphFragment", hieroglyphId: "a15", pieceIndex: 2 },
         rewards: [
           { type: "consumable", consumable: "bandage" },
@@ -4083,7 +4083,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "tomb-key", wardKeyId: "master_b_4" },
             endReward: { type: "mosaicPiece", tier: "master" },
             rewards: [undefined],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 1,
@@ -4108,7 +4108,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "hieroglyphFragment", hieroglyphId: "a1", pieceIndex: 1 },
             rewards: [undefined],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 2,
@@ -4116,7 +4116,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "mosaicPiece", tier: "master" },
             rewards: [undefined, undefined],
-            encounter: "balance-scale",
+            encounter: "futoshiki",
           },
           {
             pathPuzzles: 1,
@@ -4162,7 +4162,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
         exitOrStaircase: "exit",
         sideSections: [],
         entrance: { stairId: "master_2:p0:wing0" },
-        encounter: "futoshiki",
+        encounter: "lightbeam",
         mainEndReward: { type: "mosaicPiece", tier: "master" },
         rewards: [undefined, undefined, undefined, undefined, undefined, undefined],
       },
@@ -4181,7 +4181,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "tomb-key", wardKeyId: "master_b_1" },
             endReward: { type: "hieroglyphFragment", hieroglyphId: "a14", pieceIndex: 2 },
             rewards: [undefined],
-            encounter: "sumplete",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 1,
@@ -4205,7 +4205,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "hieroglyphFragment", hieroglyphId: "d10", pieceIndex: 0 },
             rewards: [undefined],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 2,
@@ -4213,7 +4213,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "mosaicPiece", tier: "master" },
             rewards: [undefined, undefined],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 1,
@@ -4222,7 +4222,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "floor-key", color: "blue" },
             endReward: { type: "mosaicPiece", tier: "master" },
             rewards: [undefined],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 2,
@@ -4238,10 +4238,10 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: { stairId: "master_2:p1:wing0" },
             gate: { type: "tomb-key", wardKeyId: "master_a_5" },
             rewards: [undefined],
-            encounter: "balance-scale",
+            encounter: "futoshiki",
           },
         ],
-        encounter: "sumplete",
+        encounter: "lightbeam",
         mainEndReward: { type: "hieroglyphFragment", hieroglyphId: "art15", pieceIndex: 0 },
         rewards: [
           { type: "consumable", consumable: "oil" },
@@ -4294,7 +4294,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
                 gate: { type: "floor-key", color: "green" },
                 endReward: { type: "mosaicPiece", tier: "master" },
                 rewards: [undefined],
-                encounter: "sumplete",
+                encounter: "lightbeam",
               },
             ],
           },
@@ -4321,7 +4321,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "mosaicPiece", tier: "master" },
             rewards: [undefined],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 1,
@@ -4346,7 +4346,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "floor-key", color: "blue" },
             endReward: { type: "mosaicPiece", tier: "master" },
             rewards: [undefined],
-            encounter: "sumplete",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 2,
@@ -4365,7 +4365,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             encounter: "balance-scale",
           },
         ],
-        encounter: "balance-scale",
+        encounter: "futoshiki",
         mainEndReward: { type: "hieroglyphFragment", hieroglyphId: "a3", pieceIndex: 3 },
         rewards: [
           { type: "consumable", consumable: "oil" },
@@ -4410,7 +4410,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "tomb-key", wardKeyId: "master_b_2" },
             endReward: { type: "hieroglyphFragment", hieroglyphId: "a1", pieceIndex: 3 },
             rewards: [undefined],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 1,
@@ -4451,7 +4451,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "floor-key", color: "blue" },
             endReward: { type: "mosaicPiece", tier: "master" },
             rewards: [undefined],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 2,
@@ -4472,7 +4472,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
               { type: "money", amount: 3 },
               { type: "money", amount: 3 },
             ],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
         ],
         encounter: "balance-scale",
@@ -4495,7 +4495,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
         exitOrStaircase: "exit",
         sideSections: [],
         entrance: { stairId: "master_2:p3:wing0" },
-        encounter: "futoshiki",
+        encounter: "lightbeam",
         mainEndReward: { type: "hieroglyphFragment", hieroglyphId: "a10", pieceIndex: 0 },
         rewards: [
           { type: "money", amount: 3 },
@@ -4557,7 +4557,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "floor-key", color: "blue" },
             endReward: { type: "mosaicPiece", tier: "master" },
             rewards: [undefined],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 2,
@@ -4597,7 +4597,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
         exitOrStaircase: "exit",
         sideSections: [],
         entrance: { stairId: "master_2:p4:wing0" },
-        encounter: "futoshiki",
+        encounter: "lightbeam",
         mainEndReward: { type: "mosaicPiece", tier: "master" },
         rewards: [undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined],
       },
@@ -4734,7 +4734,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "tomb-key", wardKeyId: "expert_a_1" },
             endReward: { type: "hieroglyphFragment", hieroglyphId: "d9", pieceIndex: 4 },
             rewards: [undefined],
-            encounter: "sumplete",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 1,
@@ -4750,7 +4750,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "hieroglyphFragment", hieroglyphId: "p14", pieceIndex: 3 },
             rewards: [undefined],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 1,
@@ -4775,7 +4775,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "floor-key", color: "blue" },
             endReward: { type: "sellable", itemId: "sell_gold_2" },
             rewards: [undefined],
-            encounter: "balance-scale",
+            encounter: "futoshiki",
           },
           {
             pathPuzzles: 2,
@@ -4813,7 +4813,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
         exitOrStaircase: "exit",
         sideSections: [],
         entrance: { stairId: "master_3:p1:wing0" },
-        encounter: "balance-scale",
+        encounter: "futoshiki",
         mainEndReward: { type: "sellable", itemId: "sell_gold_4" },
         rewards: [undefined, undefined, undefined, undefined, undefined, undefined, undefined],
       },
@@ -4847,7 +4847,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
                 gate: { type: "floor-key", color: "green" },
                 endReward: { type: "sellable", itemId: "sell_gold_1" },
                 rewards: [undefined],
-                encounter: "futoshiki",
+                encounter: "lightbeam",
               },
             ],
           },
@@ -4866,7 +4866,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "sellable", itemId: "sell_gold_2" },
             rewards: [undefined],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 1,
@@ -4890,7 +4890,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "sellable", itemId: "sell_gold_2" },
             rewards: [undefined, undefined],
-            encounter: "sumplete",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 1,
@@ -4963,7 +4963,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "tomb-key", wardKeyId: "master_b_1" },
             endReward: { type: "hieroglyphFragment", hieroglyphId: "art9", pieceIndex: 4 },
             rewards: [undefined],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 1,
@@ -4980,7 +4980,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "hieroglyphFragment", hieroglyphId: "a1", pieceIndex: 4 },
             rewards: [undefined],
-            encounter: "balance-scale",
+            encounter: "futoshiki",
           },
           {
             pathPuzzles: 1,
@@ -4988,7 +4988,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "hieroglyphFragment", hieroglyphId: "p14", pieceIndex: 4 },
             rewards: [undefined],
-            encounter: "balance-scale",
+            encounter: "futoshiki",
           },
           {
             pathPuzzles: 2,
@@ -5109,7 +5109,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "floor-key", color: "blue" },
             endReward: { type: "money", amount: 3 },
             rewards: [undefined],
-            encounter: "sumplete",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 2,
@@ -5149,7 +5149,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
         exitOrStaircase: "exit",
         sideSections: [],
         entrance: { stairId: "master_3:p4:wing0" },
-        encounter: "balance-scale",
+        encounter: "futoshiki",
         mainEndReward: { type: "money", amount: 3 },
         rewards: [undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined],
       },
@@ -5170,7 +5170,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "tomb-key", wardKeyId: "master_b_2" },
             endReward: { type: "hieroglyphFragment", hieroglyphId: "art11", pieceIndex: 2 },
             rewards: [undefined],
-            encounter: "balance-scale",
+            encounter: "futoshiki",
           },
           {
             pathPuzzles: 1,
@@ -5276,7 +5276,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "hieroglyphFragment", hieroglyphId: "d5", pieceIndex: 2 },
             rewards: [undefined],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 1,
@@ -5301,7 +5301,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "floor-key", color: "blue" },
             endReward: { type: "money", amount: 1 },
             rewards: [undefined],
-            encounter: "sumplete",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 2,
@@ -5320,7 +5320,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             encounter: "balance-scale",
           },
         ],
-        encounter: "sumplete",
+        encounter: "lightbeam",
         mainEndReward: { type: "hieroglyphFragment", hieroglyphId: "p15", pieceIndex: 2 },
         rewards: [
           { type: "consumable", consumable: "trapTool" },
@@ -5338,7 +5338,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
         exitOrStaircase: "exit",
         sideSections: [],
         entrance: { stairId: "master_4:p1:wing0" },
-        encounter: "sumplete",
+        encounter: "lightbeam",
         mainEndReward: { type: "money", amount: 1 },
         rewards: [undefined, undefined, undefined, undefined, undefined, undefined],
       },
@@ -5390,7 +5390,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "money", amount: 1 },
             rewards: [undefined],
-            encounter: "sumplete",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 2,
@@ -5398,7 +5398,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "sellable", itemId: "sell_gold_2" },
             rewards: [undefined, undefined],
-            encounter: "sumplete",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 1,
@@ -5444,7 +5444,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
         exitOrStaircase: "exit",
         sideSections: [],
         entrance: { stairId: "master_4:p2:wing0" },
-        encounter: "balance-scale",
+        encounter: "futoshiki",
         mainEndReward: { type: "money", amount: 1 },
         rewards: [undefined, undefined, undefined, undefined, undefined, undefined],
       },
@@ -5470,7 +5470,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "tomb-key", wardKeyId: "master_b_4" },
             endReward: { type: "hieroglyphFragment", hieroglyphId: "art11", pieceIndex: 5 },
             rewards: [undefined],
-            encounter: "sumplete",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 1,
@@ -5494,7 +5494,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "sellable", itemId: "sell_gold_3" },
             rewards: [undefined, undefined],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 1,
@@ -5503,7 +5503,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "floor-key", color: "blue" },
             endReward: { type: "money", amount: 1 },
             rewards: [undefined],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 2,
@@ -5654,7 +5654,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
         exitOrStaircase: "exit",
         sideSections: [],
         entrance: { stairId: "master_4:p4:wing0" },
-        encounter: "futoshiki",
+        encounter: "lightbeam",
         mainEndReward: { type: "money", amount: 1 },
         rewards: [undefined, undefined, undefined, undefined, undefined, undefined, undefined],
       },
@@ -5693,7 +5693,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "tomb-key", wardKeyId: "wizard_c_1" },
             endReward: { type: "hieroglyphFragment", hieroglyphId: "d14", pieceIndex: 0 },
             rewards: [{ type: "money", amount: 3 }],
-            encounter: "sumplete",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 1,
@@ -5702,7 +5702,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "tomb-key", wardKeyId: "wizard_c_2" },
             endReward: { type: "hieroglyphFragment", hieroglyphId: "d14", pieceIndex: 1 },
             rewards: [{ type: "money", amount: 3 }],
-            encounter: "balance-scale",
+            encounter: "futoshiki",
           },
           {
             pathPuzzles: 1,
@@ -5797,7 +5797,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
         end: "treasure",
         exitOrStaircase: { stairId: "wizard_1:p1:main0" },
         sideSections: [],
-        encounter: "futoshiki",
+        encounter: "lightbeam",
         mainEndReward: { type: "hieroglyphFragment", hieroglyphId: "a9", pieceIndex: 0 },
         rewards: [
           { type: "consumable", consumable: "bandage" },
@@ -5823,7 +5823,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "floor-key", color: "red" },
             endReward: { type: "mosaicPiece", tier: "wizard" },
             rewards: [{ type: "money", amount: 1 }],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
             sideSections: [
               {
                 pathPuzzles: 1,
@@ -5843,7 +5843,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "floor-key", color: "blue" },
             endReward: { type: "mosaicPiece", tier: "wizard" },
             rewards: [{ type: "money", amount: 2 }],
-            encounter: "sumplete",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 2,
@@ -5873,7 +5873,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: { stairId: "wizard_1:p1:wing0" },
             gate: { type: "tomb-key", wardKeyId: "wizard_a_1" },
             rewards: [{ type: "money", amount: 2 }],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 2,
@@ -5914,7 +5914,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
         exitOrStaircase: "exit",
         sideSections: [],
         entrance: { stairId: "wizard_1:p1:wing0" },
-        encounter: "balance-scale",
+        encounter: "futoshiki",
         mainEndReward: { type: "mosaicPiece", tier: "wizard" },
         rewards: [
           { type: "money", amount: 3 },
@@ -6031,7 +6031,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "tomb-key", wardKeyId: "wizard_a_4" },
             endReward: { type: "mosaicPiece", tier: "wizard" },
             rewards: [undefined],
-            encounter: "balance-scale",
+            encounter: "futoshiki",
           },
         ],
         entrance: { stairId: "wizard_1:p2:main0" },
@@ -6055,7 +6055,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
         exitOrStaircase: "exit",
         sideSections: [],
         entrance: { stairId: "wizard_1:p2:wing0" },
-        encounter: "futoshiki",
+        encounter: "lightbeam",
         mainEndReward: { type: "mosaicPiece", tier: "wizard" },
         rewards: [undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined],
       },
@@ -6101,7 +6101,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "floor-key", color: "blue" },
             endReward: { type: "mosaicPiece", tier: "wizard" },
             rewards: [undefined],
-            encounter: "balance-scale",
+            encounter: "futoshiki",
           },
           {
             pathPuzzles: 2,
@@ -6131,7 +6131,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: { stairId: "wizard_1:p3:wing0" },
             gate: { type: "tomb-key", wardKeyId: "wizard_a_1" },
             rewards: [undefined],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 1,
@@ -6140,7 +6140,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "tomb-key", wardKeyId: "wizard_a_3" },
             endReward: { type: "mosaicPiece", tier: "wizard" },
             rewards: [undefined],
-            encounter: "balance-scale",
+            encounter: "futoshiki",
           },
           {
             pathPuzzles: 1,
@@ -6149,7 +6149,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "tomb-key", wardKeyId: "wizard_a_4" },
             endReward: { type: "mosaicPiece", tier: "wizard" },
             rewards: [undefined],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
         ],
         entrance: { stairId: "wizard_1:p3:main0" },
@@ -6203,7 +6203,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "tomb-key", wardKeyId: "wizard_c_1" },
             endReward: { type: "hieroglyphFragment", hieroglyphId: "p6", pieceIndex: 0 },
             rewards: [undefined],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 1,
@@ -6282,7 +6282,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
         exitOrStaircase: "exit",
         sideSections: [],
         entrance: { stairId: "wizard_2:p0:wing0" },
-        encounter: "futoshiki",
+        encounter: "lightbeam",
         mainEndReward: { type: "mosaicPiece", tier: "wizard" },
         rewards: [undefined, undefined, undefined, undefined, undefined, undefined, undefined],
       },
@@ -6320,7 +6320,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "floor-key", color: "red" },
             endReward: { type: "mosaicPiece", tier: "wizard" },
             rewards: [undefined],
-            encounter: "balance-scale",
+            encounter: "futoshiki",
             sideSections: [
               {
                 pathPuzzles: 1,
@@ -6340,7 +6340,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "floor-key", color: "blue" },
             endReward: { type: "mosaicPiece", tier: "wizard" },
             rewards: [undefined],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 2,
@@ -6464,7 +6464,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "tomb-key", wardKeyId: "wizard_c_1" },
             endReward: { type: "hieroglyphFragment", hieroglyphId: "d8", pieceIndex: 0 },
             rewards: [undefined],
-            encounter: "sumplete",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 1,
@@ -6473,7 +6473,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "tomb-key", wardKeyId: "expert_b_1" },
             endReward: { type: "money", amount: 3 },
             rewards: [undefined],
-            encounter: "sumplete",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 1,
@@ -6512,7 +6512,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: { stairId: "wizard_2:p2:wing0" },
             gate: { type: "tomb-key", wardKeyId: "wizard_a_1" },
             rewards: [undefined],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 2,
@@ -6543,7 +6543,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
         exitOrStaircase: "exit",
         sideSections: [],
         entrance: { stairId: "wizard_2:p2:wing0" },
-        encounter: "futoshiki",
+        encounter: "lightbeam",
         mainEndReward: { type: "mosaicPiece", tier: "wizard" },
         rewards: [undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined],
       },
@@ -6619,7 +6619,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: { stairId: "wizard_2:p3:wing0" },
             gate: { type: "tomb-key", wardKeyId: "wizard_a_1" },
             rewards: [undefined],
-            encounter: "balance-scale",
+            encounter: "futoshiki",
           },
           {
             pathPuzzles: 1,
@@ -6738,7 +6738,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "tomb-key", wardKeyId: "wizard_a_3" },
             endReward: { type: "mosaicPiece", tier: "wizard" },
             rewards: [undefined],
-            encounter: "balance-scale",
+            encounter: "futoshiki",
           },
           {
             pathPuzzles: 1,
@@ -6810,7 +6810,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "tomb-key", wardKeyId: "wizard_c_1" },
             endReward: { type: "sellable", itemId: "sell_divine_5" },
             rewards: [undefined],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 1,
@@ -6828,7 +6828,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "floor-key", color: "blue" },
             endReward: { type: "sellable", itemId: "sell_divine_2" },
             rewards: [undefined],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 2,
@@ -6858,7 +6858,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: { stairId: "wizard_3:p0:wing0" },
             gate: { type: "tomb-key", wardKeyId: "wizard_a_1" },
             rewards: [undefined],
-            encounter: "balance-scale",
+            encounter: "futoshiki",
           },
           {
             pathPuzzles: 2,
@@ -6878,7 +6878,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
           },
         ],
         entrance: { stairId: "wizard_3:p0:main0" },
-        encounter: "futoshiki",
+        encounter: "lightbeam",
         packing: 1.6,
         mainEndReward: { type: "hieroglyphFragment", hieroglyphId: "d8", pieceIndex: 2 },
         rewards: [undefined, undefined, undefined, undefined, undefined, undefined, undefined],
@@ -6890,7 +6890,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
         exitOrStaircase: "exit",
         sideSections: [],
         entrance: { stairId: "wizard_3:p0:wing0" },
-        encounter: "futoshiki",
+        encounter: "lightbeam",
         mainEndReward: { type: "money", amount: 3 },
         rewards: [undefined, undefined, undefined, undefined, undefined, undefined, undefined],
       },
@@ -6902,7 +6902,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
         end: "treasure",
         exitOrStaircase: { stairId: "wizard_3:p1:main0" },
         sideSections: [],
-        encounter: "balance-scale",
+        encounter: "futoshiki",
         mainEndReward: { type: "hieroglyphFragment", hieroglyphId: "a12", pieceIndex: 1 },
         rewards: [
           { type: "consumable", consumable: "bandage" },
@@ -6927,7 +6927,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "floor-key", color: "red" },
             endReward: { type: "money", amount: 3 },
             rewards: [undefined],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
             sideSections: [
               {
                 pathPuzzles: 1,
@@ -7020,7 +7020,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
         end: "treasure",
         exitOrStaircase: { stairId: "wizard_3:p2:main0" },
         sideSections: [],
-        encounter: "futoshiki",
+        encounter: "lightbeam",
         mainEndReward: { type: "hieroglyphFragment", hieroglyphId: "a12", pieceIndex: 2 },
         rewards: [
           { type: "consumable", consumable: "oil" },
@@ -7046,7 +7046,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "tomb-key", wardKeyId: "wizard_c_1" },
             endReward: { type: "hieroglyphFragment", hieroglyphId: "d11", pieceIndex: 0 },
             rewards: [undefined],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 1,
@@ -7227,7 +7227,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "tomb-key", wardKeyId: "wizard_a_3" },
             endReward: { type: "money", amount: 3 },
             rewards: [undefined],
-            encounter: "sumplete",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 1,
@@ -7236,11 +7236,11 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "tomb-key", wardKeyId: "wizard_a_4" },
             endReward: { type: "money", amount: 3 },
             rewards: [undefined],
-            encounter: "balance-scale",
+            encounter: "futoshiki",
           },
         ],
         entrance: { stairId: "wizard_3:p3:main0" },
-        encounter: "futoshiki",
+        encounter: "lightbeam",
         packing: 1.6,
         mainEndReward: { type: "hieroglyphFragment", hieroglyphId: "a4", pieceIndex: 2 },
         rewards: [undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined],
@@ -7346,7 +7346,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "tomb-key", wardKeyId: "wizard_a_4" },
             endReward: { type: "money", amount: 3 },
             rewards: [undefined],
-            encounter: "sumplete",
+            encounter: "lightbeam",
           },
         ],
         entrance: { stairId: "wizard_3:p4:main0" },
@@ -7361,7 +7361,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
         exitOrStaircase: "exit",
         sideSections: [],
         entrance: { stairId: "wizard_3:p4:wing0" },
-        encounter: "balance-scale",
+        encounter: "futoshiki",
         mainEndReward: { type: "money", amount: 3 },
         rewards: [undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined],
       },
@@ -7407,7 +7407,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "floor-key", color: "blue" },
             endReward: { type: "hieroglyphFragment", hieroglyphId: "d8", pieceIndex: 6 },
             rewards: [undefined],
-            encounter: "sumplete",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 2,
@@ -7599,7 +7599,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
         exitOrStaircase: "exit",
         sideSections: [],
         entrance: { stairId: "wizard_4:p0:wing0" },
-        encounter: "futoshiki",
+        encounter: "lightbeam",
         mainEndReward: { type: "money", amount: 2 },
         rewards: [undefined, undefined, undefined, undefined, undefined, undefined, undefined],
       },
@@ -7611,7 +7611,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
         end: "treasure",
         exitOrStaircase: { stairId: "wizard_4:p1:main0" },
         sideSections: [],
-        encounter: "futoshiki",
+        encounter: "lightbeam",
         mainEndReward: { type: "hieroglyphFragment", hieroglyphId: "a12", pieceIndex: 3 },
         rewards: [
           { type: "consumable", consumable: "bandage" },
@@ -7656,7 +7656,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "floor-key", color: "blue" },
             endReward: { type: "money", amount: 2 },
             rewards: [undefined],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 2,
@@ -7686,7 +7686,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: { stairId: "wizard_4:p1:wing0" },
             gate: { type: "tomb-key", wardKeyId: "wizard_a_1" },
             rewards: [undefined],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 2,
@@ -7706,7 +7706,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
           },
         ],
         entrance: { stairId: "wizard_4:p1:main0" },
-        encounter: "balance-scale",
+        encounter: "futoshiki",
         corridorStraightness: 0.35,
         mainEndReward: { type: "hieroglyphFragment", hieroglyphId: "d11", pieceIndex: 3 },
         rewards: [undefined, undefined, undefined, undefined, undefined, undefined, undefined],
@@ -7756,7 +7756,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "tomb-key", wardKeyId: "wizard_c_2" },
             endReward: { type: "money", amount: 2 },
             rewards: [undefined],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 1,
@@ -7815,7 +7815,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
           },
         ],
         entrance: { stairId: "wizard_4:p2:main0" },
-        encounter: "balance-scale",
+        encounter: "futoshiki",
         corridorStraightness: 0.35,
         mainEndReward: { type: "hieroglyphFragment", hieroglyphId: "d7", pieceIndex: 4 },
         rewards: [undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined],
@@ -7827,7 +7827,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
         exitOrStaircase: "exit",
         sideSections: [],
         entrance: { stairId: "wizard_4:p2:wing0" },
-        encounter: "balance-scale",
+        encounter: "futoshiki",
         mainEndReward: { type: "money", amount: 2 },
         rewards: [undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined],
       },
@@ -7880,7 +7880,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "tomb-key", wardKeyId: "wizard_c_1" },
             endReward: { type: "money", amount: 2 },
             rewards: [undefined],
-            encounter: "balance-scale",
+            encounter: "futoshiki",
           },
           {
             pathPuzzles: 1,
@@ -7961,7 +7961,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
         exitOrStaircase: "exit",
         sideSections: [],
         entrance: { stairId: "wizard_4:p3:wing0" },
-        encounter: "sumplete",
+        encounter: "lightbeam",
         mainEndReward: { type: "money", amount: 2 },
         rewards: [undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined],
       },
@@ -7973,7 +7973,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
         end: "treasure",
         exitOrStaircase: { stairId: "wizard_4:p4:main0" },
         sideSections: [],
-        encounter: "balance-scale",
+        encounter: "futoshiki",
         mainEndReward: { type: "hieroglyphFragment", hieroglyphId: "a9", pieceIndex: 5 },
         rewards: [
           { type: "consumable", consumable: "bandage" },
@@ -8000,7 +8000,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "floor-key", color: "blue" },
             endReward: { type: "hieroglyphFragment", hieroglyphId: "d11", pieceIndex: 5 },
             rewards: [undefined],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 2,
@@ -8052,7 +8052,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
           },
         ],
         entrance: { stairId: "wizard_4:p4:main0" },
-        encounter: "futoshiki",
+        encounter: "lightbeam",
         mainEndReward: { type: "hieroglyphFragment", hieroglyphId: "a12", pieceIndex: 4 },
         rewards: [undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined],
       },
@@ -8063,7 +8063,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
         exitOrStaircase: "exit",
         sideSections: [],
         entrance: { stairId: "wizard_4:p4:wing0" },
-        encounter: "futoshiki",
+        encounter: "lightbeam",
         mainEndReward: { type: "money", amount: 2 },
         rewards: [undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined],
       },
@@ -8148,7 +8148,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "tomb-key", wardKeyId: "wizard_a_3" },
             endReward: { type: "money", amount: 2 },
             rewards: [undefined],
-            encounter: "futoshiki",
+            encounter: "lightbeam",
           },
           {
             pathPuzzles: 1,

--- a/src/mods/puzzle/app/index.ts
+++ b/src/mods/puzzle/app/index.ts
@@ -5,6 +5,7 @@ import { isModEnabled } from "@/mods/registeredMods"
 // puzzle's app entrypoint (side-effect): the non-gating puzzle families.
 import "./sumplete/plugin"
 import "./futoshiki/plugin"
+import "./lightbeam/plugin"
 import "./crocodile/plugin"
 import "./balanceScale/plugin"
 

--- a/src/mods/puzzle/app/lightbeam/LightbeamBoard.stories.tsx
+++ b/src/mods/puzzle/app/lightbeam/LightbeamBoard.stories.tsx
@@ -1,0 +1,76 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import { useState } from "react"
+import { generateLightbeam } from "@/mods/puzzle/game/lightbeam/generateLightbeam"
+import { LIGHTBEAM_CONFIG } from "@/mods/puzzle/game/lightbeam/lightbeamConfig"
+import { createLightbeamState, cycleLightbeamPiece } from "@/mods/puzzle/game/lightbeam/lightbeamState"
+import { buildLightbeamHint } from "./lightbeamHint"
+import { LightbeamBoard } from "./LightbeamBoard"
+
+const meta = {
+  title: "Puzzle/LightbeamBoard",
+  component: LightbeamBoard,
+  parameters: {
+    layout: "centered",
+    backgrounds: { default: "dungeon", values: [{ name: "dungeon", value: "#110d08" }] },
+  },
+} satisfies Meta<typeof LightbeamBoard>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+const board = (difficulty: keyof typeof LIGHTBEAM_CONFIG, seed: number) => {
+  const { size, ...options } = LIGHTBEAM_CONFIG[difficulty]
+  return generateLightbeam(size, seed, options)
+}
+
+const starter = board("starter", 1)
+const expert = board("expert", 2)
+const wizard = board("wizard", 4)
+
+/** How the board opens: dark, with the beam running out somewhere it should not. */
+export const Starter: Story = { args: { puzzle: starter, states: starter.initial, onCycle: () => {} } }
+
+/** The same board answered — the beam bends the whole way and the shrine takes the light. */
+export const Solved: Story = { args: { puzzle: starter, states: starter.solution, onCycle: () => {} } }
+
+/** Sliding pieces and a decoy. A vacant stop keeps its dashed outline, so its track shows before it is tapped. */
+export const Expert: Story = { args: { puzzle: expert, states: expert.initial, onCycle: () => {} } }
+
+/** The widest board the family ships. Seven squares still measure a thumb across on a 360px screen. */
+export const Wizard: Story = { args: { puzzle: wizard, states: wizard.initial, onCycle: () => {} } }
+
+/** Playable, so the beam can be watched moving. Each tap cycles one piece. */
+export const Playable: Story = {
+  args: { puzzle: expert, states: expert.initial, onCycle: () => {} },
+  render: () => {
+    const [state, setState] = useState(() => createLightbeamState(expert))
+    return (
+      <LightbeamBoard
+        puzzle={expert}
+        states={state.states}
+        onCycle={piece => setState(prev => cycleLightbeamPiece(prev, expert, piece))}
+      />
+    )
+  },
+}
+
+/** The board with the hint's piece and beam lit — the state after pressing Hint. */
+export const WithHint: Story = {
+  args: { puzzle: starter, states: starter.initial, onCycle: () => {} },
+  render: () => {
+    const [state, setState] = useState(() => createLightbeamState(starter))
+    const hint = buildLightbeamHint(starter, state.states)
+    return (
+      <div className="flex flex-col items-center gap-3">
+        <LightbeamBoard
+          puzzle={starter}
+          states={state.states}
+          highlighted={hint?.cells}
+          litBeam={hint?.beam}
+          onCycle={piece => setState(prev => cycleLightbeamPiece(prev, starter, piece))}
+        />
+        <p className="text-sm text-amber-300">{hint ? hint.key : "lit"}</p>
+      </div>
+    )
+  },
+}

--- a/src/mods/puzzle/app/lightbeam/LightbeamBoard.tsx
+++ b/src/mods/puzzle/app/lightbeam/LightbeamBoard.tsx
@@ -1,0 +1,282 @@
+import clsx from "clsx"
+import type { FC, ReactNode } from "react"
+import {
+  cellKey,
+  opposite,
+  pieceCells,
+  pieceOccupant,
+  traceBeam,
+  type BeamSegment,
+  type Blocker,
+  type CellRef,
+  type Direction,
+  type LightbeamPuzzleData,
+  type MirrorFace,
+} from "@/mods/puzzle/game/lightbeam/beam"
+
+type Props = {
+  puzzle: LightbeamPuzzleData
+  /** Which state each movable piece is in — the whole of the player's answer. */
+  states: readonly number[]
+  /** Cell keys ("row,col") the current hint talks about. */
+  highlighted?: ReadonlySet<string>
+  /** The stretch of beam the current hint is about, drawn over the rest. */
+  litBeam?: BeamSegment[]
+  onCycle: (piece: number) => void
+}
+
+/** What to draw in a cell, once the fixed pieces and the player's settings are both accounted for. */
+type CellView =
+  | { kind: "empty" }
+  | { kind: "sun"; facing: Direction }
+  | { kind: "shrine" }
+  | { kind: "mirror"; face: MirrorFace; piece?: number }
+  | { kind: "wall"; piece?: number }
+  /**
+   * A stop a sliding piece is not currently standing on. It carries a ghost of the piece rather than
+   * being merely outlined: an empty dashed square says something can come here, which leaves the player
+   * to find out what by tapping. Whether the thing that arrives will bend the light or swallow it is the
+   * whole difference between the two sliding pieces, so the track says which.
+   */
+  | { kind: "stop"; piece: number; ghost: Blocker }
+
+const viewGrid = (puzzle: LightbeamPuzzleData, states: readonly number[]): CellView[][] => {
+  const grid: CellView[][] = Array.from({ length: puzzle.size }, () =>
+    Array.from({ length: puzzle.size }, (): CellView => ({ kind: "empty" }))
+  )
+  puzzle.movable.forEach((piece, index) => {
+    for (const at of pieceCells(piece))
+      grid[at.row][at.col] = { kind: "stop", piece: index, ghost: pieceOccupant(piece, 0).blocks }
+  })
+  for (const piece of puzzle.fixed)
+    grid[piece.at.row][piece.at.col] = piece.kind === "mirror" ? { kind: "mirror", face: piece.face } : { kind: "wall" }
+  puzzle.movable.forEach((piece, index) => {
+    const { at, blocks } = pieceOccupant(piece, states[index])
+    grid[at.row][at.col] =
+      blocks.kind === "mirror" ? { kind: "mirror", face: blocks.face, piece: index } : { kind: "wall", piece: index }
+  })
+  grid[puzzle.shrine.row][puzzle.shrine.col] = { kind: "shrine" }
+  grid[puzzle.sun.at.row][puzzle.sun.at.col] = { kind: "sun", facing: puzzle.sun.facing }
+  return grid
+}
+
+// ---------------------------------------------------------------------------------------------------
+// Glyphs. Drawn rather than lettered, and each on its own 100-unit square so it scales with the cell
+// instead of with the screen — a 5-wide board and a 7-wide one then read the same (PUZZLE_FAMILIES.md
+// P2: the board carries no language).
+// ---------------------------------------------------------------------------------------------------
+
+const Glyph: FC<{ children: ReactNode }> = ({ children }) => (
+  <svg viewBox="0 0 100 100" className="size-full overflow-visible">
+    {children}
+  </svg>
+)
+
+/** A quarter-turn mirror: the diagonal it sits on, drawn as the polished edge it is. */
+const Mirror: FC<{ face: MirrorFace; movable: boolean }> = ({ face, movable }) => (
+  <Glyph>
+    <line
+      x1={face === "/" ? 18 : 18}
+      y1={face === "/" ? 82 : 18}
+      x2={face === "/" ? 82 : 82}
+      y2={face === "/" ? 18 : 82}
+      strokeWidth={14}
+      strokeLinecap="round"
+      className={movable ? "stroke-sky-200" : "stroke-stone-400"}
+    />
+  </Glyph>
+)
+
+const Wall: FC<{ movable: boolean }> = ({ movable }) => (
+  <Glyph>
+    <rect x={10} y={10} width={80} height={80} rx={8} className={movable ? "fill-stone-500" : "fill-stone-600"} />
+    {/* Three courses, offset like real coursing, so a block of stone never reads as a shaded empty square. */}
+    <line x1={10} y1={37} x2={90} y2={37} strokeWidth={4} className="stroke-stone-800/70" />
+    <line x1={10} y1={64} x2={90} y2={64} strokeWidth={4} className="stroke-stone-800/70" />
+    <line x1={44} y1={10} x2={44} y2={37} strokeWidth={4} className="stroke-stone-800/70" />
+    <line x1={66} y1={37} x2={66} y2={64} strokeWidth={4} className="stroke-stone-800/70" />
+    <line x1={32} y1={64} x2={32} y2={90} strokeWidth={4} className="stroke-stone-800/70" />
+  </Glyph>
+)
+
+const NOSE: Record<Direction, string> = {
+  up: "50,4 66,26 34,26",
+  down: "50,96 66,74 34,74",
+  left: "4,50 26,66 26,34",
+  right: "96,50 74,66 74,34",
+}
+
+const SunDisc: FC<{ facing: Direction }> = ({ facing }) => (
+  <Glyph>
+    <circle cx={50} cy={50} r={30} className="fill-amber-300" />
+    <circle cx={50} cy={50} r={30} className="fill-amber-100/40" />
+    {/* The nose says which way the light leaves, which is half of what the player has to know. */}
+    <polygon points={NOSE[facing]} className="fill-amber-300" />
+  </Glyph>
+)
+
+/** A niche cut in the wall. Dark until the light arrives, then it is the whole point of the board. */
+const Shrine: FC<{ lit: boolean }> = ({ lit }) => (
+  <Glyph>
+    <path
+      d="M22 92 L22 46 A28 28 0 0 1 78 46 L78 92 Z"
+      strokeWidth={8}
+      className={clsx(lit ? "fill-amber-200 stroke-amber-100" : "fill-stone-900 stroke-stone-400")}
+    />
+    {lit && <circle cx={50} cy={56} r={40} className="fill-amber-200/30" />}
+  </Glyph>
+)
+
+// ---------------------------------------------------------------------------------------------------
+// The beam. Drawn over the pieces rather than under them: light does touch the mirror it bounces off,
+// and a beam that stopped under a glyph would read as a beam that stopped short.
+// ---------------------------------------------------------------------------------------------------
+
+/** The midpoint of the cell edge a beam travelling `direction` crosses on its way out. */
+const sidePoint = (at: CellRef, direction: Direction): [number, number] => {
+  if (direction === "up") return [at.col + 0.5, at.row]
+  if (direction === "down") return [at.col + 0.5, at.row + 1]
+  if (direction === "left") return [at.col, at.row + 0.5]
+  return [at.col + 1, at.row + 0.5]
+}
+
+const segmentPoints = (segment: BeamSegment): string => {
+  const from = sidePoint(segment.at, opposite(segment.enter))
+  const centre: [number, number] = [segment.at.col + 0.5, segment.at.row + 0.5]
+  const points = segment.exit ? [from, centre, sidePoint(segment.at, segment.exit)] : [from, centre]
+  return points.map(([x, y]) => `${x},${y}`).join(" ")
+}
+
+const BeamLayer: FC<{ puzzle: LightbeamPuzzleData; states: readonly number[]; lit?: BeamSegment[] }> = ({
+  puzzle,
+  states,
+  lit,
+}) => {
+  const walk = traceBeam(puzzle, states)
+  const highlighted = new Set((lit ?? []).map(segment => `${cellKey(segment.at)},${segment.enter}`))
+  const last = walk.path[walk.path.length - 1]
+  return (
+    <svg
+      viewBox={`0 0 ${puzzle.size} ${puzzle.size}`}
+      className="pointer-events-none absolute inset-0 size-full mix-blend-screen"
+      aria-hidden
+    >
+      <defs>
+        <filter id="lightbeam-haze" x="-50%" y="-50%" width="200%" height="200%">
+          <feGaussianBlur stdDeviation="0.1" />
+        </filter>
+      </defs>
+      {/* Two passes: a blurred haze under a thin core. One flat line reads as a wire someone drew, and a
+          hard-edged haze reads as a tan bar — the blur and the round joins are what make it light. */}
+      <g filter="url(#lightbeam-haze)">
+        {walk.path.map(segment => (
+          <polyline
+            key={`haze:${cellKey(segment.at)},${segment.enter}`}
+            points={segmentPoints(segment)}
+            fill="none"
+            strokeWidth={0.26}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="stroke-amber-400/35"
+          />
+        ))}
+      </g>
+      {walk.path.map(segment => {
+        const key = `${cellKey(segment.at)},${segment.enter}`
+        return (
+          <polyline
+            key={key}
+            points={segmentPoints(segment)}
+            fill="none"
+            strokeWidth={0.08}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className={highlighted.has(key) ? "stroke-white" : "stroke-amber-200"}
+          />
+        )
+      })}
+      {/* Where the light ends, marked — otherwise a beam that stops short reads as a drawing fault. */}
+      {walk.end === "absorbed" && last && (
+        <circle
+          cx={sidePoint(last.at, opposite(last.enter))[0]}
+          cy={sidePoint(last.at, opposite(last.enter))[1]}
+          r={0.16}
+          className="fill-orange-400/70"
+        />
+      )}
+      {walk.end === "escapes" && last?.exit && (
+        <circle
+          cx={sidePoint(last.at, last.exit)[0]}
+          cy={sidePoint(last.at, last.exit)[1]}
+          r={0.12}
+          className="fill-amber-200/60"
+        />
+      )}
+    </svg>
+  )
+}
+
+// ---------------------------------------------------------------------------------------------------
+
+const cellCls = (view: CellView, state: { lit: boolean; movable: boolean }) =>
+  clsx("relative flex aspect-square items-center justify-center rounded bg-stone-800 p-[8%] transition-colors", {
+    // Movable pieces have to read as movable at a glance, and a vacant stop has to read as somewhere a
+    // piece can go rather than as an empty square (design doc §8).
+    "ring-1 ring-amber-400/50": state.movable && view.kind !== "stop" && !state.lit,
+    "outline-2 -outline-offset-2 outline-stone-500/70 outline-dashed": view.kind === "stop" && !state.lit,
+    "ring-2 ring-sky-300": state.lit,
+  })
+
+export const LightbeamBoard: FC<Props> = ({ puzzle, states, highlighted, litBeam, onCycle }) => {
+  const { size } = puzzle
+  const grid = viewGrid(puzzle, states)
+  const solved = traceBeam(puzzle, states).end === "lit"
+  return (
+    <div className="relative aspect-square w-full max-w-[min(56vh,26rem)] select-none">
+      <div
+        className="grid size-full gap-px"
+        style={{
+          gridTemplateColumns: `repeat(${size}, minmax(0, 1fr))`,
+          gridTemplateRows: `repeat(${size}, minmax(0, 1fr))`,
+        }}
+      >
+        {grid.map((row, rowIndex) =>
+          row.map((view, colIndex) => {
+            const key = cellKey({ row: rowIndex, col: colIndex })
+            const piece = "piece" in view ? view.piece : undefined
+            const className = cellCls(view, {
+              lit: highlighted?.has(key) ?? false,
+              movable: piece !== undefined,
+            })
+            const body =
+              view.kind === "mirror" ? (
+                <Mirror face={view.face} movable={view.piece !== undefined} />
+              ) : view.kind === "wall" ? (
+                <Wall movable={view.piece !== undefined} />
+              ) : view.kind === "sun" ? (
+                <SunDisc facing={view.facing} />
+              ) : view.kind === "shrine" ? (
+                <Shrine lit={solved} />
+              ) : view.kind === "stop" ? (
+                <span className="size-full opacity-25">
+                  {view.ghost.kind === "mirror" ? <Mirror face={view.ghost.face} movable /> : <Wall movable />}
+                </span>
+              ) : null
+            // Every cell a piece can stand in is tappable, vacant stops included: tapping where you want
+            // it to go is the same gesture as tapping the piece, and it doubles the target.
+            return piece === undefined ? (
+              <div key={key} className={className}>
+                {body}
+              </div>
+            ) : (
+              <button key={key} onClick={() => onCycle(piece)} className={className}>
+                {body}
+              </button>
+            )
+          })
+        )}
+      </div>
+      <BeamLayer puzzle={puzzle} states={states} lit={litBeam} />
+    </div>
+  )
+}

--- a/src/mods/puzzle/app/lightbeam/LightbeamBoard.tsx
+++ b/src/mods/puzzle/app/lightbeam/LightbeamBoard.tsx
@@ -221,10 +221,16 @@ const BeamLayer: FC<{ puzzle: LightbeamPuzzleData; states: readonly number[]; li
 const cellCls = (view: CellView, state: { lit: boolean; movable: boolean }) =>
   clsx("relative flex aspect-square items-center justify-center rounded bg-stone-800 p-[8%] transition-colors", {
     // Movable pieces have to read as movable at a glance, and a vacant stop has to read as somewhere a
-    // piece can go rather than as an empty square (design doc §8).
+    // piece can go rather than as an empty square (design doc §9).
     "ring-1 ring-amber-400/50": state.movable && view.kind !== "stop" && !state.lit,
     "outline-2 -outline-offset-2 outline-stone-500/70 outline-dashed": view.kind === "stop" && !state.lit,
     "ring-2 ring-sky-300": state.lit,
+    // The tap target is bigger than the square it sits in. That is what lets this family's grid go past the
+    // 7-wide ceiling the other grid families stop at: there, every cell is tappable, so cell size IS target
+    // size. Here only the pieces are, and generation never lets two of them touch, so a piece owns the empty
+    // shoulders around it and can reach out into them. 5px each way puts a 35px cell — the 9-wide wizard
+    // board on a 360px screen — over the 44px bar without any two targets meeting.
+    "after:absolute after:inset-[-5px] after:content-['']": state.movable,
   })
 
 export const LightbeamBoard: FC<Props> = ({ puzzle, states, highlighted, litBeam, onCycle }) => {

--- a/src/mods/puzzle/app/lightbeam/LightbeamPuzzle.tsx
+++ b/src/mods/puzzle/app/lightbeam/LightbeamPuzzle.tsx
@@ -1,0 +1,54 @@
+import { useCallback, useMemo, useState, type FC } from "react"
+import { useTranslation } from "react-i18next"
+import { LightbeamBoard } from "@/mods/puzzle/app/lightbeam/LightbeamBoard"
+import { LightbeamRules } from "@/mods/puzzle/app/lightbeam/LightbeamRules"
+import { buildLightbeamHint } from "@/mods/puzzle/app/lightbeam/lightbeamHint"
+import { isLit } from "@/mods/puzzle/game/lightbeam/beam"
+import type { LightbeamPuzzle as LightbeamPuzzleData } from "@/mods/puzzle/game/lightbeam/generateLightbeam"
+import { createLightbeamState, cycleLightbeamPiece } from "@/mods/puzzle/game/lightbeam/lightbeamState"
+import { PuzzleFamilyShell } from "@/mods/core/app/PuzzleFamilyShell"
+import { hintIdleDelay } from "@/mods/core/app/useHintAvailability"
+import type { Difficulty } from "@/data/difficultyLevels"
+
+type Props = {
+  puzzle: LightbeamPuzzleData
+  difficulty?: Difficulty
+  onSolved: () => void
+  onCancel: () => void
+}
+
+// One gesture and no undo, which is the whole control scheme: a tap cycles a piece, and tapping round
+// again puts it back (design doc §7). There is no pad, no eraser and nothing to take back, so this screen
+// is the shell, the board, and nothing in between.
+export const LightbeamPuzzle: FC<Props> = ({ puzzle, difficulty, onSolved, onCancel }) => {
+  const { t } = useTranslation("common")
+  const [state, setState] = useState(() => createLightbeamState(puzzle))
+
+  const hint = useMemo(() => buildLightbeamHint(puzzle, state.states), [puzzle, state])
+  const cycle = useCallback((piece: number) => setState(prev => cycleLightbeamPiece(prev, puzzle, piece)), [puzzle])
+
+  return (
+    <PuzzleFamilyShell
+      onSolved={onSolved}
+      onCancel={onCancel}
+      solved={isLit(puzzle, state.states)}
+      onReset={() => setState(createLightbeamState(puzzle))}
+      hint={hint && t(`lightbeam.hint.${hint.key}`)}
+      idleMs={hintIdleDelay(difficulty)}
+      rules={<LightbeamRules />}
+    >
+      {({ reportInput, hintVisible }) => (
+        <LightbeamBoard
+          puzzle={puzzle}
+          states={state.states}
+          highlighted={hintVisible ? hint?.cells : undefined}
+          litBeam={hintVisible ? hint?.beam : undefined}
+          onCycle={piece => {
+            reportInput()
+            cycle(piece)
+          }}
+        />
+      )}
+    </PuzzleFamilyShell>
+  )
+}

--- a/src/mods/puzzle/app/lightbeam/LightbeamRules.tsx
+++ b/src/mods/puzzle/app/lightbeam/LightbeamRules.tsx
@@ -1,0 +1,16 @@
+import type { FC } from "react"
+import { useTranslation } from "react-i18next"
+
+// Read below the board, never in the way of it: the puzzle is solvable without ever reading this
+// (docs/instructions/puzzle-screens.md §1, PUZZLE_FAMILIES.md P2).
+export const LightbeamRules: FC = () => {
+  const { t } = useTranslation("common")
+  return (
+    <ul className="list-disc space-y-1 pl-4">
+      <li>{t("lightbeam.rules.goal")}</li>
+      <li>{t("lightbeam.rules.mirrors")}</li>
+      <li>{t("lightbeam.rules.walls")}</li>
+      <li>{t("lightbeam.rules.tap")}</li>
+    </ul>
+  )
+}

--- a/src/mods/puzzle/app/lightbeam/lightbeamHint.spec.ts
+++ b/src/mods/puzzle/app/lightbeam/lightbeamHint.spec.ts
@@ -53,7 +53,15 @@ describe("buildLightbeamHint", () => {
   // whatever the decoy is doing — and once something else IS wrong, that is what the player needs to hear
   // about, not the piece they can safely ignore.
   it("never spends a hint on a decoy while something real is set wrong", () => {
-    const expert = board("expert", 2)
+    // Asks for the decoy goal by name rather than trusting a tier seed to draw it — which is also a check
+    // that `sortTheWheat` puts a genuinely free piece on the board.
+    const expert = generateLightbeam(6, 2, {
+      turns: 3,
+      slidingMirrors: 1,
+      techniqueCap: "neverReached",
+      goals: ["sortTheWheat"],
+      goalCount: 1,
+    })
     // A piece whose every setting still lights the shrine is exactly a decoy.
     const decoy = expert.movable.findIndex((piece, index) =>
       Array.from({ length: pieceStateCount(piece) }, (_, state) =>

--- a/src/mods/puzzle/app/lightbeam/lightbeamHint.spec.ts
+++ b/src/mods/puzzle/app/lightbeam/lightbeamHint.spec.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest"
+import en from "../../../../../public/locales/en/common.json"
+import nl from "../../../../../public/locales/nl/common.json"
+import { difficulties } from "@/data/difficultyLevels"
+import { isLit, pieceStateCount } from "@/mods/puzzle/game/lightbeam/beam"
+import { generateLightbeam } from "@/mods/puzzle/game/lightbeam/generateLightbeam"
+import { LIGHTBEAM_CONFIG } from "@/mods/puzzle/game/lightbeam/lightbeamConfig"
+import { TECHNIQUES } from "@/mods/puzzle/game/lightbeam/techniques"
+import { buildLightbeamHint } from "./lightbeamHint"
+
+const board = (difficulty: (typeof difficulties)[number], seed: number) => {
+  const { size, ...options } = LIGHTBEAM_CONFIG[difficulty]
+  return generateLightbeam(size, seed, options)
+}
+
+const phrase = (locale: object, key: string): unknown =>
+  key.split(".").reduce<unknown>((node, part) => (node as Record<string, unknown> | undefined)?.[part], locale)
+
+describe("buildLightbeamHint", () => {
+  const starter = board("starter", 1)
+
+  it("says nothing once the shrine is lit", () => {
+    expect(buildLightbeamHint(starter, starter.solution)).toBeUndefined()
+  })
+
+  it("names a piece the player is holding on a setting that cannot work", () => {
+    const hint = buildLightbeamHint(starter, starter.initial)
+    expect(hint?.piece).toBeDefined()
+    expect(starter.movable[hint!.piece!]).toBeDefined()
+  })
+
+  it("shows the beam its reason is about, so 'the light dies here' has a here", () => {
+    expect(buildLightbeamHint(starter, starter.initial)?.beam.length).toBeGreaterThan(0)
+  })
+
+  it("lights the squares the piece it names can stand in", () => {
+    const hint = buildLightbeamHint(starter, starter.initial)
+    const piece = starter.movable[hint!.piece!]
+    const cells = piece.kind === "turnMirror" ? [piece.at] : piece.stops
+    for (const at of cells) expect(hint?.cells.has(`${at.row},${at.col}`)).toBe(true)
+  })
+
+  // Following the advice is what moves the hint on: put the piece it named where the deduction says, and
+  // the next hint is about something else.
+  it("moves on once its advice is taken", () => {
+    const first = buildLightbeamHint(starter, starter.initial)
+    const piece = first!.piece!
+    const fixed = starter.initial.map((state, index) => (index === piece ? starter.solution[index] : state))
+    expect(buildLightbeamHint(starter, fixed)?.piece).not.toBe(piece)
+  })
+
+  // A decoy's setting genuinely does not matter, so a board that is right everywhere else is solved
+  // whatever the decoy is doing — and once something else IS wrong, that is what the player needs to hear
+  // about, not the piece they can safely ignore.
+  it("never spends a hint on a decoy while something real is set wrong", () => {
+    const expert = board("expert", 2)
+    // A piece whose every setting still lights the shrine is exactly a decoy.
+    const decoy = expert.movable.findIndex((piece, index) =>
+      Array.from({ length: pieceStateCount(piece) }, (_, state) =>
+        expert.solution.map((held, other) => (other === index ? state : held))
+      ).every(config => isLit(expert, config))
+    )
+    expect(decoy).toBeGreaterThanOrEqual(0)
+    const fiddled = expert.solution.map((state, index) =>
+      index === decoy ? (state + 1) % pieceStateCount(expert.movable[index]) : state
+    )
+    // Fiddling with it leaves the shrine lit, so there is no hint to give — the board is already solved.
+    expect(isLit(expert, fiddled)).toBe(true)
+    // Take the route apart and the decoy is no longer what the player needs to hear about.
+    const alsoWrong = fiddled.map((state, index) =>
+      index === decoy ? state : (state + 1) % pieceStateCount(expert.movable[index])
+    )
+    expect(buildLightbeamHint(expert, alsoWrong)?.key).not.toBe("neverReached")
+  })
+
+  it("always has something to say while the board is dark", () => {
+    for (const difficulty of difficulties)
+      for (let seed = 1; seed <= 6; seed++) {
+        const puzzle = board(difficulty, seed)
+        expect(buildLightbeamHint(puzzle, puzzle.initial)).toBeDefined()
+      }
+  })
+})
+
+describe("every reason the ladder can give is phrased in both locales", () => {
+  // A hint that reaches the player as a raw translation key is worse than no hint, so the keys are checked
+  // against the ladder itself rather than against whatever the specs above happened to trip over.
+  const keys = [
+    "entryRun",
+    "exitRun",
+    ...["deadEnd", "feedsExit"].flatMap(technique => ["wall", "edge", "loop"].map(end => `${technique}.${end}`)),
+    "neverReached",
+    "onlySurvivor",
+  ]
+
+  it("covers every rung of the ladder", () => {
+    for (const technique of TECHNIQUES) expect(keys.some(key => key.startsWith(technique))).toBe(true)
+  })
+
+  it.each(keys)("%s reads as a sentence in English and Dutch", key => {
+    expect(typeof phrase(en.lightbeam.hint, key)).toBe("string")
+    expect(typeof phrase(nl.lightbeam.hint, key)).toBe("string")
+  })
+
+  it("has the rules in both", () => {
+    for (const locale of [en, nl])
+      for (const rule of ["goal", "mirrors", "walls", "tap"])
+        expect(typeof phrase(locale.lightbeam.rules, rule)).toBe("string")
+  })
+})

--- a/src/mods/puzzle/app/lightbeam/lightbeamHint.ts
+++ b/src/mods/puzzle/app/lightbeam/lightbeamHint.ts
@@ -1,0 +1,58 @@
+import { cellKey, isLit, pieceCells, type BeamSegment } from "@/mods/puzzle/game/lightbeam/beam"
+import type { LightbeamPuzzle } from "@/mods/puzzle/game/lightbeam/generateLightbeam"
+import { solveLightbeamByTechniques, type LightbeamStep } from "@/mods/puzzle/game/lightbeam/techniques"
+
+export type LightbeamHint = {
+  /** Translation key under `lightbeam.hint`. */
+  key: string
+  /** The piece the reason is about, so the board can single it out. */
+  piece?: number
+  /** Cell keys the reason points at. */
+  cells: ReadonlySet<string>
+  /** The stretch of beam the reason is about — "the light dies here" means nothing without showing where. */
+  beam: BeamSegment[]
+}
+
+const stepKey = (step: LightbeamStep): string => [step.technique, step.variant].filter(Boolean).join(".")
+
+const asHint = (puzzle: LightbeamPuzzle, step: LightbeamStep): LightbeamHint => ({
+  key: stepKey(step),
+  piece: step.piece,
+  cells: new Set([
+    ...step.beam.map(segment => cellKey(segment.at)),
+    ...(step.piece === undefined ? [] : pieceCells(puzzle.movable[step.piece]).map(cellKey)),
+  ]),
+  beam: step.beam,
+})
+
+/**
+ * The next thing to say to the player.
+ *
+ * Unlike the families where the player writes numbers down, there is nothing here to be *wrong* about in
+ * the way a misplaced digit is wrong — every setting is a legal setting. So a hint is not a correction, it
+ * is the first reason the player has not yet acted on: the deduction is replayed from a blank board, and
+ * the hint is the earliest step whose conclusion the board in front of them contradicts. Follow it and the
+ * hint moves on by itself.
+ *
+ * A piece the player has been fiddling with that the light can never reach comes second, and only when
+ * nothing is actually set wrong — that is `neverReached` earning its keep, and it is the one hint in the
+ * game whose advice is to leave something alone.
+ */
+export const buildLightbeamHint = (puzzle: LightbeamPuzzle, states: readonly number[]): LightbeamHint | undefined => {
+  if (isLit(puzzle, states)) return undefined
+  const { steps } = solveLightbeamByTechniques(puzzle, puzzle.techniqueCap)
+
+  for (const step of steps)
+    for (const decision of step.decisions)
+      if (decision.kind === "eliminate" && decision.states.includes(states[decision.piece])) return asHint(puzzle, step)
+
+  for (const step of steps)
+    for (const decision of step.decisions)
+      if (decision.kind === "free" && states[decision.piece] !== puzzle.initial[decision.piece])
+        return asHint(puzzle, step)
+
+  // Nothing the player holds is ruled out, which on a settled board means the light is already on its
+  // way — but a stalled board (a cap that could not finish it, which generation rejects) still deserves
+  // the run it does know about rather than silence.
+  return steps.length ? asHint(puzzle, steps[0]) : undefined
+}

--- a/src/mods/puzzle/app/lightbeam/plugin.tsx
+++ b/src/mods/puzzle/app/lightbeam/plugin.tsx
@@ -1,0 +1,27 @@
+/* eslint-disable react-refresh/only-export-components -- side-effect registration file */
+import { registerFamily, type FamilyPlugin } from "@/app/families/familyRegistry"
+import type { Difficulty } from "@/data/difficultyLevels"
+import {
+  generateLightbeam,
+  type LightbeamPuzzle as LightbeamGrid,
+} from "@/mods/puzzle/game/lightbeam/generateLightbeam"
+import { LIGHTBEAM_CONFIG } from "@/mods/puzzle/game/lightbeam/lightbeamConfig"
+import { LIGHTBEAM_META } from "@/mods/puzzle/game/lightbeam/meta"
+import { LightbeamPuzzle } from "./LightbeamPuzzle"
+import { isModEnabled } from "@/mods/registeredMods"
+
+const LightbeamComponent: FamilyPlugin<LightbeamGrid>["Component"] = ({ puzzle, ctx, onSolved, onCancel }) => (
+  <LightbeamPuzzle puzzle={puzzle} difficulty={ctx.difficulty} onSolved={onSolved} onCancel={onCancel} />
+)
+
+export const generateLightbeamFor = (difficulty: Difficulty | undefined, seed: number): LightbeamGrid => {
+  const { size, ...options } = LIGHTBEAM_CONFIG[difficulty ?? "starter"]
+  return generateLightbeam(size, seed, options)
+}
+
+if (isModEnabled("puzzle"))
+  registerFamily({
+    meta: LIGHTBEAM_META,
+    generate: (seed, ctx): LightbeamGrid => generateLightbeamFor(ctx.difficulty, seed),
+    Component: LightbeamComponent,
+  })

--- a/src/mods/puzzle/game/lightbeam/beam.spec.ts
+++ b/src/mods/puzzle/game/lightbeam/beam.spec.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from "vitest"
+import {
+  configGrid,
+  eachConfig,
+  gridResolver,
+  opposite,
+  pieceOccupant,
+  pieceStateCount,
+  reflect,
+  stepCell,
+  traceBeam,
+  walkBackward,
+  walkForward,
+  type LightbeamPuzzleData,
+  type MovablePiece,
+} from "./beam"
+
+// A 4x4 board: the disc on the top edge shining down, one mirror bending the beam right, the shrine
+// waiting on the right edge of that row.
+//
+//     · S · ·        S = sun (facing down)
+//     · / · X        / = the mirror,  X = the shrine
+//     · · · ·
+//     · · · ·
+const board: LightbeamPuzzleData = {
+  size: 4,
+  sun: { at: { row: 0, col: 1 }, facing: "down" },
+  shrine: { row: 1, col: 3 },
+  fixed: [],
+  movable: [{ kind: "turnMirror", at: { row: 1, col: 1 }, faces: ["/", "\\"] }],
+}
+
+describe("geometry", () => {
+  it("steps one cell in each direction", () => {
+    expect(stepCell({ row: 2, col: 2 }, "up")).toEqual({ row: 1, col: 2 })
+    expect(stepCell({ row: 2, col: 2 }, "right")).toEqual({ row: 2, col: 3 })
+  })
+
+  it("turns the beam a quarter off either diagonal", () => {
+    expect(reflect("/", "right")).toBe("up")
+    expect(reflect("/", "down")).toBe("left")
+    expect(reflect("\\", "right")).toBe("down")
+    expect(reflect("\\", "up")).toBe("left")
+  })
+
+  // The backward walk leans on this: bouncing the same face twice gives the direction back, so tracing
+  // the beam in reverse can reuse the very same reflection rather than a second table to keep in step.
+  it("reflection is its own inverse", () => {
+    for (const face of ["/", "\\"] as const)
+      for (const travel of ["up", "down", "left", "right"] as const)
+        expect(reflect(face, reflect(face, travel))).toBe(travel)
+  })
+
+  it("counts a piece's states and where each one puts it", () => {
+    const sliding: MovablePiece = {
+      kind: "slidingWall",
+      stops: [
+        { row: 0, col: 0 },
+        { row: 0, col: 2 },
+      ],
+    }
+    expect(pieceStateCount(sliding)).toBe(2)
+    expect(pieceOccupant(sliding, 1)).toEqual({ at: { row: 0, col: 2 }, blocks: { kind: "wall" } })
+  })
+})
+
+describe("traceBeam", () => {
+  it("lights the shrine when the mirror faces the right way", () => {
+    const walk = traceBeam(board, [1]) // "\\" turns the beam down-then-right
+    expect(walk.end).toBe("lit")
+    expect(walk.path.map(segment => segment.at)).toEqual([
+      { row: 1, col: 1 },
+      { row: 1, col: 2 },
+      { row: 1, col: 3 },
+    ])
+  })
+
+  it("runs off the frame when it faces the other way", () => {
+    expect(traceBeam(board, [0]).end).toBe("escapes")
+  })
+
+  it("dies where a wall stands", () => {
+    const walled = { ...board, fixed: [{ kind: "wall" as const, at: { row: 1, col: 2 } }] }
+    const walk = traceBeam(walled, [1])
+    expect(walk.end).toBe("absorbed")
+    expect(walk.stopAt).toEqual({ row: 1, col: 2 })
+  })
+
+  it("the disc absorbs light that comes back at it", () => {
+    const returning: LightbeamPuzzleData = {
+      size: 4,
+      sun: { at: { row: 0, col: 1 }, facing: "down" },
+      shrine: { row: 3, col: 3 },
+      fixed: [
+        { kind: "mirror", at: { row: 2, col: 1 }, face: "\\" },
+        { kind: "mirror", at: { row: 2, col: 2 }, face: "/" },
+        { kind: "mirror", at: { row: 0, col: 2 }, face: "\\" },
+      ],
+      movable: [],
+    }
+    const walk = traceBeam(returning, [])
+    expect(walk.end).toBe("absorbed")
+    expect(walk.stopAt).toEqual({ row: 0, col: 1 })
+  })
+})
+
+// A ring of four mirrors carries light round forever, and the walk has to stop rather than spin. What it
+// cannot do is trap the beam the player is looking at: a 90° mirror maps (cell, direction) one-to-one, so
+// every state has exactly one predecessor, and the disc's very first state has none. A beam from the disc
+// therefore walks a path and can never join a ring — the ring is only reachable by starting inside it.
+//
+// So loop detection here is a guard, not a game state. It earns its place all the same: it is what keeps
+// the walk total, and the first piece that bends light by anything other than a quarter turn (the
+// deferred prism, §11) breaks the one-to-one and makes it load-bearing.
+describe("a ring of mirrors", () => {
+  const ring: LightbeamPuzzleData = {
+    size: 5,
+    sun: { at: { row: 0, col: 0 }, facing: "down" },
+    shrine: { row: 4, col: 4 },
+    fixed: [
+      { kind: "mirror", at: { row: 3, col: 3 }, face: "/" },
+      { kind: "mirror", at: { row: 1, col: 3 }, face: "\\" },
+      { kind: "mirror", at: { row: 1, col: 1 }, face: "/" },
+      { kind: "mirror", at: { row: 3, col: 1 }, face: "\\" },
+    ],
+    movable: [],
+  }
+
+  it("stops the walk instead of spinning, for a beam started inside it", () => {
+    const walk = walkForward(ring.size, { row: 3, col: 1 }, "right", gridResolver(configGrid(ring, [])))
+    expect(walk.end).toBe("loops")
+  })
+
+  it("never catches the beam the disc actually sends", () => {
+    expect(traceBeam(ring, []).end).not.toBe("loops")
+  })
+})
+
+describe("walkBackward", () => {
+  const resolve = gridResolver(configGrid(board, [1]))
+
+  it("finds the disc when it traces the winning route in reverse", () => {
+    // The beam arrives at the shrine travelling right, so backwards is leftwards along that row.
+    expect(walkBackward(board.size, board.shrine, "right", resolve).end).toBe("lit")
+  })
+
+  it("rules out a side nothing could have delivered the light from", () => {
+    // The shrine sits on the right edge: light arriving leftwards would have had to come from outside.
+    expect(walkBackward(board.size, board.shrine, "left", resolve).end).toBe("escapes")
+  })
+
+  it("cannot be traced back into the disc's shadowed side", () => {
+    // Disc halfway down the column shining down, shrine above it. Going backwards from the shrine
+    // reaches the disc from the wrong side, and the disc only ever emits downwards — so light arriving
+    // upwards at this shrine is not something the disc could have sent.
+    const behind: LightbeamPuzzleData = {
+      size: 4,
+      sun: { at: { row: 2, col: 1 }, facing: "down" },
+      shrine: { row: 0, col: 1 },
+      fixed: [],
+      movable: [],
+    }
+    expect(walkBackward(behind.size, behind.shrine, "up", gridResolver(configGrid(behind, []))).end).toBe("absorbed")
+  })
+
+  it("agrees with the forward walk on which way round it goes", () => {
+    const forward = traceBeam(board, [1])
+    const last = forward.path[forward.path.length - 1]
+    expect(opposite(last.enter)).toBe("left")
+    expect(walkBackward(board.size, board.shrine, last.enter, resolve).end).toBe("lit")
+  })
+})
+
+describe("eachConfig", () => {
+  it("visits every combination once", () => {
+    const seen: number[][] = []
+    expect(
+      eachConfig(
+        [
+          [0, 1],
+          [0, 1, 2],
+        ],
+        config => seen.push([...config])
+      )
+    ).toBe(true)
+    expect(seen).toHaveLength(6)
+    expect(new Set(seen.map(String)).size).toBe(6)
+  })
+
+  it("refuses a space bigger than the caller will pay for", () => {
+    let visits = 0
+    expect(
+      eachConfig(
+        [
+          [0, 1],
+          [0, 1],
+        ],
+        () => visits++,
+        3
+      )
+    ).toBe(false)
+    expect(visits).toBe(0)
+  })
+})

--- a/src/mods/puzzle/game/lightbeam/beam.ts
+++ b/src/mods/puzzle/game/lightbeam/beam.ts
@@ -1,0 +1,232 @@
+// The board and the beam, per docs/game-design/puzzles/lightbeam.md §3. Everything else in the family
+// — the solver, generation, the drawn board — is written against these types and this one walk.
+//
+// A configuration is a flat array of integers, one per movable piece: the state that piece is in. That
+// is the whole of the player's answer, which is what makes the configuration space enumerable and reset
+// a one-liner.
+
+export const DIRECTIONS = ["up", "right", "down", "left"] as const
+
+export type Direction = (typeof DIRECTIONS)[number]
+
+export type CellRef = { row: number; col: number }
+
+/** The two diagonals a mirror can sit on, written as they are drawn. */
+export type MirrorFace = "/" | "\\"
+
+/** What a piece does to the beam when it stands in its way. */
+export type Blocker = { kind: "mirror"; face: MirrorFace } | { kind: "wall" }
+
+/** Part of the puzzle, like a Sudoku given: the player cannot change it. */
+export type FixedPiece = { kind: "mirror"; at: CellRef; face: MirrorFace } | { kind: "wall"; at: CellRef }
+
+/**
+ * A piece the player cycles with a tap. Its states are listed out, and a configuration names one of
+ * them by index — a turn mirror by which face, a sliding piece by which stop.
+ */
+export type MovablePiece =
+  | { kind: "turnMirror"; at: CellRef; faces: MirrorFace[] }
+  | { kind: "slidingMirror"; face: MirrorFace; stops: CellRef[] }
+  | { kind: "slidingWall"; stops: CellRef[] }
+
+export type LightbeamPuzzleData = {
+  size: number
+  /** Where the light comes from, and which way it leaves. The disc itself absorbs anything hitting it. */
+  sun: { at: CellRef; facing: Direction }
+  shrine: CellRef
+  fixed: FixedPiece[]
+  movable: MovablePiece[]
+}
+
+export type LightbeamConfig = readonly number[]
+
+export const cellKey = (at: CellRef): string => `${at.row},${at.col}`
+
+export const segmentKey = (at: CellRef, direction: Direction): string => `${at.row},${at.col},${direction}`
+
+export const sameCell = (a: CellRef, b: CellRef): boolean => a.row === b.row && a.col === b.col
+
+const STEPS: Record<Direction, CellRef> = {
+  up: { row: -1, col: 0 },
+  down: { row: 1, col: 0 },
+  left: { row: 0, col: -1 },
+  right: { row: 0, col: 1 },
+}
+
+const OPPOSITES: Record<Direction, Direction> = { up: "down", down: "up", left: "right", right: "left" }
+
+// Reflection off either diagonal. Both are involutions — bouncing the same face twice gives the
+// direction back — which is why the backward walk below can reuse this untouched.
+const FACES: Record<MirrorFace, Record<Direction, Direction>> = {
+  "/": { right: "up", up: "right", left: "down", down: "left" },
+  "\\": { right: "down", down: "right", left: "up", up: "left" },
+}
+
+export const stepCell = (at: CellRef, direction: Direction): CellRef => ({
+  row: at.row + STEPS[direction].row,
+  col: at.col + STEPS[direction].col,
+})
+
+export const opposite = (direction: Direction): Direction => OPPOSITES[direction]
+
+export const reflect = (face: MirrorFace, travel: Direction): Direction => FACES[face][travel]
+
+export const insideGrid = (size: number, at: CellRef): boolean =>
+  at.row >= 0 && at.col >= 0 && at.row < size && at.col < size
+
+/** How many states a piece cycles through. */
+export const pieceStateCount = (piece: MovablePiece): number =>
+  piece.kind === "turnMirror" ? piece.faces.length : piece.stops.length
+
+/** Where a piece stands in a given state, and what it does to the beam there. */
+export const pieceOccupant = (piece: MovablePiece, state: number): { at: CellRef; blocks: Blocker } => {
+  if (piece.kind === "turnMirror") return { at: piece.at, blocks: { kind: "mirror", face: piece.faces[state] } }
+  if (piece.kind === "slidingMirror") return { at: piece.stops[state], blocks: { kind: "mirror", face: piece.face } }
+  return { at: piece.stops[state], blocks: { kind: "wall" } }
+}
+
+/** Every cell a piece could ever stand on, whatever the player does. */
+export const pieceCells = (piece: MovablePiece): CellRef[] => (piece.kind === "turnMirror" ? [piece.at] : piece.stops)
+
+/**
+ * What the walk finds in a cell. `unknown` is the one that matters: it is how a partly-deduced board
+ * says "something movable could be standing here", and it is where every deduction in techniques.ts
+ * starts.
+ */
+export type CellContent =
+  { kind: "empty" } | { kind: "unknown" } | { kind: "sun"; facing: Direction } | { kind: "shrine" } | Blocker
+
+/** One cell of the beam: which way it came in, and which way it left (nothing, if it died here). */
+export type BeamSegment = { at: CellRef; enter: Direction; exit?: Direction }
+
+/**
+ * Why the beam stopped. `unknown` only ever comes back from a partly-deduced board — a real
+ * configuration always resolves to one of the other four.
+ */
+export type BeamEnd = "lit" | "absorbed" | "escapes" | "loops" | "unknown"
+
+export type BeamWalk = {
+  /** Cells the beam crossed, in order. A cell crossed twice appears twice, once per direction. */
+  path: BeamSegment[]
+  end: BeamEnd
+  /** The cell the walk stopped in, absent when it left the grid. */
+  stopAt?: CellRef
+}
+
+type Resolver = (at: CellRef) => CellContent
+
+/**
+ * Walks the beam forward from a cell, in a direction, over whatever the resolver says is there.
+ *
+ * Loop detection is what keeps this walk total, but on this family's pieces it is a guard rather than a
+ * game state: a 90° mirror maps (cell, direction) one-to-one, so every state has exactly one
+ * predecessor, and the disc's first state has none. A beam from the disc therefore walks a path and can
+ * never join a ring — a ring of mirrors is only reachable by starting inside it (beam.spec.ts proves
+ * both halves). The guard earns its keep the moment a piece bends light by anything but a quarter turn,
+ * which is exactly what the deferred prism does.
+ */
+export const walkForward = (size: number, from: CellRef, direction: Direction, resolve: Resolver): BeamWalk => {
+  const path: BeamSegment[] = []
+  const seen = new Set<string>()
+  let at = stepCell(from, direction)
+  let travel = direction
+  for (;;) {
+    if (!insideGrid(size, at)) return { path, end: "escapes" }
+    const key = segmentKey(at, travel)
+    if (seen.has(key)) return { path, end: "loops", stopAt: at }
+    seen.add(key)
+    const content = resolve(at)
+    if (content.kind === "unknown") return { path: [...path, { at, enter: travel }], end: "unknown", stopAt: at }
+    if (content.kind === "shrine") return { path: [...path, { at, enter: travel }], end: "lit", stopAt: at }
+    if (content.kind === "wall" || content.kind === "sun")
+      return { path: [...path, { at, enter: travel }], end: "absorbed", stopAt: at }
+    const exit = content.kind === "mirror" ? reflect(content.face, travel) : travel
+    path.push({ at, enter: travel, exit })
+    at = stepCell(at, exit)
+    travel = exit
+  }
+}
+
+/**
+ * Walks the beam backwards from the shrine, given the direction it would be travelling as it arrives.
+ *
+ * This is how the board answers "which side can the shrine even be lit from": a direction whose
+ * backward walk runs off the grid or into a wall is a direction nothing could have delivered the light
+ * from. Reaching the sun-disc facing the right way ends it — that is the whole beam, found from the
+ * other end.
+ */
+export const walkBackward = (size: number, shrine: CellRef, enter: Direction, resolve: Resolver): BeamWalk => {
+  const path: BeamSegment[] = [{ at: shrine, enter }]
+  const seen = new Set<string>()
+  let back = opposite(enter)
+  let at = stepCell(shrine, back)
+  for (;;) {
+    if (!insideGrid(size, at)) return { path, end: "escapes" }
+    const key = segmentKey(at, back)
+    if (seen.has(key)) return { path, end: "loops", stopAt: at }
+    seen.add(key)
+    const content = resolve(at)
+    // The disc only emits one way; light cannot be traced back into its shadowed side.
+    if (content.kind === "sun")
+      return opposite(back) === content.facing
+        ? { path, end: "lit", stopAt: at }
+        : { path, end: "absorbed", stopAt: at }
+    if (content.kind === "unknown")
+      return { path: [...path, { at, exit: opposite(back), enter: opposite(back) }], end: "unknown", stopAt: at }
+    if (content.kind === "wall" || content.kind === "shrine") return { path, end: "absorbed", stopAt: at }
+    const nextBack = content.kind === "mirror" ? reflect(content.face, back) : back
+    path.push({ at, enter: opposite(nextBack), exit: opposite(back) })
+    at = stepCell(at, nextBack)
+    back = nextBack
+  }
+}
+
+/** The board as a configuration leaves it: every cell resolved, nothing unknown. */
+export const configGrid = (puzzle: LightbeamPuzzleData, config: LightbeamConfig): CellContent[][] => {
+  const grid: CellContent[][] = Array.from({ length: puzzle.size }, () =>
+    Array.from({ length: puzzle.size }, (): CellContent => ({ kind: "empty" }))
+  )
+  for (const piece of puzzle.fixed)
+    grid[piece.at.row][piece.at.col] = piece.kind === "mirror" ? { kind: "mirror", face: piece.face } : { kind: "wall" }
+  puzzle.movable.forEach((piece, index) => {
+    const { at, blocks } = pieceOccupant(piece, config[index])
+    grid[at.row][at.col] = blocks
+  })
+  grid[puzzle.shrine.row][puzzle.shrine.col] = { kind: "shrine" }
+  grid[puzzle.sun.at.row][puzzle.sun.at.col] = { kind: "sun", facing: puzzle.sun.facing }
+  return grid
+}
+
+export const gridResolver =
+  (grid: CellContent[][]): Resolver =>
+  at =>
+    grid[at.row][at.col]
+
+/** Where the light actually goes, for the configuration the player is holding. */
+export const traceBeam = (puzzle: LightbeamPuzzleData, config: LightbeamConfig): BeamWalk =>
+  walkForward(puzzle.size, puzzle.sun.at, puzzle.sun.facing, gridResolver(configGrid(puzzle, config)))
+
+export const isLit = (puzzle: LightbeamPuzzleData, config: LightbeamConfig): boolean =>
+  traceBeam(puzzle, config).end === "lit"
+
+/** Every configuration the puzzle allows, in odometer order over the pieces' states. */
+export const eachConfig = (
+  states: readonly (readonly number[])[],
+  visit: (config: number[]) => void,
+  limit = Number.POSITIVE_INFINITY
+): boolean => {
+  const total = states.reduce((product, options) => product * options.length, 1)
+  if (total > limit) return false
+  const config = new Array<number>(states.length).fill(0)
+  const cursor = new Array<number>(states.length).fill(0)
+  for (let n = 0; n < total; n++) {
+    for (let i = 0; i < states.length; i++) config[i] = states[i][cursor[i]]
+    visit(config)
+    for (let i = 0; i < states.length; i++) {
+      cursor[i]++
+      if (cursor[i] < states[i].length) break
+      cursor[i] = 0
+    }
+  }
+  return true
+}

--- a/src/mods/puzzle/game/lightbeam/generateLightbeam.spec.ts
+++ b/src/mods/puzzle/game/lightbeam/generateLightbeam.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { difficulties } from "@/data/difficultyLevels"
-import { cellKey, eachConfig, isLit, pieceCells, pieceStateCount, traceBeam } from "./beam"
+import { cellKey, eachConfig, isLit, pieceCells, pieceStateCount, stepCell, traceBeam } from "./beam"
 import { generateLightbeam } from "./generateLightbeam"
 import { LIGHTBEAM_CONFIG } from "./lightbeamConfig"
 import { solveLightbeamByTechniques } from "./techniques"
@@ -19,8 +19,12 @@ describe.each(difficulties)("at %s", difficulty => {
   const { size, ...options } = LIGHTBEAM_CONFIG[difficulty]
   const boards = Array.from({ length: 10 }, (_, seed) => generateLightbeam(size, seed + 1, options))
 
-  it("fits the screen — 7 wide is the ceiling for every family on this grid", () => {
-    expect(size).toBeLessThanOrEqual(7)
+  // The other grid families stop at 7 wide because every cell there is tappable, so cell size IS tap-target
+  // size. This family's ceiling is set by legibility instead: only the pieces are tappable and they never
+  // touch, so a piece reaches into its empty shoulders for a 44px target (asserted at the foot of this file)
+  // and the cell only has to stay big enough to read a mirror's diagonal in.
+  it("stays inside the width a phone can draw legibly", () => {
+    expect(size).toBeLessThanOrEqual(9)
   })
 
   it("its answer lights the shrine", () => {
@@ -173,5 +177,49 @@ describe("the tiers demand different reasoning", () => {
       "neverReached",
       "onlySurvivor",
     ])
+  })
+})
+
+// The tap-accuracy rule, and what buys this family a grid wider than the other grid families allow. There,
+// every cell is tappable, so cell size is tap-target size and 7 wide is a real ceiling. Here only the
+// movable pieces are tappable and they are never allowed to touch, so a piece owns the empty shoulders
+// around it and its hit area can be a thumb wide while its cell is smaller (LightbeamBoard spends that).
+//
+// Before this rule existed essentially every board broke it — up to ten touching pairs on one wizard grid.
+describe("no two pieces the player can tap ever touch", () => {
+  // The board is 318px inside a 360px encounter modal, measured; 5px of overflow each way is what the
+  // movable cells carry.
+  const BOARD_PX = 318
+  const OVERFLOW_PX = 5
+  const TAP_TARGET_PX = 44
+
+  describe.each(difficulties)("at %s", difficulty => {
+    const { size, ...options } = LIGHTBEAM_CONFIG[difficulty]
+    const boards = Array.from({ length: 16 }, (_, seed) => generateLightbeam(size, seed + 1, options))
+
+    it("keeps every pair of movable pieces at least a square apart", () => {
+      for (const board of boards) {
+        const owner = new Map<string, number>()
+        board.movable.forEach((piece, index) => {
+          for (const at of pieceCells(piece)) owner.set(cellKey(at), index)
+        })
+        for (const [key, index] of owner) {
+          const [row, col] = key.split(",").map(Number)
+          for (const direction of ["up", "right", "down", "left"] as const) {
+            const beside = stepCell({ row, col }, direction)
+            expect(owner.get(cellKey(beside)) ?? index).toBe(index)
+          }
+        }
+      }
+    })
+
+    it("still clears the 44px tap target once a piece reaches into its shoulders", () => {
+      expect(BOARD_PX / size + 2 * OVERFLOW_PX).toBeGreaterThanOrEqual(TAP_TARGET_PX)
+    })
+
+    // The overflow may reach into empty squares, never into another target's.
+    it("leaves no two tap targets overlapping", () => {
+      expect(BOARD_PX / size + 2 * OVERFLOW_PX).toBeLessThanOrEqual(2 * (BOARD_PX / size))
+    })
   })
 })

--- a/src/mods/puzzle/game/lightbeam/generateLightbeam.spec.ts
+++ b/src/mods/puzzle/game/lightbeam/generateLightbeam.spec.ts
@@ -137,7 +137,11 @@ describe("the tiers demand different reasoning", () => {
 
   // Footprint is only half of difficulty, but it may never go backwards: a junior board that is smaller
   // than a starter one is a tier table that reads right and plays wrong, which is exactly what the first
-  // pass at this table did.
+  // pass at this table did — and then what the first pass at the goal pool did again, by letting two goals
+  // add four pieces on top of baselines that already carried some.
+  //
+  // Asserted in AGGREGATE over a tier rather than board by board: with goals drawn per board, one starter
+  // grid can legitimately out-measure one junior grid. It is the tier that has to grow, not every board.
   it("never shrinks as the tiers go up", () => {
     const space = difficulties.map(difficulty =>
       sweep(difficulty).reduce(

--- a/src/mods/puzzle/game/lightbeam/generateLightbeam.spec.ts
+++ b/src/mods/puzzle/game/lightbeam/generateLightbeam.spec.ts
@@ -123,15 +123,30 @@ describe.each(difficulties)("at %s", difficulty => {
 // is a chain of `deadEnd` eliminations, so the tiers would differ only in size — the shadow pieces
 // (generateLightbeam's `shadows`) are what make the higher rungs necessary rather than merely permitted.
 describe("the tiers demand different reasoning", () => {
-  const demanded = (difficulty: (typeof difficulties)[number]) => {
+  const sweep = (difficulty: (typeof difficulties)[number]) => {
     const { size, ...options } = LIGHTBEAM_CONFIG[difficulty]
+    return Array.from({ length: 16 }, (_, seed) => generateLightbeam(size, seed + 1, options))
+  }
+
+  const demanded = (difficulty: (typeof difficulties)[number]) => {
     const used = new Set<string>()
-    for (let seed = 1; seed <= 16; seed++) {
-      const board = generateLightbeam(size, seed, options)
+    for (const board of sweep(difficulty))
       for (const technique of solveLightbeamByTechniques(board, board.techniqueCap).used) used.add(technique)
-    }
     return used
   }
+
+  // Footprint is only half of difficulty, but it may never go backwards: a junior board that is smaller
+  // than a starter one is a tier table that reads right and plays wrong, which is exactly what the first
+  // pass at this table did.
+  it("never shrinks as the tiers go up", () => {
+    const space = difficulties.map(difficulty =>
+      sweep(difficulty).reduce(
+        (total, board) => total + board.movable.reduce((product, piece) => product * pieceStateCount(piece), 1),
+        0
+      )
+    )
+    for (let tier = 1; tier < space.length; tier++) expect(space[tier]).toBeGreaterThan(space[tier - 1])
+  })
 
   it("asks a starter board for nothing but a visible dead end", () => {
     expect([...demanded("starter")].sort()).toEqual(["deadEnd", "entryRun", "exitRun"])

--- a/src/mods/puzzle/game/lightbeam/generateLightbeam.spec.ts
+++ b/src/mods/puzzle/game/lightbeam/generateLightbeam.spec.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest"
+import { difficulties } from "@/data/difficultyLevels"
+import { cellKey, eachConfig, isLit, pieceCells, pieceStateCount, traceBeam } from "./beam"
+import { generateLightbeam } from "./generateLightbeam"
+import { LIGHTBEAM_CONFIG } from "./lightbeamConfig"
+import { solveLightbeamByTechniques } from "./techniques"
+
+describe("generateLightbeam", () => {
+  it("is deterministic", () => {
+    expect(generateLightbeam(5, 42, { turns: 2 })).toEqual(generateLightbeam(5, 42, { turns: 2 }))
+  })
+
+  it("different seeds produce different boards", () => {
+    expect(generateLightbeam(5, 1, { turns: 2 })).not.toEqual(generateLightbeam(5, 2, { turns: 2 }))
+  })
+})
+
+describe.each(difficulties)("at %s", difficulty => {
+  const { size, ...options } = LIGHTBEAM_CONFIG[difficulty]
+  const boards = Array.from({ length: 10 }, (_, seed) => generateLightbeam(size, seed + 1, options))
+
+  it("fits the screen — 7 wide is the ceiling for every family on this grid", () => {
+    expect(size).toBeLessThanOrEqual(7)
+  })
+
+  it("its answer lights the shrine", () => {
+    for (const board of boards) expect(isLit(board, board.solution)).toBe(true)
+  })
+
+  it("opens dark, so there is something to do", () => {
+    for (const board of boards) expect(isLit(board, board.initial)).toBe(false)
+  })
+
+  it("opens more than one tap from done", () => {
+    for (const board of boards)
+      for (let piece = 0; piece < board.movable.length; piece++)
+        for (let state = 0; state < pieceStateCount(board.movable[piece]); state++) {
+          const oneTap = board.initial.map((held, index) => (index === piece ? state : held))
+          expect(isLit(board, oneTap)).toBe(false)
+        }
+  })
+
+  it("never needs a guess — every board settles inside its own technique cap", () => {
+    for (const board of boards) expect(solveLightbeamByTechniques(board, board.techniqueCap).settled).toBe(true)
+  })
+
+  // Gate 4, and the honest form of uniqueness for this family: a decoy has a free setting by definition,
+  // so a board with decoys has many winning configurations. What may not be ambiguous is the route.
+  it("has exactly one winning route", () => {
+    for (const board of boards) {
+      const paths = new Set<string>()
+      const states = board.movable.map(piece => Array.from({ length: pieceStateCount(piece) }, (_, i) => i))
+      eachConfig(states, config => {
+        if (!isLit(board, config)) return
+        paths.add(
+          traceBeam(board, config)
+            .path.map(segment => cellKey(segment.at))
+            .join(" ")
+        )
+      })
+      expect(paths.size).toBe(1)
+    }
+  })
+
+  it("puts nothing on top of anything else", () => {
+    for (const board of boards) {
+      const claims = [
+        cellKey(board.sun.at),
+        cellKey(board.shrine),
+        ...board.fixed.map(piece => cellKey(piece.at)),
+        ...board.movable.flatMap(piece => pieceCells(piece).map(cellKey)),
+      ]
+      expect(new Set(claims).size).toBe(claims.length)
+    }
+  })
+
+  it("keeps every piece on the board", () => {
+    for (const board of boards)
+      for (const piece of board.movable)
+        for (const at of pieceCells(piece)) {
+          expect(at.row).toBeGreaterThanOrEqual(0)
+          expect(at.col).toBeGreaterThanOrEqual(0)
+          expect(at.row).toBeLessThan(size)
+          expect(at.col).toBeLessThan(size)
+        }
+  })
+
+  it("sets the disc and the shrine in the frame, never adrift in the middle", () => {
+    const onEdge = (row: number, col: number) => row === 0 || col === 0 || row === size - 1 || col === size - 1
+    for (const board of boards) {
+      expect(onEdge(board.sun.at.row, board.sun.at.col)).toBe(true)
+      expect(onEdge(board.shrine.row, board.shrine.col)).toBe(true)
+    }
+  })
+
+  it("gives the player something to tap", () => {
+    for (const board of boards) expect(board.movable.length).toBeGreaterThan(0)
+  })
+
+  // Wall-thinning's own test. A wall the player cannot spend hides which obstacles the deduction turns
+  // on, so every one left standing has to be load-bearing under this board's cap.
+  it("shows no wall the player cannot spend", () => {
+    for (const board of boards)
+      for (const wall of board.fixed.filter(piece => piece.kind === "wall")) {
+        const without = { ...board, fixed: board.fixed.filter(piece => piece !== wall) }
+        const states = board.movable.map(piece => Array.from({ length: pieceStateCount(piece) }, (_, i) => i))
+        const paths = new Set<string>()
+        eachConfig(states, config => {
+          if (isLit(without, config))
+            paths.add(
+              traceBeam(without, config)
+                .path.map(segment => cellKey(segment.at))
+                .join(" ")
+            )
+        })
+        const stillAPuzzle = paths.size === 1 && solveLightbeamByTechniques(without, board.techniqueCap).settled
+        expect(stillAPuzzle).toBe(false)
+      }
+  })
+})
+
+// The whole point of the technique cap is that it is what a board may DEMAND. Built plainly every board
+// is a chain of `deadEnd` eliminations, so the tiers would differ only in size — the shadow pieces
+// (generateLightbeam's `shadows`) are what make the higher rungs necessary rather than merely permitted.
+describe("the tiers demand different reasoning", () => {
+  const demanded = (difficulty: (typeof difficulties)[number]) => {
+    const { size, ...options } = LIGHTBEAM_CONFIG[difficulty]
+    const used = new Set<string>()
+    for (let seed = 1; seed <= 16; seed++) {
+      const board = generateLightbeam(size, seed, options)
+      for (const technique of solveLightbeamByTechniques(board, board.techniqueCap).used) used.add(technique)
+    }
+    return used
+  }
+
+  it("asks a starter board for nothing but a visible dead end", () => {
+    expect([...demanded("starter")].sort()).toEqual(["deadEnd", "entryRun", "exitRun"])
+  })
+
+  it("reaches the shrine-side elimination by junior", () => {
+    expect(demanded("junior")).toContain("feedsExit")
+  })
+
+  it("names an irrelevant piece from expert on, where the decoys start", () => {
+    expect(demanded("expert")).toContain("neverReached")
+  })
+
+  it("spends the whole ladder at wizard", () => {
+    expect([...demanded("wizard")].sort()).toEqual([
+      "deadEnd",
+      "entryRun",
+      "exitRun",
+      "feedsExit",
+      "neverReached",
+      "onlySurvivor",
+    ])
+  })
+})

--- a/src/mods/puzzle/game/lightbeam/generateLightbeam.ts
+++ b/src/mods/puzzle/game/lightbeam/generateLightbeam.ts
@@ -4,6 +4,7 @@ import {
   eachConfig,
   insideGrid,
   isLit,
+  pieceCells,
   pieceStateCount,
   reflect,
   segmentKey,
@@ -76,6 +77,9 @@ const MAX_ATTEMPTS = 600
 // Thinning reaches a fixpoint in two sweeps on every tier measured; the rest is the guard, not the plan.
 const MAX_PRUNE_SWEEPS = 4
 
+// The shortest a route leg may be, which is what stops two consecutive bend mirrors touching.
+const MIN_LEG = 2
+
 const FACES: MirrorFace[] = ["/", "\\"]
 
 const faceFor = (enter: Direction, exit: Direction): MirrorFace | undefined =>
@@ -142,10 +146,16 @@ const buildRoute = (size: number, turns: number, random: () => number): Route | 
   // Legs share the grid, so their length has to know how many of them there are. Drawing 1..size-2 every
   // time ate the board in three strides and a long route then almost never fitted — which read as the goal
   // pool falling back, not as the route builder being greedy.
-  const maxLeg = Math.max(1, Math.min(size - 2, Math.floor((size - 1) / Math.max(1, turns)) + 1))
+  //
+  // The floor of MIN_LEG is what keeps two consecutive bends off each other's shoulder: a leg of one cell
+  // puts the two mirrors in touching squares, and two tappable pieces in touching squares is a mis-tap
+  // waiting to happen (§9). It is a floor, not a guarantee — a route that folds back can still bring two
+  // non-consecutive bends together, which `piecesAreSpaced` catches at the end.
+  const budget = Math.max(MIN_LEG, Math.floor((size - 1) / Math.max(1, turns + 1)))
+  const span = Math.max(1, budget - MIN_LEG + 1)
   for (let leg = 0; leg <= turns; leg++) {
     const last = leg === turns
-    const length = last ? stepsToEdge(size, at, direction) : 1 + Math.floor(random() * maxLeg)
+    const length = last ? stepsToEdge(size, at, direction) : MIN_LEG + Math.floor(random() * span)
     if (length < 1) return undefined
     for (let step = 0; step < length; step++) {
       at = stepCell(at, direction)
@@ -192,6 +202,19 @@ const trackStops = (at: CellRef, across: Direction): CellRef[] =>
 
 type Ray = { from: CellRef; direction: Direction }
 
+const ADJACENT: Direction[] = ["up", "right", "down", "left"]
+
+/**
+ * Is this cell clear of every piece already placed, and of their shoulders?
+ *
+ * Checked at placement rather than only by the gate at the end, because a decoy or a shadow that lands on
+ * a neighbour's shoulder would throw away the whole draft — and shadows land beside a mirror by their very
+ * nature, so the gate alone rejected almost every board that wanted one.
+ */
+const spacedFrom = (draft: Draft, at: CellRef): boolean =>
+  !draft.movableCells.has(cellKey(at)) &&
+  ADJACENT.every(direction => !draft.movableCells.has(cellKey(stepCell(at, direction))))
+
 /**
  * Shadow pieces: decoys dropped into the very stretch a wrong setting would light.
  *
@@ -206,9 +229,12 @@ type Ray = { from: CellRef; direction: Direction }
  */
 const placeShadows = (size: number, draft: Draft, rays: Ray[], count: number, random: () => number) => {
   for (const ray of shuffle(rays, random).slice(0, count)) {
-    let at = stepCell(ray.from, ray.direction)
+    // Two cells out, not one. A shadow one cell along the ray sits on the shoulder of the very mirror it
+    // shadows, which no spacing rule can allow — and the empty cell between them costs nothing, since the
+    // wrong setting's beam still meets the shadow before it meets anything else the player controls.
+    let at = stepCell(stepCell(ray.from, ray.direction), ray.direction)
     for (let step = 0; step < 2 && insideGrid(size, at); step++) {
-      if (!draft.taken.has(cellKey(at))) {
+      if (!draft.taken.has(cellKey(at)) && spacedFrom(draft, at)) {
         draft.taken.add(cellKey(at))
         draft.movableCells.add(cellKey(at))
         draft.movable.push({ kind: "turnMirror", at, faces: FACES })
@@ -297,7 +323,7 @@ const buildPieces = (size: number, route: Route, options: LightbeamDials, random
       // The track runs across the beam, so the far stop takes the mirror clean out of its way and the
       // light sails past — a different sentence from a mirror turned the wrong way, and a clearer one.
       const stop = shuffle(trackStops(bend.at, bend.enter), random).find(
-        candidate => insideGrid(size, candidate) && !draft.taken.has(cellKey(candidate))
+        candidate => insideGrid(size, candidate) && !draft.taken.has(cellKey(candidate)) && spacedFrom(draft, candidate)
       )
       if (!stop) return
       draft.taken.add(cellKey(stop))
@@ -325,7 +351,7 @@ const buildPieces = (size: number, route: Route, options: LightbeamDials, random
   )
   for (const cell of straights.slice(0, options.slidingWalls)) {
     const stop = shuffle(trackStops(cell.at, cell.enter), random).find(
-      candidate => insideGrid(size, candidate) && !draft.taken.has(cellKey(candidate))
+      candidate => insideGrid(size, candidate) && !draft.taken.has(cellKey(candidate)) && spacedFrom(draft, candidate)
     )
     if (!stop) continue
     draft.taken.add(cellKey(stop))
@@ -346,6 +372,7 @@ const buildPieces = (size: number, route: Route, options: LightbeamDials, random
     for (let col = 0; col < size; col++) {
       const at = { row, col }
       if (draft.taken.has(cellKey(at)) || draft.rays.has(cellKey(at))) continue
+      if (!spacedFrom(draft, at)) continue
       open.push(at)
     }
   for (const at of shuffle(open, random).slice(0, options.decoys)) {
@@ -355,6 +382,36 @@ const buildPieces = (size: number, route: Route, options: LightbeamDials, random
     draft.solution.push(Math.floor(random() * FACES.length))
   }
   return draft
+}
+
+const NEIGHBOURS: Direction[] = ["up", "right", "down", "left"]
+
+/**
+ * No two pieces the player can tap may touch.
+ *
+ * This is a tap-accuracy rule, not an aesthetic one, and it is what lets the grid be denser than the tap
+ * target: only movable pieces are tappable, so a cell may be smaller than a thumb as long as the piece
+ * standing in it can own a hit area reaching into the empty cells around it (§9). Two adjacent movable
+ * pieces would have to share that space, and then neither can be reliably hit.
+ *
+ * Measured before this existed, essentially every board broke it — up to ten touching pairs on one wizard
+ * grid — so it is a real gate rather than a formality.
+ */
+const piecesAreSpaced = (size: number, movable: MovablePiece[]): boolean => {
+  const owner = new Map<string, number>()
+  movable.forEach((piece, index) => {
+    for (const at of pieceCells(piece)) owner.set(cellKey(at), index)
+  })
+  for (const [key, index] of owner) {
+    const [row, col] = key.split(",").map(Number)
+    for (const direction of NEIGHBOURS) {
+      const beside = stepCell({ row, col }, direction)
+      if (!insideGrid(size, beside)) continue
+      const other = owner.get(cellKey(beside))
+      if (other !== undefined && other !== index) return false
+    }
+  }
+  return true
 }
 
 const pathSignature = (puzzle: LightbeamPuzzleData, config: readonly number[]): string =>
@@ -441,6 +498,7 @@ const attemptGeneration = (
     if (!route) continue
     const draft = buildPieces(size, route, dials, random)
     if (!draft) continue
+    if (!piecesAreSpaced(size, draft.movable)) continue
 
     const puzzle: LightbeamPuzzleData = {
       size,

--- a/src/mods/puzzle/game/lightbeam/generateLightbeam.ts
+++ b/src/mods/puzzle/game/lightbeam/generateLightbeam.ts
@@ -344,7 +344,7 @@ const pathSignature = (puzzle: LightbeamPuzzleData, config: readonly number[]): 
     .join(" ")
 
 /**
- * Gate 4 — the route is the only route.
+ * The uniqueness gate — the route is the only route (design doc §5, gate 5).
  *
  * "Exactly one winning configuration" would be the wrong test for this family: a decoy has a free
  * setting by definition, so a board with decoys has many winning configurations and only one winning
@@ -361,15 +361,18 @@ const routeIsUnique = (puzzle: LightbeamPuzzleData, states: number[][]): boolean
 /**
  * Takes away every wall the board turns out not to need, to a fixpoint.
  *
- * This is where the technique cap stops being a label and starts being difficulty. Built as it is, a
- * board is a chain of `deadEnd` eliminations and nothing more — every wrong setting has a wall waiting
- * for it, so the strongest rungs of the ladder never have to fire and every tier solves the same way.
- * Thinning under the cap fixes that from the other end: at a low cap the walls are exactly what the
- * deduction spends, so they stay; at a high cap the board can be reasoned without them, so they go, and
- * what is left demands the reasoning the tier was set to demand.
- *
  * A wall the player cannot spend is worse than no wall, for the same reason a redundant sign is worse
  * than none in Futoshiki: it hides which obstacles the deduction actually turns on.
+ *
+ * In practice this removes nearly all of them — a shipped board carries 0.0 to 0.1 fixed walls, measured
+ * over 40 seeds a tier — because `blockWrongSettings` only ever adds one where the wrong ray would
+ * otherwise rejoin the route, and a board that size mostly lets a wrong turn run off the frame instead.
+ * The stone the player hears about in a hint is therefore almost always a sliding wall they are holding
+ * in the way, which is a better board than one dressed with scenery nobody can spend (design doc §5.1).
+ *
+ * Note what this is NOT: it is not what makes the technique cap bite. Removing a wall usually leaves the
+ * wrong setting running off the frame, which `deadEnd` explains just as happily — so thinning alone left
+ * every tier solving by "the light visibly dies there". The shadow pieces are what fixed that (§6.1).
  */
 const thinWalls = (
   puzzle: LightbeamPuzzleData,

--- a/src/mods/puzzle/game/lightbeam/generateLightbeam.ts
+++ b/src/mods/puzzle/game/lightbeam/generateLightbeam.ts
@@ -16,7 +16,32 @@ import {
   type MirrorFace,
   type MovablePiece,
 } from "./beam"
+import { applyGoals, drawGoals } from "./goals"
 import { solveLightbeamByTechniques, type TechniqueId } from "./techniques"
+
+export const LIGHTBEAM_GOALS = ["longChain", "sortTheWheat", "clearTheWay", "blindAlleys"] as const
+
+/** What kind of problem a board is, as against how hard it is (design doc §7). */
+export type LightbeamGoal = (typeof LIGHTBEAM_GOALS)[number]
+
+/** The knobs that shape a board. A goal turns some of these hard; the tier sets the lean baseline. */
+export type LightbeamDials = {
+  /** How many times the route bends between sun-disc and shrine. */
+  turns: number
+  /** How many of the route's mirrors are givens rather than movable. */
+  setMirrors: number
+  /** How many movable route mirrors slide to a stop instead of turning in place. */
+  slidingMirrors: number
+  /** Sliding walls parked across the route, there to be moved out of the way. */
+  slidingWalls: number
+  /** Pieces the light can never reach, there to be reasoned irrelevant (technique T4). */
+  decoys: number
+  /**
+   * Decoys placed in the stretch a wrong setting would light, so that setting cannot be ruled out by
+   * watching the light die. This is what pushes a board past `deadEnd` into the exhaustive rungs.
+   */
+  shadows: number
+}
 
 export type LightbeamPuzzle = LightbeamPuzzleData & {
   /** The state each piece opens in — every movable one deliberately wrong, so the board opens dark. */
@@ -25,26 +50,21 @@ export type LightbeamPuzzle = LightbeamPuzzleData & {
   solution: number[]
   /** Carried so hints stay inside the same ladder the board was accepted under. */
   techniqueCap: TechniqueId
+  /**
+   * The goals this board was actually built to, after any fallback. Carried as data rather than logged:
+   * a fallback that fires silently makes the whole pool decorative, and this way the playtest bench can
+   * show what a board was meant to be and a spec can assert the fallback stays rare.
+   */
+  goals: LightbeamGoal[]
 }
 
-export type LightbeamOptions = {
+export type LightbeamOptions = Partial<LightbeamDials> & {
   /** The strongest deduction a board may demand (design doc §6). */
   techniqueCap?: TechniqueId
-  /** How many times the route bends between sun-disc and shrine. */
-  turns?: number
-  /** How many of the route's mirrors are givens rather than movable. */
-  setMirrors?: number
-  /** How many movable route mirrors slide to a stop instead of turning in place. */
-  slidingMirrors?: number
-  /** Sliding walls parked across the route, there to be moved out of the way. */
-  slidingWalls?: number
-  /** Pieces the light can never reach, there to be reasoned irrelevant (technique T4). */
-  decoys?: number
-  /**
-   * Decoys placed in the stretch a wrong setting would light, so that setting cannot be ruled out by
-   * watching the light die. This is what pushes a board past `deadEnd` into the exhaustive rungs.
-   */
-  shadows?: number
+  /** Which goals this tier may draw. Empty leaves the board on its baseline dials. */
+  goals?: readonly LightbeamGoal[]
+  /** How many of them to draw. */
+  goalCount?: number
 }
 
 // Generation is route-then-obstruct, per docs/game-design/puzzles/lightbeam.md §5: lay a beam from disc
@@ -119,9 +139,13 @@ const buildRoute = (size: number, turns: number, random: () => number): Route | 
   let at = sun.at
   let direction = sun.facing
 
+  // Legs share the grid, so their length has to know how many of them there are. Drawing 1..size-2 every
+  // time ate the board in three strides and a long route then almost never fitted — which read as the goal
+  // pool falling back, not as the route builder being greedy.
+  const maxLeg = Math.max(1, Math.min(size - 2, Math.floor((size - 1) / Math.max(1, turns)) + 1))
   for (let leg = 0; leg <= turns; leg++) {
     const last = leg === turns
-    const length = last ? stepsToEdge(size, at, direction) : 1 + Math.floor(random() * Math.max(1, size - 2))
+    const length = last ? stepsToEdge(size, at, direction) : 1 + Math.floor(random() * maxLeg)
     if (length < 1) return undefined
     for (let step = 0; step < length; step++) {
       at = stepCell(at, direction)
@@ -235,12 +259,7 @@ const blockWrongSettings = (size: number, draft: Draft, rays: Ray[]): boolean =>
   return true
 }
 
-const buildPieces = (
-  size: number,
-  route: Route,
-  options: Required<LightbeamOptions>,
-  random: () => number
-): Draft | undefined => {
+const buildPieces = (size: number, route: Route, options: LightbeamDials, random: () => number): Draft | undefined => {
   const draft: Draft = {
     fixed: [],
     movable: [],
@@ -400,8 +419,7 @@ const thinWalls = (
   return fixed
 }
 
-const DEFAULTS: Required<LightbeamOptions> = {
-  techniqueCap: "deadEnd",
+const BASELINE: LightbeamDials = {
   turns: 2,
   setMirrors: 0,
   slidingMirrors: 0,
@@ -410,13 +428,18 @@ const DEFAULTS: Required<LightbeamOptions> = {
   shadows: 0,
 }
 
-export const generateLightbeam = (size: number, seed: number, options: LightbeamOptions = {}): LightbeamPuzzle => {
-  const settings = { ...DEFAULTS, ...options }
+/** One run of the build-and-gate loop, at a fixed set of dials. Undefined when the budget runs out. */
+const attemptGeneration = (
+  size: number,
+  seed: number,
+  dials: LightbeamDials,
+  cap: TechniqueId
+): Omit<LightbeamPuzzle, "goals"> | undefined => {
   for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
     const random = mulberry32(seed * 7919 + attempt)
-    const route = buildRoute(size, settings.turns, random)
+    const route = buildRoute(size, dials.turns, random)
     if (!route) continue
-    const draft = buildPieces(size, route, settings, random)
+    const draft = buildPieces(size, route, dials, random)
     if (!draft) continue
 
     const puzzle: LightbeamPuzzleData = {
@@ -430,16 +453,38 @@ export const generateLightbeam = (size: number, seed: number, options: Lightbeam
 
     const states = draft.movable.map(piece => Array.from({ length: pieceStateCount(piece) }, (_, i) => i))
     if (!routeIsUnique(puzzle, states)) continue
-    if (!solveLightbeamByTechniques(puzzle, settings.techniqueCap).settled) continue
+    if (!solveLightbeamByTechniques(puzzle, cap).settled) continue
 
-    const thinned = { ...puzzle, fixed: thinWalls(puzzle, states, settings.techniqueCap, random) }
+    const thinned = { ...puzzle, fixed: thinWalls(puzzle, states, cap, random) }
 
     // The board opens dark, and never one tap from done: every movable piece starts on a setting the
     // deduction will have to rule out.
     const initial = draft.movable.map((piece, index) => (draft.solution[index] + 1) % pieceStateCount(piece))
     if (isLit(thinned, initial)) continue
 
-    return { ...thinned, initial, solution: draft.solution, techniqueCap: settings.techniqueCap }
+    return { ...thinned, initial, solution: draft.solution, techniqueCap: cap }
+  }
+  return undefined
+}
+
+/**
+ * Builds a board at the tier's dials, with one or two goals turned hard on top (design doc §7).
+ *
+ * The fallback ladder is the part that needs care. A goal is a constraint, and two of them at once can be
+ * a pair no board satisfies — so when the budget runs out, a goal is dropped and it tries again, down to
+ * the bare baseline. What matters is that the board says which goals it ended up with (`goals` on the
+ * result) rather than the fallback happening quietly: a silent fallback that fires often would make the
+ * whole pool decorative while every measurement still looked fine.
+ */
+export const generateLightbeam = (size: number, seed: number, options: LightbeamOptions = {}): LightbeamPuzzle => {
+  const { techniqueCap = "deadEnd", goals: pool = [], goalCount = 0, ...overrides } = options
+  const baseline: LightbeamDials = { ...BASELINE, ...overrides }
+  const drawn = drawGoals(seed, pool, goalCount)
+
+  for (let dropped = 0; dropped <= drawn.length; dropped++) {
+    const goals = drawn.slice(0, drawn.length - dropped)
+    const puzzle = attemptGeneration(size, seed, applyGoals(baseline, goals), techniqueCap)
+    if (puzzle) return { ...puzzle, goals }
   }
   throw new Error(`generateLightbeam: no logically solvable board (size=${size}, seed=${seed})`)
 }

--- a/src/mods/puzzle/game/lightbeam/generateLightbeam.ts
+++ b/src/mods/puzzle/game/lightbeam/generateLightbeam.ts
@@ -1,0 +1,442 @@
+import { mulberry32, shuffle } from "@/game/random"
+import {
+  cellKey,
+  eachConfig,
+  insideGrid,
+  isLit,
+  pieceStateCount,
+  reflect,
+  segmentKey,
+  stepCell,
+  traceBeam,
+  type CellRef,
+  type Direction,
+  type FixedPiece,
+  type LightbeamPuzzleData,
+  type MirrorFace,
+  type MovablePiece,
+} from "./beam"
+import { solveLightbeamByTechniques, type TechniqueId } from "./techniques"
+
+export type LightbeamPuzzle = LightbeamPuzzleData & {
+  /** The state each piece opens in — every movable one deliberately wrong, so the board opens dark. */
+  initial: number[]
+  /** A configuration that lights the shrine. Carried for tests and for the mistake check, not for hints. */
+  solution: number[]
+  /** Carried so hints stay inside the same ladder the board was accepted under. */
+  techniqueCap: TechniqueId
+}
+
+export type LightbeamOptions = {
+  /** The strongest deduction a board may demand (design doc §6). */
+  techniqueCap?: TechniqueId
+  /** How many times the route bends between sun-disc and shrine. */
+  turns?: number
+  /** How many of the route's mirrors are givens rather than movable. */
+  setMirrors?: number
+  /** How many movable route mirrors slide to a stop instead of turning in place. */
+  slidingMirrors?: number
+  /** Sliding walls parked across the route, there to be moved out of the way. */
+  slidingWalls?: number
+  /** Pieces the light can never reach, there to be reasoned irrelevant (technique T4). */
+  decoys?: number
+  /**
+   * Decoys placed in the stretch a wrong setting would light, so that setting cannot be ruled out by
+   * watching the light die. This is what pushes a board past `deadEnd` into the exhaustive rungs.
+   */
+  shadows?: number
+}
+
+// Generation is route-then-obstruct, per docs/game-design/puzzles/lightbeam.md §5: lay a beam from disc
+// to shrine, turn some of its mirrors into pieces the player must set, then wall off the ways they could
+// be set wrong. The gates at the end are what make it a puzzle rather than a maze — the route must be
+// the only route, and the ladder must be able to find it.
+const MAX_ATTEMPTS = 600
+
+// Thinning reaches a fixpoint in two sweeps on every tier measured; the rest is the guard, not the plan.
+const MAX_PRUNE_SWEEPS = 4
+
+const FACES: MirrorFace[] = ["/", "\\"]
+
+const faceFor = (enter: Direction, exit: Direction): MirrorFace | undefined =>
+  FACES.find(face => reflect(face, enter) === exit)
+
+const perpendicular = (direction: Direction): Direction[] =>
+  direction === "up" || direction === "down" ? ["left", "right"] : ["up", "down"]
+
+/** Steps from a cell to the last one still on the grid, travelling in a direction. */
+const stepsToEdge = (size: number, at: CellRef, direction: Direction): number => {
+  switch (direction) {
+    case "up":
+      return at.row
+    case "down":
+      return size - 1 - at.row
+    case "left":
+      return at.col
+    case "right":
+      return size - 1 - at.col
+  }
+}
+
+type RouteCell = { at: CellRef; enter: Direction; exit?: Direction }
+
+type Route = {
+  sun: { at: CellRef; facing: Direction }
+  shrine: CellRef
+  /** Every cell the beam crosses, first after the disc through to the shrine. */
+  cells: RouteCell[]
+  /** The bends, in beam order — one mirror each. */
+  bends: { at: CellRef; enter: Direction; exit: Direction; face: MirrorFace }[]
+}
+
+/**
+ * The disc sits on an edge facing inward, never in a corner: a corner disc gives the first leg only one
+ * way to go, which is a turn the player can read off the frame instead of the board.
+ */
+const pickSun = (size: number, random: () => number): { at: CellRef; facing: Direction } => {
+  const along = 1 + Math.floor(random() * (size - 2))
+  const side = Math.floor(random() * 4)
+  if (side === 0) return { at: { row: 0, col: along }, facing: "down" }
+  if (side === 1) return { at: { row: size - 1, col: along }, facing: "up" }
+  if (side === 2) return { at: { row: along, col: 0 }, facing: "right" }
+  return { at: { row: along, col: size - 1 }, facing: "left" }
+}
+
+/**
+ * Lays the winning beam. Legs never revisit a cell, so the route never crosses itself — a crossing would
+ * be legal to trace but would put two reasons on one square, and every technique in the ladder points at
+ * a square.
+ *
+ * The final leg runs all the way to the frame, which sets the shrine in the wall. That is worth the
+ * constraint: a shrine on an edge can only be lit from three sides at most, and the frame kills most of
+ * those outright, which is what lets the `exitRun` deduction fire at all.
+ */
+const buildRoute = (size: number, turns: number, random: () => number): Route | undefined => {
+  const sun = pickSun(size, random)
+  const used = new Set([cellKey(sun.at)])
+  const cells: RouteCell[] = []
+  const bends: Route["bends"] = []
+  let at = sun.at
+  let direction = sun.facing
+
+  for (let leg = 0; leg <= turns; leg++) {
+    const last = leg === turns
+    const length = last ? stepsToEdge(size, at, direction) : 1 + Math.floor(random() * Math.max(1, size - 2))
+    if (length < 1) return undefined
+    for (let step = 0; step < length; step++) {
+      at = stepCell(at, direction)
+      if (!insideGrid(size, at) || used.has(cellKey(at))) return undefined
+      used.add(cellKey(at))
+      cells.push({ at, enter: direction, exit: direction })
+    }
+    if (last) {
+      cells[cells.length - 1].exit = undefined
+      return { sun, shrine: at, cells, bends }
+    }
+    const exit = shuffle(perpendicular(direction), random)[0]
+    const face = faceFor(direction, exit)
+    if (!face) return undefined
+    cells[cells.length - 1].exit = exit
+    bends.push({ at, enter: direction, exit, face })
+    direction = exit
+  }
+  return undefined
+}
+
+type Draft = {
+  fixed: FixedPiece[]
+  movable: MovablePiece[]
+  /** The winning state of each movable piece, in the same order. */
+  solution: number[]
+  /** Cells nothing else may be put on. */
+  taken: Set<string>
+  /** Cells some movable piece can stand in — what a wrong setting may run into instead of a wall. */
+  movableCells: Set<string>
+  /** Cells a wrong setting sends light across — kept clear of decoys, which must never be reachable. */
+  rays: Set<string>
+}
+
+/** Cells in the same row or column as `at`, one or two steps away, across the beam's line of travel. */
+const trackStops = (at: CellRef, across: Direction): CellRef[] =>
+  perpendicular(across).flatMap(direction =>
+    [1, 2].map(distance => {
+      let stop = at
+      for (let step = 0; step < distance; step++) stop = stepCell(stop, direction)
+      return stop
+    })
+  )
+
+type Ray = { from: CellRef; direction: Direction }
+
+/**
+ * Shadow pieces: decoys dropped into the very stretch a wrong setting would light.
+ *
+ * This is the dial that makes the technique cap mean something. Built plainly, every board is a chain of
+ * `deadEnd` eliminations — turn the mirror the wrong way and the light visibly dies — so a wizard board
+ * solves exactly like a starter one, only longer. A shadow breaks that: with something movable standing
+ * in the wrong setting's way, the light does not visibly die, it disappears into a piece nobody has
+ * settled yet. `deadEnd` has nothing to say, and ruling that setting out takes the exhaustive rungs.
+ *
+ * The shadow is still a genuine decoy — no winning beam ever touches it — so `neverReached` still frees
+ * it, and it is still the player's job to work out that it never mattered.
+ */
+const placeShadows = (size: number, draft: Draft, rays: Ray[], count: number, random: () => number) => {
+  for (const ray of shuffle(rays, random).slice(0, count)) {
+    let at = stepCell(ray.from, ray.direction)
+    for (let step = 0; step < 2 && insideGrid(size, at); step++) {
+      if (!draft.taken.has(cellKey(at))) {
+        draft.taken.add(cellKey(at))
+        draft.movableCells.add(cellKey(at))
+        draft.movable.push({ kind: "turnMirror", at, faces: FACES })
+        draft.solution.push(Math.floor(random() * FACES.length))
+        break
+      }
+      at = stepCell(at, ray.direction)
+    }
+  }
+}
+
+/**
+ * Walls off the ways a piece could be set wrong.
+ *
+ * This is what makes the family deducible rather than fiddled with: for each movable piece, the light
+ * under its wrong setting has to run out — off the frame, or into a wall — before it meets anything else
+ * the player controls. Then `deadEnd` can rule that setting out with a reason the player can see, and
+ * the piece it settles lets the entry run reach the next one. That chain is the whole starter board.
+ *
+ * A ray that runs into something movable is left alone: that is a shadow doing its job, and walling it
+ * off would undo it.
+ */
+const hasWall = (draft: Draft, at: CellRef): boolean =>
+  draft.fixed.some(piece => piece.kind === "wall" && cellKey(piece.at) === cellKey(at))
+
+const blockWrongSettings = (size: number, draft: Draft, rays: Ray[]): boolean => {
+  for (const ray of rays) {
+    // Only the first cell the wrong setting reaches is ever considered: a wall right there is the most
+    // legible dead end there is, and anything further along is a longer story for the same conclusion.
+    const first = stepCell(ray.from, ray.direction)
+    const key = cellKey(first)
+    // Off the frame, already walled, or facing a shadow that was put there on purpose: nothing to do.
+    const settled = !insideGrid(size, first) || hasWall(draft, first) || draft.movableCells.has(key)
+    if (!settled) {
+      if (draft.taken.has(key)) return false // reaches the route with nowhere to wall it off
+      draft.fixed.push({ kind: "wall", at: first })
+      draft.taken.add(key)
+      draft.rays.add(key)
+    }
+    // Everything the wrong setting lights up stays clear of decoys, whose whole point is unreachability.
+    let scan = stepCell(ray.from, ray.direction)
+    while (insideGrid(size, scan)) {
+      draft.rays.add(cellKey(scan))
+      if (hasWall(draft, scan)) break
+      scan = stepCell(scan, ray.direction)
+    }
+  }
+  return true
+}
+
+const buildPieces = (
+  size: number,
+  route: Route,
+  options: Required<LightbeamOptions>,
+  random: () => number
+): Draft | undefined => {
+  const draft: Draft = {
+    fixed: [],
+    movable: [],
+    solution: [],
+    taken: new Set(),
+    movableCells: new Set(),
+    rays: new Set(),
+  }
+  draft.taken.add(cellKey(route.sun.at))
+  for (const cell of route.cells) draft.taken.add(cellKey(cell.at))
+
+  const bends = shuffle(
+    route.bends.map((bend, index) => ({ bend, index })),
+    random
+  )
+  const setCount = Math.min(options.setMirrors, Math.max(0, route.bends.length - 1))
+  const given = new Set(bends.slice(0, setCount).map(entry => entry.index))
+  const movableBends = route.bends.filter((_, index) => !given.has(index))
+  const slidingCount = Math.min(options.slidingMirrors, movableBends.length - 1 < 0 ? 0 : movableBends.length)
+  const sliding = new Set(
+    shuffle(
+      movableBends.map(bend => cellKey(bend.at)),
+      random
+    ).slice(0, slidingCount)
+  )
+
+  const wrongRays: Ray[] = []
+
+  route.bends.forEach((bend, index) => {
+    if (given.has(index)) {
+      draft.fixed.push({ kind: "mirror", at: bend.at, face: bend.face })
+      return
+    }
+    if (sliding.has(cellKey(bend.at))) {
+      // The track runs across the beam, so the far stop takes the mirror clean out of its way and the
+      // light sails past — a different sentence from a mirror turned the wrong way, and a clearer one.
+      const stop = shuffle(trackStops(bend.at, bend.enter), random).find(
+        candidate => insideGrid(size, candidate) && !draft.taken.has(cellKey(candidate))
+      )
+      if (!stop) return
+      draft.taken.add(cellKey(stop))
+      for (const cell of [bend.at, stop]) draft.movableCells.add(cellKey(cell))
+      const stops = shuffle([bend.at, stop], random)
+      draft.movable.push({ kind: "slidingMirror", face: bend.face, stops })
+      draft.solution.push(stops.findIndex(candidate => cellKey(candidate) === cellKey(bend.at)))
+      wrongRays.push({ from: bend.at, direction: bend.enter })
+      return
+    }
+    draft.movableCells.add(cellKey(bend.at))
+    draft.movable.push({ kind: "turnMirror", at: bend.at, faces: FACES })
+    draft.solution.push(FACES.indexOf(bend.face))
+    wrongRays.push({ from: bend.at, direction: reflect(bend.face === "/" ? "\\" : "/", bend.enter) })
+  })
+  if (draft.movable.length + given.size !== route.bends.length) return undefined
+
+  // Sliding walls sit on a straight stretch of the route, and the player's move is to clear the path
+  // rather than bend it — the one piece in the family whose question is "does the light get through".
+  const straights = shuffle(
+    route.cells.filter(
+      cell => cell.exit === cell.enter && !route.bends.some(bend => cellKey(bend.at) === cellKey(cell.at))
+    ),
+    random
+  )
+  for (const cell of straights.slice(0, options.slidingWalls)) {
+    const stop = shuffle(trackStops(cell.at, cell.enter), random).find(
+      candidate => insideGrid(size, candidate) && !draft.taken.has(cellKey(candidate))
+    )
+    if (!stop) continue
+    draft.taken.add(cellKey(stop))
+    for (const at of [cell.at, stop]) draft.movableCells.add(cellKey(at))
+    const stops = shuffle([cell.at, stop], random)
+    draft.movable.push({ kind: "slidingWall", stops })
+    draft.solution.push(stops.findIndex(candidate => cellKey(candidate) !== cellKey(cell.at)))
+  }
+
+  if (!draft.movable.length) return undefined
+  placeShadows(size, draft, wrongRays, options.shadows, random)
+  if (!blockWrongSettings(size, draft, wrongRays)) return undefined
+
+  // Decoys last, on cells no wrong setting can light either — a decoy the light can reach is not a decoy,
+  // and the gates below would throw the board out for it.
+  const open: CellRef[] = []
+  for (let row = 0; row < size; row++)
+    for (let col = 0; col < size; col++) {
+      const at = { row, col }
+      if (draft.taken.has(cellKey(at)) || draft.rays.has(cellKey(at))) continue
+      open.push(at)
+    }
+  for (const at of shuffle(open, random).slice(0, options.decoys)) {
+    draft.taken.add(cellKey(at))
+    draft.movableCells.add(cellKey(at))
+    draft.movable.push({ kind: "turnMirror", at, faces: FACES })
+    draft.solution.push(Math.floor(random() * FACES.length))
+  }
+  return draft
+}
+
+const pathSignature = (puzzle: LightbeamPuzzleData, config: readonly number[]): string =>
+  traceBeam(puzzle, config)
+    .path.map(segment => segmentKey(segment.at, segment.enter))
+    .join(" ")
+
+/**
+ * Gate 4 — the route is the only route.
+ *
+ * "Exactly one winning configuration" would be the wrong test for this family: a decoy has a free
+ * setting by definition, so a board with decoys has many winning configurations and only one winning
+ * *path*. That is the property the player actually solves for, so that is the one checked.
+ */
+const routeIsUnique = (puzzle: LightbeamPuzzleData, states: number[][]): boolean => {
+  const paths = new Set<string>()
+  const ran = eachConfig(states, config => {
+    if (isLit(puzzle, config)) paths.add(pathSignature(puzzle, config))
+  })
+  return ran && paths.size === 1
+}
+
+/**
+ * Takes away every wall the board turns out not to need, to a fixpoint.
+ *
+ * This is where the technique cap stops being a label and starts being difficulty. Built as it is, a
+ * board is a chain of `deadEnd` eliminations and nothing more — every wrong setting has a wall waiting
+ * for it, so the strongest rungs of the ladder never have to fire and every tier solves the same way.
+ * Thinning under the cap fixes that from the other end: at a low cap the walls are exactly what the
+ * deduction spends, so they stay; at a high cap the board can be reasoned without them, so they go, and
+ * what is left demands the reasoning the tier was set to demand.
+ *
+ * A wall the player cannot spend is worse than no wall, for the same reason a redundant sign is worse
+ * than none in Futoshiki: it hides which obstacles the deduction actually turns on.
+ */
+const thinWalls = (
+  puzzle: LightbeamPuzzleData,
+  states: number[][],
+  cap: TechniqueId,
+  random: () => number
+): FixedPiece[] => {
+  let fixed = puzzle.fixed
+  for (let sweep = 0; sweep < MAX_PRUNE_SWEEPS; sweep++) {
+    const before = fixed.length
+    for (const wall of shuffle(
+      fixed.filter(piece => piece.kind === "wall"),
+      random
+    )) {
+      const trial = fixed.filter(piece => piece !== wall)
+      if (trial.length === fixed.length) continue
+      const candidate = { ...puzzle, fixed: trial }
+      // Both gates again: taking a wall away can open a second route as easily as it can open a
+      // deduction, and a board with two routes is not a puzzle whatever the ladder makes of it.
+      if (!routeIsUnique(candidate, states)) continue
+      if (solveLightbeamByTechniques(candidate, cap).settled) fixed = trial
+    }
+    if (fixed.length === before) break
+  }
+  return fixed
+}
+
+const DEFAULTS: Required<LightbeamOptions> = {
+  techniqueCap: "deadEnd",
+  turns: 2,
+  setMirrors: 0,
+  slidingMirrors: 0,
+  slidingWalls: 0,
+  decoys: 0,
+  shadows: 0,
+}
+
+export const generateLightbeam = (size: number, seed: number, options: LightbeamOptions = {}): LightbeamPuzzle => {
+  const settings = { ...DEFAULTS, ...options }
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+    const random = mulberry32(seed * 7919 + attempt)
+    const route = buildRoute(size, settings.turns, random)
+    if (!route) continue
+    const draft = buildPieces(size, route, settings, random)
+    if (!draft) continue
+
+    const puzzle: LightbeamPuzzleData = {
+      size,
+      sun: route.sun,
+      shrine: route.shrine,
+      fixed: draft.fixed,
+      movable: draft.movable,
+    }
+    if (!isLit(puzzle, draft.solution)) continue
+
+    const states = draft.movable.map(piece => Array.from({ length: pieceStateCount(piece) }, (_, i) => i))
+    if (!routeIsUnique(puzzle, states)) continue
+    if (!solveLightbeamByTechniques(puzzle, settings.techniqueCap).settled) continue
+
+    const thinned = { ...puzzle, fixed: thinWalls(puzzle, states, settings.techniqueCap, random) }
+
+    // The board opens dark, and never one tap from done: every movable piece starts on a setting the
+    // deduction will have to rule out.
+    const initial = draft.movable.map((piece, index) => (draft.solution[index] + 1) % pieceStateCount(piece))
+    if (isLit(thinned, initial)) continue
+
+    return { ...thinned, initial, solution: draft.solution, techniqueCap: settings.techniqueCap }
+  }
+  throw new Error(`generateLightbeam: no logically solvable board (size=${size}, seed=${seed})`)
+}

--- a/src/mods/puzzle/game/lightbeam/goals.spec.ts
+++ b/src/mods/puzzle/game/lightbeam/goals.spec.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest"
+import { difficulties } from "@/data/difficultyLevels"
+import { applyGoals, drawGoals, GOAL_DIALS } from "./goals"
+import { generateLightbeam, LIGHTBEAM_GOALS, type LightbeamDials, type LightbeamGoal } from "./generateLightbeam"
+import { LIGHTBEAM_CONFIG } from "./lightbeamConfig"
+import { solveLightbeamByTechniques } from "./techniques"
+
+const LEAN: LightbeamDials = { turns: 2, setMirrors: 0, slidingMirrors: 0, slidingWalls: 0, decoys: 0, shadows: 0 }
+
+const DIALS = ["turns", "setMirrors", "slidingMirrors", "slidingWalls", "decoys", "shadows"] as const
+
+describe("the goal pool", () => {
+  it("has a dial change for every goal in the list", () => {
+    for (const goal of LIGHTBEAM_GOALS) expect(GOAL_DIALS[goal]).toBeTypeOf("function")
+  })
+
+  // The property that lets two goals apply together and both still mean something. An earlier draft had
+  // each goal flatten the dials it did not care about, so drawing two silently cancelled the first.
+  it("only ever turns a dial up, never down", () => {
+    for (const goal of LIGHTBEAM_GOALS) {
+      const after = GOAL_DIALS[goal](LEAN)
+      for (const dial of DIALS) expect(after[dial]).toBeGreaterThanOrEqual(LEAN[dial])
+    }
+  })
+
+  it("gives the same board whichever order two goals are applied in", () => {
+    for (const first of LIGHTBEAM_GOALS)
+      for (const second of LIGHTBEAM_GOALS)
+        expect(applyGoals(LEAN, [first, second])).toEqual(applyGoals(LEAN, [second, first]))
+  })
+
+  it("each goal actually changes something", () => {
+    for (const goal of LIGHTBEAM_GOALS) expect(GOAL_DIALS[goal](LEAN)).not.toEqual(LEAN)
+  })
+
+  // Character, not size: a goal adds one or two pieces so the tier still decides how big a board is. The
+  // first cut added four per pair, which put five pieces on a starter board and collapsed the top three
+  // tiers into one ten-piece blur.
+  it("adds at most two pieces' worth of work", () => {
+    for (const goal of LIGHTBEAM_GOALS) {
+      const after = GOAL_DIALS[goal](LEAN)
+      const added =
+        after.turns -
+        after.setMirrors -
+        (LEAN.turns - LEAN.setMirrors) +
+        (after.slidingWalls - LEAN.slidingWalls) +
+        (after.decoys - LEAN.decoys) +
+        (after.shadows - LEAN.shadows)
+      expect(added).toBeLessThanOrEqual(2)
+    }
+  })
+})
+
+describe("drawGoals", () => {
+  it("is deterministic for a seed", () => {
+    expect(drawGoals(7, LIGHTBEAM_GOALS, 2)).toEqual(drawGoals(7, LIGHTBEAM_GOALS, 2))
+  })
+
+  it("draws different sets for different seeds", () => {
+    const drawn = new Set(Array.from({ length: 20 }, (_, seed) => drawGoals(seed + 1, LIGHTBEAM_GOALS, 2).join("+")))
+    expect(drawn.size).toBeGreaterThan(1)
+  })
+
+  it("never asks for more goals than the pool holds", () => {
+    expect(drawGoals(1, ["longChain"], 3)).toEqual(["longChain"])
+    expect(drawGoals(1, [], 2)).toEqual([])
+  })
+})
+
+describe("goals on generated boards", () => {
+  describe.each(difficulties)("at %s", difficulty => {
+    const { size, ...options } = LIGHTBEAM_CONFIG[difficulty]
+    const boards = Array.from({ length: 24 }, (_, seed) => generateLightbeam(size, seed + 1, options))
+    const wanted = options.goalCount ?? 0
+
+    it("records what it was built to, so a fallback cannot happen quietly", () => {
+      for (const board of boards) expect(board.goals.length).toBeLessThanOrEqual(wanted)
+    })
+
+    it("draws its full set of goals — the fallback ladder is the guard, not the plan", () => {
+      // A fallback that fires often would make the whole pool decorative while every other measurement
+      // still looked fine, so this is asserted rather than trusted.
+      const fellBack = boards.filter(board => board.goals.length < wanted)
+      expect(fellBack).toHaveLength(0)
+    })
+
+    it("only draws goals its cap can actually resolve", () => {
+      for (const board of boards) for (const goal of board.goals) expect(options.goals).toContain(goal)
+    })
+
+    it("spreads its boards over more than one kind of problem", () => {
+      if (!wanted) return
+      const kinds = new Set(boards.map(board => [...board.goals].sort().join("+")))
+      expect(kinds.size).toBeGreaterThan(1)
+    })
+
+    it("still settles inside its cap whatever it drew", () => {
+      for (const board of boards) expect(solveLightbeamByTechniques(board, board.techniqueCap).settled).toBe(true)
+    })
+  })
+})
+
+describe("a goal changes the board it names", () => {
+  const build = (goals: LightbeamGoal[]) =>
+    generateLightbeam(6, 5, {
+      turns: 3,
+      slidingMirrors: 1,
+      techniqueCap: "onlySurvivor",
+      goals,
+      goalCount: goals.length,
+    })
+
+  it("sortTheWheat leaves pieces the light can never reach", () => {
+    const bare = solveLightbeamByTechniques(build([]), "onlySurvivor").board.free.size
+    const sorted = solveLightbeamByTechniques(build(["sortTheWheat"]), "onlySurvivor").board.free.size
+    expect(sorted).toBeGreaterThan(bare)
+  })
+
+  it("clearTheWay puts stone across the route", () => {
+    expect(build(["clearTheWay"]).movable.filter(piece => piece.kind === "slidingWall").length).toBeGreaterThan(
+      build([]).movable.filter(piece => piece.kind === "slidingWall").length
+    )
+  })
+
+  it("longChain lengthens the beam", () => {
+    expect(build(["longChain"]).fixed.filter(piece => piece.kind === "mirror").length).toBeGreaterThan(0)
+  })
+})

--- a/src/mods/puzzle/game/lightbeam/goals.spec.ts
+++ b/src/mods/puzzle/game/lightbeam/goals.spec.ts
@@ -101,14 +101,19 @@ describe("goals on generated boards", () => {
 })
 
 describe("a goal changes the board it names", () => {
-  const build = (goals: LightbeamGoal[]) =>
-    generateLightbeam(6, 5, {
+  const build = (goals: LightbeamGoal[]) => {
+    const puzzle = generateLightbeam(8, 5, {
       turns: 3,
       slidingMirrors: 1,
       techniqueCap: "onlySurvivor",
       goals,
       goalCount: goals.length,
     })
+    // Guards the tests below against a silent fallback: comparing a board that dropped its goal with one
+    // that never had it would pass for the wrong reason.
+    expect(puzzle.goals).toEqual(goals)
+    return puzzle
+  }
 
   it("sortTheWheat leaves pieces the light can never reach", () => {
     const bare = solveLightbeamByTechniques(build([]), "onlySurvivor").board.free.size
@@ -123,6 +128,10 @@ describe("a goal changes the board it names", () => {
   })
 
   it("longChain lengthens the beam", () => {
-    expect(build(["longChain"]).fixed.filter(piece => piece.kind === "mirror").length).toBeGreaterThan(0)
+    const bends = (goals: LightbeamGoal[]) => {
+      const board = build(goals)
+      return board.fixed.filter(piece => piece.kind === "mirror").length + board.movable.length
+    }
+    expect(bends(["longChain"])).toBeGreaterThan(bends([]))
   })
 })

--- a/src/mods/puzzle/game/lightbeam/goals.ts
+++ b/src/mods/puzzle/game/lightbeam/goals.ts
@@ -1,0 +1,56 @@
+import { mulberry32, shuffle } from "@/game/random"
+import type { LightbeamDials, LightbeamGoal } from "./generateLightbeam"
+
+// The goal pool, per docs/game-design/puzzles/lightbeam.md §7.
+//
+// Without this, every tier turns every dial a little and every board is the AVERAGE board for its tier:
+// a wizard grid was five turns AND a set mirror AND two sliding mirrors AND a sliding wall AND a decoy
+// AND three shadows, every single time. A goal draws one or two dials and turns those hard, leaving the
+// rest at the tier's lean baseline — so boards have character rather than mean settings, and "how hard is
+// this" (the cap) stops being welded to "what kind of problem is this".
+//
+// Goals only ever ADD to their own dials, never zero another's. That is what lets two of them apply in
+// either order and still mean what they say; an earlier draft had each goal flatten the dials it did not
+// care about, and drawing two then silently cancelled the first.
+// The division of labour that keeps the tier ramp intact: **the tier sets the route** — how long, how
+// wide, how much of it is given — and **a goal sets what is in the way**. So a goal adds one or two pieces,
+// never four, and the tier still decides how big a board is.
+//
+// The first cut had each goal add two of its own thing on top of baselines that already carried some. Two
+// goals then added four pieces, which put five pieces on a starter board that wanted three and collapsed
+// expert, master and wizard into the same ten-piece blur.
+export const GOAL_DIALS: Record<LightbeamGoal, (dials: LightbeamDials) => LightbeamDials> = {
+  /**
+   * A long bending route and nothing to distract from it. This board is about following the light.
+   *
+   * Two more bends but one more given mirror, so the route grows visibly while the player's workload grows
+   * by one piece — the length is the character, not the piece count.
+   */
+  longChain: dials => ({ ...dials, turns: dials.turns + 2, setMirrors: dials.setMirrors + 1 }),
+
+  /** A route buried in pieces that do not matter. The skill is telling which is which (technique T4). */
+  sortTheWheat: dials => ({ ...dials, decoys: dials.decoys + 2 }),
+
+  /**
+   * Stone in the way rather than a corner to find: the question is whether the light gets through.
+   *
+   * Deliberately does NOT lengthen the route. It used to add a turn as well, to be sure of a straight
+   * stretch to park the wall on, and paired with `longChain` that asked for seven bends on a seven-wide
+   * grid — which is where a fifth of wizard boards were falling back to no goals at all.
+   */
+  clearTheWay: dials => ({ ...dials, slidingWalls: dials.slidingWalls + 1 }),
+
+  /** Every wrong turn vanishes into something unsettled, so nothing is ruled out by watching it die. */
+  blindAlleys: dials => ({ ...dials, shadows: dials.shadows + 1 }),
+}
+
+export const applyGoals = (dials: LightbeamDials, goals: readonly LightbeamGoal[]): LightbeamDials =>
+  goals.reduce((carried, goal) => GOAL_DIALS[goal](carried), dials)
+
+/**
+ * Which goals this board gets. Drawn from its own stream rather than the attempt stream, so the goals stay
+ * put while generation retries — a board that re-rolled its goals on every attempt would just drift to
+ * whichever pair happens to be easiest to build.
+ */
+export const drawGoals = (seed: number, pool: readonly LightbeamGoal[], count: number): LightbeamGoal[] =>
+  shuffle([...pool], mulberry32(seed * 104729)).slice(0, Math.min(count, pool.length))

--- a/src/mods/puzzle/game/lightbeam/lightbeamConfig.ts
+++ b/src/mods/puzzle/game/lightbeam/lightbeamConfig.ts
@@ -30,19 +30,28 @@ import type { LightbeamOptions } from "./generateLightbeam"
 // - `blindAlleys` piles on shadows, which need at least the shrine-side elimination to unpick — so junior
 //   and up.
 //
-// 7 wide is the ceiling, matching the other grid families: inside a 360px encounter modal there are no
-// gutters to reclaim here, so a cell is simply the board over N — 45px at seven columns, and an eighth
-// would drop under a thumb's width (docs/instructions/puzzle-screens.md §1).
+// **Grid size is capacity, not difficulty.** It is set by what has to fit — the route's length, the pieces,
+// and the empty shoulders that keep two tappable pieces apart — and it barely moves how hard a board is,
+// because the configuration space is driven by piece count and the reasoning by the cap. Difficulty is the
+// cap and the goals; size is the canvas they need. An earlier version of this table listed grid size as a
+// difficulty knob, which was wrong.
+//
+// That is also why this family goes past the 7-wide ceiling the other grid families stop at. Theirs is a
+// real ceiling because every cell is tappable, so cell size IS tap-target size. Here only the movable
+// pieces are tappable, they are never allowed to touch (generateLightbeam's `piecesAreSpaced`), and a piece
+// therefore owns the empty shoulders around it — so its hit area can be a thumb wide while the cell it
+// stands in is smaller. `LightbeamBoard` spends that, and the sizes below run 45 / 45 / 40 / 40 / 35px a
+// cell inside a 360px modal (docs/instructions/puzzle-screens.md §1, and §9 of the family doc).
 export const LIGHTBEAM_CONFIG: Record<Difficulty, { size: number } & LightbeamOptions> = {
   starter: {
-    size: 5,
+    size: 7,
     turns: 2,
     techniqueCap: "deadEnd",
     goals: ["longChain", "clearTheWay"],
     goalCount: 1,
   },
   junior: {
-    size: 5,
+    size: 7,
     turns: 3,
     slidingMirrors: 1,
     techniqueCap: "feedsExit",
@@ -50,7 +59,7 @@ export const LIGHTBEAM_CONFIG: Record<Difficulty, { size: number } & LightbeamOp
     goalCount: 1,
   },
   expert: {
-    size: 6,
+    size: 8,
     turns: 3,
     slidingMirrors: 1,
     techniqueCap: "neverReached",
@@ -58,7 +67,7 @@ export const LIGHTBEAM_CONFIG: Record<Difficulty, { size: number } & LightbeamOp
     goalCount: 2,
   },
   master: {
-    size: 6,
+    size: 8,
     turns: 3,
     slidingMirrors: 1,
     shadows: 1,
@@ -67,7 +76,7 @@ export const LIGHTBEAM_CONFIG: Record<Difficulty, { size: number } & LightbeamOp
     goalCount: 2,
   },
   wizard: {
-    size: 7,
+    size: 9,
     turns: 5,
     setMirrors: 1,
     slidingMirrors: 1,

--- a/src/mods/puzzle/game/lightbeam/lightbeamConfig.ts
+++ b/src/mods/puzzle/game/lightbeam/lightbeamConfig.ts
@@ -6,15 +6,24 @@ import type { LightbeamOptions } from "./generateLightbeam"
 // inside a wizard pyramid, so a starter board is not only ever seen by a beginner. Starter is therefore
 // gentle rather than empty — a real route to find, just a short one with a low cap.
 //
-// The cap is the dial that carries the difficulty, as everywhere: it is what a board may DEMAND. Turn
-// count and decoy count shape how a board feels; the cap is what it costs to solve.
+// Two dials do the work, and they pull against each other:
+//
+// - **The cap** is what a board may DEMAND, as everywhere in the catalogue.
+// - **`shadows`** is what makes a board demand it. Built without them, a board is a chain of "the light
+//   visibly dies there" whatever the cap says, and every tier solves like starter only bigger. A shadow
+//   puts something unsettled in the way of a wrong setting, and then ruling that setting out takes the
+//   rungs the tier was set to reach.
+//
+// Measured over 40 seeds a tier: 3.0 / 3.7 / 5.8 / 6.6 / 8.4 movable pieces and 8 / 14 / 57 / 105 / 371
+// configurations, so the space the player is choosing inside grows the whole way up. Starter is settled
+// by a visible dead end alone; two thirds of master and wizard boards need the exhaustive rung.
 //
 // 7 wide is the ceiling, matching the other grid families: inside a 360px encounter modal there are no
-// gutters to reclaim here, so a cell is simply the board over N, and an eighth column drops under a
-// thumb's width (docs/instructions/puzzle-screens.md §1).
+// gutters to reclaim here, so a cell is simply the board over N — 47px at seven columns, and an eighth
+// would drop under a thumb's width (docs/instructions/puzzle-screens.md §1).
 export const LIGHTBEAM_CONFIG: Record<Difficulty, { size: number } & LightbeamOptions> = {
-  starter: { size: 5, turns: 2, techniqueCap: "deadEnd" },
-  junior: { size: 5, turns: 3, setMirrors: 1, slidingMirrors: 1, shadows: 1, techniqueCap: "feedsExit" },
+  starter: { size: 5, turns: 3, techniqueCap: "deadEnd" },
+  junior: { size: 5, turns: 4, setMirrors: 1, slidingMirrors: 1, shadows: 1, techniqueCap: "feedsExit" },
   expert: {
     size: 6,
     turns: 3,
@@ -26,12 +35,11 @@ export const LIGHTBEAM_CONFIG: Record<Difficulty, { size: number } & LightbeamOp
   },
   master: {
     size: 6,
-    turns: 4,
-    setMirrors: 1,
+    turns: 3,
     slidingMirrors: 1,
     slidingWalls: 1,
     decoys: 1,
-    shadows: 1,
+    shadows: 2,
     techniqueCap: "onlySurvivor",
   },
   wizard: {
@@ -41,7 +49,7 @@ export const LIGHTBEAM_CONFIG: Record<Difficulty, { size: number } & LightbeamOp
     slidingMirrors: 2,
     slidingWalls: 1,
     decoys: 1,
-    shadows: 2,
+    shadows: 3,
     techniqueCap: "onlySurvivor",
   },
 }

--- a/src/mods/puzzle/game/lightbeam/lightbeamConfig.ts
+++ b/src/mods/puzzle/game/lightbeam/lightbeamConfig.ts
@@ -1,0 +1,47 @@
+import type { Difficulty } from "@/data/difficultyLevels"
+import type { LightbeamOptions } from "./generateLightbeam"
+
+// Tier settings, from docs/game-design/puzzles/lightbeam.md §6. Every tier gets a full configuration:
+// this family is not gated to a debut tier, because a starter corridor can sit behind a ward gate deep
+// inside a wizard pyramid, so a starter board is not only ever seen by a beginner. Starter is therefore
+// gentle rather than empty — a real route to find, just a short one with a low cap.
+//
+// The cap is the dial that carries the difficulty, as everywhere: it is what a board may DEMAND. Turn
+// count and decoy count shape how a board feels; the cap is what it costs to solve.
+//
+// 7 wide is the ceiling, matching the other grid families: inside a 360px encounter modal there are no
+// gutters to reclaim here, so a cell is simply the board over N, and an eighth column drops under a
+// thumb's width (docs/instructions/puzzle-screens.md §1).
+export const LIGHTBEAM_CONFIG: Record<Difficulty, { size: number } & LightbeamOptions> = {
+  starter: { size: 5, turns: 2, techniqueCap: "deadEnd" },
+  junior: { size: 5, turns: 3, setMirrors: 1, slidingMirrors: 1, shadows: 1, techniqueCap: "feedsExit" },
+  expert: {
+    size: 6,
+    turns: 3,
+    slidingMirrors: 1,
+    slidingWalls: 1,
+    decoys: 1,
+    shadows: 1,
+    techniqueCap: "neverReached",
+  },
+  master: {
+    size: 6,
+    turns: 4,
+    setMirrors: 1,
+    slidingMirrors: 1,
+    slidingWalls: 1,
+    decoys: 1,
+    shadows: 1,
+    techniqueCap: "onlySurvivor",
+  },
+  wizard: {
+    size: 7,
+    turns: 5,
+    setMirrors: 1,
+    slidingMirrors: 2,
+    slidingWalls: 1,
+    decoys: 1,
+    shadows: 2,
+    techniqueCap: "onlySurvivor",
+  },
+}

--- a/src/mods/puzzle/game/lightbeam/lightbeamConfig.ts
+++ b/src/mods/puzzle/game/lightbeam/lightbeamConfig.ts
@@ -1,55 +1,80 @@
 import type { Difficulty } from "@/data/difficultyLevels"
 import type { LightbeamOptions } from "./generateLightbeam"
 
-// Tier settings, from docs/game-design/puzzles/lightbeam.md §6. Every tier gets a full configuration:
-// this family is not gated to a debut tier, because a starter corridor can sit behind a ward gate deep
-// inside a wizard pyramid, so a starter board is not only ever seen by a beginner. Starter is therefore
-// gentle rather than empty — a real route to find, just a short one with a low cap.
+// Tier settings, from docs/game-design/puzzles/lightbeam.md §6 and §7. Every tier gets a full
+// configuration: this family is not gated to a debut tier, because a starter corridor can sit behind a
+// ward gate deep inside a wizard pyramid, so a starter board is not only ever seen by a beginner. Starter
+// is therefore gentle rather than empty — a real route to find, just a short one with a low cap.
 //
-// Two dials do the work, and they pull against each other:
+// Three dials, and they do different jobs:
 //
 // - **The cap** is what a board may DEMAND, as everywhere in the catalogue.
 // - **`shadows`** is what makes a board demand it. Built without them, a board is a chain of "the light
 //   visibly dies there" whatever the cap says, and every tier solves like starter only bigger. A shadow
-//   puts something unsettled in the way of a wrong setting, and then ruling that setting out takes the
-//   rungs the tier was set to reach.
+//   puts something unsettled in the way of a wrong setting, so ruling that setting out takes the rungs the
+//   tier was set to reach.
+// - **`goals`** is what kind of problem the board is, as against how hard. The numbers below are a LEAN
+//   BASELINE, and one or two goals turn their own dials hard on top (goals.ts). Before this existed every
+//   dial was turned a little on every board, so every wizard grid was the average wizard grid.
 //
-// Measured over 40 seeds a tier: 3.0 / 3.7 / 5.8 / 6.6 / 8.4 movable pieces and 8 / 14 / 57 / 105 / 371
-// configurations, so the space the player is choosing inside grows the whole way up. Starter is settled
-// by a visible dead end alone; two thirds of master and wizard boards need the exhaustive rung.
+// The split that keeps the ramp intact: **the tier sets the route** — how long, how wide, how much is
+// given — and **a goal sets what is in the way**. Measured over 40 seeds a tier with goals drawn:
+// 3.0 / 3.9 / 5.4 / 6.3 / 8.0 movable pieces and 8 / 15 / 45 / 82 / 315 configurations, no goal falling
+// back on any tier, worst generation 50ms. Starter is settled by a visible dead end alone; expert always
+// has a piece to reason irrelevant; half of master and two thirds of wizard need the exhaustive rung.
+//
+// Which goals a tier may draw is a fairness question, not a taste one:
+//
+// - `sortTheWheat` piles on decoys, and a decoy is only fair once `neverReached` can prove it irrelevant —
+//   so expert and up.
+// - `blindAlleys` piles on shadows, which need at least the shrine-side elimination to unpick — so junior
+//   and up.
 //
 // 7 wide is the ceiling, matching the other grid families: inside a 360px encounter modal there are no
-// gutters to reclaim here, so a cell is simply the board over N — 47px at seven columns, and an eighth
+// gutters to reclaim here, so a cell is simply the board over N — 45px at seven columns, and an eighth
 // would drop under a thumb's width (docs/instructions/puzzle-screens.md §1).
 export const LIGHTBEAM_CONFIG: Record<Difficulty, { size: number } & LightbeamOptions> = {
-  starter: { size: 5, turns: 3, techniqueCap: "deadEnd" },
-  junior: { size: 5, turns: 4, setMirrors: 1, slidingMirrors: 1, shadows: 1, techniqueCap: "feedsExit" },
+  starter: {
+    size: 5,
+    turns: 2,
+    techniqueCap: "deadEnd",
+    goals: ["longChain", "clearTheWay"],
+    goalCount: 1,
+  },
+  junior: {
+    size: 5,
+    turns: 3,
+    slidingMirrors: 1,
+    techniqueCap: "feedsExit",
+    goals: ["longChain", "clearTheWay", "blindAlleys"],
+    goalCount: 1,
+  },
   expert: {
     size: 6,
     turns: 3,
     slidingMirrors: 1,
-    slidingWalls: 1,
-    decoys: 1,
-    shadows: 1,
     techniqueCap: "neverReached",
+    goals: ["longChain", "sortTheWheat", "clearTheWay", "blindAlleys"],
+    goalCount: 2,
   },
   master: {
     size: 6,
     turns: 3,
     slidingMirrors: 1,
-    slidingWalls: 1,
-    decoys: 1,
-    shadows: 2,
+    shadows: 1,
     techniqueCap: "onlySurvivor",
+    goals: ["longChain", "sortTheWheat", "clearTheWay", "blindAlleys"],
+    goalCount: 2,
   },
   wizard: {
     size: 7,
     turns: 5,
     setMirrors: 1,
-    slidingMirrors: 2,
-    slidingWalls: 1,
+    slidingMirrors: 1,
     decoys: 1,
-    shadows: 3,
+    shadows: 1,
     techniqueCap: "onlySurvivor",
+    goals: ["longChain", "sortTheWheat", "clearTheWay", "blindAlleys"],
+    goalCount: 2,
   },
 }

--- a/src/mods/puzzle/game/lightbeam/lightbeamState.spec.ts
+++ b/src/mods/puzzle/game/lightbeam/lightbeamState.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest"
+import { isLit } from "./beam"
+import { generateLightbeam } from "./generateLightbeam"
+import { createLightbeamState, cycleLightbeamPiece, pieceMoved } from "./lightbeamState"
+
+const puzzle = generateLightbeam(5, 3, { turns: 2 })
+
+describe("lightbeamState", () => {
+  it("opens on the board's own starting settings", () => {
+    expect(createLightbeamState(puzzle).states).toEqual(puzzle.initial)
+  })
+
+  it("a tap moves one piece on and leaves the rest alone", () => {
+    const state = cycleLightbeamPiece(createLightbeamState(puzzle), puzzle, 0)
+    expect(state.states[0]).not.toBe(puzzle.initial[0])
+    expect(state.states.slice(1)).toEqual(puzzle.initial.slice(1))
+  })
+
+  // The reason this family has no undo: a piece has two settings, so tapping round again is the undo.
+  it("tapping a piece round returns it to where it was", () => {
+    let state = createLightbeamState(puzzle)
+    for (let tap = 0; tap < 2; tap++) state = cycleLightbeamPiece(state, puzzle, 0)
+    expect(state.states).toEqual(puzzle.initial)
+  })
+
+  it("does not touch the state it was handed", () => {
+    const before = createLightbeamState(puzzle)
+    cycleLightbeamPiece(before, puzzle, 0)
+    expect(before.states).toEqual(puzzle.initial)
+  })
+
+  it("notices a piece the player has moved off its opening setting", () => {
+    const state = cycleLightbeamPiece(createLightbeamState(puzzle), puzzle, 0)
+    expect(pieceMoved(state, puzzle, 0)).toBe(true)
+    expect(pieceMoved(createLightbeamState(puzzle), puzzle, 0)).toBe(false)
+  })
+
+  it("reaches the answer by tapping, which is all the player can do", () => {
+    let state = createLightbeamState(puzzle)
+    puzzle.movable.forEach((_, piece) => {
+      while (state.states[piece] !== puzzle.solution[piece]) state = cycleLightbeamPiece(state, puzzle, piece)
+    })
+    expect(isLit(puzzle, state.states)).toBe(true)
+  })
+})

--- a/src/mods/puzzle/game/lightbeam/lightbeamState.ts
+++ b/src/mods/puzzle/game/lightbeam/lightbeamState.ts
@@ -1,0 +1,26 @@
+import { produce } from "immer"
+import { pieceStateCount, type LightbeamPuzzleData } from "./beam"
+import type { LightbeamPuzzle } from "./generateLightbeam"
+
+/**
+ * The whole of the player's answer: which state each movable piece is in.
+ *
+ * There is no undo stack here, and that is deliberate (design doc §7). A tap cycles a piece, and cycling
+ * round again puts it back — the move is its own inverse, so nothing a tap does is unrecoverable. The
+ * Futoshiki argument for undo was that a placement destroyed pencilled work elsewhere; nothing here
+ * destroys anything.
+ */
+export type LightbeamState = {
+  states: number[]
+}
+
+export const createLightbeamState = (puzzle: LightbeamPuzzle): LightbeamState => ({ states: [...puzzle.initial] })
+
+export const cycleLightbeamPiece = produce((state: LightbeamState, puzzle: LightbeamPuzzleData, piece: number) => {
+  const total = pieceStateCount(puzzle.movable[piece])
+  state.states[piece] = (state.states[piece] + 1) % total
+})
+
+/** How many taps this piece is away from where it started — what a "you have been fiddling" hint reads. */
+export const pieceMoved = (state: LightbeamState, puzzle: LightbeamPuzzle, piece: number): boolean =>
+  state.states[piece] !== puzzle.initial[piece]

--- a/src/mods/puzzle/game/lightbeam/meta.ts
+++ b/src/mods/puzzle/game/lightbeam/meta.ts
@@ -1,0 +1,13 @@
+import type { FamilyMeta } from "@/game/families/familyMeta"
+
+export const LIGHTBEAM_META: FamilyMeta = {
+  id: "lightbeam",
+  ownerMod: "puzzle",
+  tags: ["puzzle"],
+  // Configured for every tier (docs/game-design/puzzles/lightbeam.md §6), so the allocator may draw it
+  // anywhere and a node may author it anywhere.
+  minTier: "starter",
+  icon: "🔆",
+  color: "amber",
+  rewardPriority: 60, // fills only once treasure's guaranteed slots are spoken for
+}

--- a/src/mods/puzzle/game/lightbeam/techniques.spec.ts
+++ b/src/mods/puzzle/game/lightbeam/techniques.spec.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "vitest"
+import type { LightbeamPuzzleData } from "./beam"
+import {
+  applyLightbeamDecisions,
+  applyLightbeamTechniques,
+  createLightbeamBoard,
+  lightbeamSettled,
+  nextLightbeamStep,
+  settledStates,
+  solveLightbeamByTechniques,
+  techniquesUpTo,
+  TECHNIQUES,
+  type TechniqueId,
+} from "./techniques"
+
+/**
+ * A minimal deducible board. The disc shines down column 1; a turn mirror at (2,1) must bend it right to
+ * the shrine on the right edge, and a wall waits where the other face would send it.
+ *
+ *     · S · · ·      S = disc facing down    X = shrine
+ *     · · · · ·      M = the turn mirror     # = wall
+ *     # M · · X
+ *     · · · · ·
+ */
+const oneMirror: LightbeamPuzzleData = {
+  size: 5,
+  sun: { at: { row: 0, col: 1 }, facing: "down" },
+  shrine: { row: 2, col: 4 },
+  fixed: [{ kind: "wall", at: { row: 2, col: 0 } }],
+  movable: [{ kind: "turnMirror", at: { row: 2, col: 1 }, faces: ["/", "\\"] }],
+}
+
+/** Runs the ladder up to `cap` and hands back only what the last technique to fire concluded. */
+const firstStep = (puzzle: LightbeamPuzzleData, cap: TechniqueId, only?: TechniqueId) => {
+  const board = createLightbeamBoard(puzzle)
+  const allowed = only ? techniquesUpTo(cap).filter(technique => technique !== only) : []
+  // Spend the cheaper rungs first, so the technique under test is the one left with something to say.
+  if (only)
+    for (let pass = 0; pass < 12; pass++) {
+      const harvest = applyLightbeamTechniques(board, allowed)
+      if (!harvest) break
+      for (const step of harvest) applyLightbeamDecisions(board, step.decisions)
+    }
+  return nextLightbeamStep(board, cap)
+}
+
+describe("the ladder", () => {
+  it("is ordered by how well a reason explains itself, cheapest first", () => {
+    expect([...TECHNIQUES]).toEqual(["entryRun", "exitRun", "deadEnd", "feedsExit", "neverReached", "onlySurvivor"])
+  })
+
+  it("a cap admits itself and everything below it", () => {
+    expect(techniquesUpTo("deadEnd")).toEqual(["entryRun", "exitRun", "deadEnd"])
+  })
+})
+
+describe("entryRun", () => {
+  it("settles the stretch before the light meets anything the player can change", () => {
+    const step = nextLightbeamStep(createLightbeamBoard(oneMirror), "entryRun")
+    expect(step?.technique).toBe("entryRun")
+    // Down column 1 to the mirror, and no further: that cell could be facing either way.
+    expect(step?.beam.map(segment => segment.at)).toEqual([
+      { row: 1, col: 1 },
+      { row: 2, col: 1 },
+    ])
+  })
+})
+
+describe("exitRun", () => {
+  it("finds the only side the shrine can be lit from", () => {
+    const step = firstStep(oneMirror, "exitRun", "exitRun")
+    expect(step?.technique).toBe("exitRun")
+    // The shrine sits on the right edge, so light can only reach it travelling rightwards.
+    expect(step?.decisions).toContainEqual({ kind: "shrineEntry", direction: "right" })
+  })
+
+  it("says nothing while two sides are still open", () => {
+    // A shrine in open ground with something unsettled on two of its approaches: light could arrive
+    // rightwards off the mirror beside it, or downwards off the one above it, and nothing yet tells them
+    // apart. The frame rules out the other two sides, but two open sides is one too many.
+    const open: LightbeamPuzzleData = {
+      ...oneMirror,
+      shrine: { row: 2, col: 2 },
+      fixed: [],
+      movable: [...oneMirror.movable, { kind: "turnMirror", at: { row: 1, col: 2 }, faces: ["/", "\\"] }],
+    }
+    expect(applyLightbeamTechniques(createLightbeamBoard(open), ["exitRun"])).toBeUndefined()
+  })
+})
+
+describe("deadEnd", () => {
+  it("rules out the face that walks the light into a wall", () => {
+    const step = firstStep(oneMirror, "deadEnd", "deadEnd")
+    expect(step?.technique).toBe("deadEnd")
+    expect(step?.variant).toBe("wall")
+    // Face "/" sends the beam left, into the wall at (2,0).
+    expect(step?.decisions).toEqual([{ kind: "eliminate", piece: 0, states: [0] }])
+  })
+
+  it("tells the frame apart from a wall — they are different sentences", () => {
+    const noWall: LightbeamPuzzleData = { ...oneMirror, fixed: [] }
+    expect(firstStep(noWall, "deadEnd", "deadEnd")?.variant).toBe("edge")
+  })
+
+  it("blames nothing when every setting dies — a broken board is not the piece's fault", () => {
+    // The shrine is unreachable whichever way the mirror faces, so neither face may be ruled out.
+    const hopeless: LightbeamPuzzleData = { ...oneMirror, shrine: { row: 4, col: 4 } }
+    const board = createLightbeamBoard(hopeless)
+    applyLightbeamDecisions(
+      board,
+      (applyLightbeamTechniques(board, ["entryRun"]) ?? []).flatMap(step => step.decisions)
+    )
+    expect(applyLightbeamTechniques(board, ["deadEnd"])).toBeUndefined()
+  })
+})
+
+describe("solveLightbeamByTechniques", () => {
+  it("settles the board and names the setting the light needs", () => {
+    const solve = solveLightbeamByTechniques(oneMirror, "deadEnd")
+    expect(solve.settled).toBe(true)
+    expect(settledStates(solve.board)).toEqual([1])
+  })
+
+  it("stops short of a board its cap cannot reach", () => {
+    // Nothing below `deadEnd` rules a setting out, so with only the runs allowed the board stalls.
+    const solve = solveLightbeamByTechniques(oneMirror, "exitRun")
+    expect(solve.settled).toBe(false)
+    expect(lightbeamSettled(solve.board)).toBe(false)
+  })
+
+  it("records which rungs the board actually demanded", () => {
+    expect([...solveLightbeamByTechniques(oneMirror, "onlySurvivor").used]).toContain("deadEnd")
+  })
+})
+
+/**
+ * A board with a decoy. The route is the same one-mirror bend; the extra mirror at (0,4) sits where no
+ * beam can ever reach it, whatever either piece is set to.
+ */
+const withDecoy: LightbeamPuzzleData = {
+  ...oneMirror,
+  movable: [...oneMirror.movable, { kind: "turnMirror", at: { row: 0, col: 4 }, faces: ["/", "\\"] }],
+}
+
+describe("neverReached", () => {
+  it("frees the piece the light can never touch", () => {
+    const solve = solveLightbeamByTechniques(withDecoy, "neverReached")
+    expect(solve.settled).toBe(true)
+    expect([...solve.board.free]).toEqual([1])
+  })
+
+  // It is the one rung whose conclusion the answer does not need — the board is already settled by the
+  // time it speaks — so it runs as a closing sweep rather than inside the fixpoint loop. Without that it
+  // would never fire at all, and the family's own skill would have nothing to say.
+  it("still speaks even though the route never needed it", () => {
+    expect([...solveLightbeamByTechniques(withDecoy, "neverReached").used]).toContain("neverReached")
+  })
+
+  it("holds its tongue below its own rung", () => {
+    expect(solveLightbeamByTechniques(withDecoy, "deadEnd").board.free.size).toBe(0)
+  })
+
+  it("never frees a piece that could stand in the beam's way", () => {
+    expect(solveLightbeamByTechniques(oneMirror, "neverReached").board.free.size).toBe(0)
+  })
+})

--- a/src/mods/puzzle/game/lightbeam/techniques.ts
+++ b/src/mods/puzzle/game/lightbeam/techniques.ts
@@ -1,0 +1,406 @@
+// The deduction system behind both generation and hints, per docs/game-design/puzzles/lightbeam.md §4.
+//
+// A beam puzzle's natural solving mode is trial — flip a mirror, look, flip another — and that is not
+// deduction. This ladder is what makes the family admissible: every board that ships was settled by it,
+// so every board can be reasoned to the end, and every hint is one of these reasons rather than a peek
+// at the answer.
+//
+// Ordered by how well a reason explains itself, not by strength. `onlySurvivor` subsumes `deadEnd` and
+// `feedsExit` outright — a solver could be the runs plus that one technique — and it is ranked last
+// anyway, because its reason is "I tried the alternatives and they all failed", which teaches nothing.
+// `deadEnd`'s reason is a sentence a child repeats back and checks by eye: face it that way and the
+// light dies in the wall.
+import {
+  DIRECTIONS,
+  cellKey,
+  eachConfig,
+  gridResolver,
+  insideGrid,
+  pieceOccupant,
+  pieceStateCount,
+  sameCell,
+  segmentKey,
+  traceBeam,
+  walkBackward,
+  walkForward,
+  type BeamSegment,
+  type BeamWalk,
+  type Blocker,
+  type CellContent,
+  type CellRef,
+  type Direction,
+  type LightbeamPuzzleData,
+} from "./beam"
+
+export const TECHNIQUES = ["entryRun", "exitRun", "deadEnd", "feedsExit", "neverReached", "onlySurvivor"] as const
+
+export type TechniqueId = (typeof TECHNIQUES)[number]
+
+export type LightbeamDecision =
+  | { kind: "carries"; segments: BeamSegment[] }
+  | { kind: "shrineEntry"; direction: Direction }
+  | { kind: "eliminate"; piece: number; states: number[] }
+  | { kind: "free"; piece: number }
+
+export type LightbeamStep = {
+  technique: TechniqueId
+  /** Which reading of the technique fired — each one is a different sentence to the player. */
+  variant?: string
+  /** The piece the reason is about, where it is about one. */
+  piece?: number
+  /** The beam the reason talks about, so "the light dies here" has something to point at. */
+  beam: BeamSegment[]
+  decisions: LightbeamDecision[]
+}
+
+/**
+ * A board mid-deduction: which state each movable piece could still be in, which stretches of beam are
+ * settled whatever the player does, which side the shrine can be lit from, and which pieces have been
+ * shown not to matter.
+ */
+export type LightbeamBoard = {
+  puzzle: LightbeamPuzzleData
+  candidates: Set<number>[]
+  /** Beam segments proven to happen. Keyed so a stretch that gains a known exit reads as new. */
+  forced: Map<string, BeamSegment>
+  shrineEntry?: Direction
+  /** Pieces the light provably never touches — the decoys (§4.2). */
+  free: Set<number>
+}
+
+const forcedKey = (segment: BeamSegment): string => `${segmentKey(segment.at, segment.enter)}>${segment.exit ?? "-"}`
+
+export const createLightbeamBoard = (puzzle: LightbeamPuzzleData): LightbeamBoard => ({
+  puzzle,
+  candidates: puzzle.movable.map(piece => new Set(Array.from({ length: pieceStateCount(piece) }, (_, i) => i))),
+  forced: new Map(),
+  free: new Set(),
+})
+
+const sameBlocker = (a: Blocker, b: Blocker): boolean =>
+  a.kind === b.kind && (a.kind !== "mirror" || b.kind !== "mirror" || a.face === b.face)
+
+/**
+ * The board as the deduction currently knows it. A cell is `unknown` whenever a movable piece could be
+ * standing there and could also not be, or could be there facing either way — and that is the whole
+ * engine: every walk stops at the first unknown, and each technique below asks a different question
+ * about what it stopped on.
+ *
+ * A piece is only resolved when every state it could still be in puts the same thing in the same cell,
+ * which for a settled piece is always, and for a two-faced mirror is never.
+ */
+const knownGrid = (board: LightbeamBoard, pin?: { piece: number; state: number }): CellContent[][] => {
+  const { puzzle } = board
+  const grid: CellContent[][] = Array.from({ length: puzzle.size }, () =>
+    Array.from({ length: puzzle.size }, (): CellContent => ({ kind: "empty" }))
+  )
+  for (const piece of puzzle.fixed)
+    grid[piece.at.row][piece.at.col] = piece.kind === "mirror" ? { kind: "mirror", face: piece.face } : { kind: "wall" }
+
+  const certain = new Map<string, Blocker>()
+  const uncertain = new Set<string>()
+  puzzle.movable.forEach((piece, index) => {
+    const options = pin?.piece === index ? [pin.state] : [...board.candidates[index]]
+    if (!options.length) return
+    const occupants = options.map(state => pieceOccupant(piece, state))
+    const [first] = occupants
+    if (occupants.every(other => sameCell(other.at, first.at) && sameBlocker(other.blocks, first.blocks)))
+      certain.set(cellKey(first.at), first.blocks)
+    else for (const occupant of occupants) uncertain.add(cellKey(occupant.at))
+  })
+  for (const [key, blocker] of certain) {
+    if (uncertain.has(key)) continue
+    const [row, col] = key.split(",").map(Number)
+    grid[row][col] = blocker
+  }
+  for (const key of uncertain) {
+    const [row, col] = key.split(",").map(Number)
+    grid[row][col] = { kind: "unknown" }
+  }
+
+  grid[puzzle.shrine.row][puzzle.shrine.col] = { kind: "shrine" }
+  grid[puzzle.sun.at.row][puzzle.sun.at.col] = { kind: "sun", facing: puzzle.sun.facing }
+  return grid
+}
+
+const knownForward = (board: LightbeamBoard, pin?: { piece: number; state: number }): BeamWalk =>
+  walkForward(board.puzzle.size, board.puzzle.sun.at, board.puzzle.sun.facing, gridResolver(knownGrid(board, pin)))
+
+const knownBackward = (board: LightbeamBoard, enter: Direction, pin?: { piece: number; state: number }): BeamWalk =>
+  walkBackward(board.puzzle.size, board.puzzle.shrine, enter, gridResolver(knownGrid(board, pin)))
+
+/** The board is done when the light reaches the shrine without any unsettled piece left on its way. */
+export const lightbeamSettled = (board: LightbeamBoard): boolean => knownForward(board).end === "lit"
+
+const DEATHS: ReadonlySet<BeamWalk["end"]> = new Set(["absorbed", "escapes", "loops"] as const)
+
+/** How a state died, which is the difference between three quite different sentences to the player. */
+const DEATH_VARIANT: Record<string, string> = { absorbed: "wall", escapes: "edge", loops: "loop" }
+
+const freshSegments = (board: LightbeamBoard, walk: BeamWalk): BeamSegment[] =>
+  walk.path.filter(segment => !board.forced.has(forcedKey(segment)))
+
+// ---------------------------------------------------------------------------------------------------
+// T0 / T1 — the facts. Neither rules anything out; both hand the eliminations below something to work
+// against, and both are worth saying out loud to a player staring at a fresh board.
+// ---------------------------------------------------------------------------------------------------
+
+/** Where the light must go before it meets anything the player can change. */
+const entryRun = (board: LightbeamBoard): LightbeamStep[] => {
+  const walk = knownForward(board)
+  if (DEATHS.has(walk.end)) return []
+  const fresh = freshSegments(board, walk)
+  if (!fresh.length) return []
+  return [{ technique: "entryRun", beam: walk.path, decisions: [{ kind: "carries", segments: fresh }] }]
+}
+
+/**
+ * Which side the shrine can be lit from, traced backwards. A direction whose backward run leaves the
+ * grid or dies in a wall is a direction nothing could have delivered the light from; when only one is
+ * left, the stretch behind the shrine is settled too.
+ */
+const exitRun = (board: LightbeamBoard): LightbeamStep[] => {
+  const feasible = DIRECTIONS.map(direction => ({ direction, walk: knownBackward(board, direction) })).filter(
+    ({ walk }) => !DEATHS.has(walk.end)
+  )
+  if (feasible.length !== 1) return []
+  const [{ direction, walk }] = feasible
+  const decisions: LightbeamDecision[] = []
+  if (board.shrineEntry !== direction) decisions.push({ kind: "shrineEntry", direction })
+  const fresh = freshSegments(board, walk)
+  if (fresh.length) decisions.push({ kind: "carries", segments: fresh })
+  if (!decisions.length) return []
+  return [{ technique: "exitRun", beam: walk.path, decisions }]
+}
+
+// ---------------------------------------------------------------------------------------------------
+// T2 / T3 — the local eliminations. Both pin one piece to one state and walk, from the sun for T2 and
+// from the shrine for T3. A state whose walk dies is a state the puzzle cannot be in.
+//
+// Both only speak when at least one state survives: if every state of a piece dies the board is broken,
+// and blaming the piece would be a nonsense reason rather than a deduction.
+// ---------------------------------------------------------------------------------------------------
+
+const pinnedEliminations = (
+  board: LightbeamBoard,
+  technique: "deadEnd" | "feedsExit",
+  walkWith: (pin: { piece: number; state: number }) => BeamWalk
+): LightbeamStep[] => {
+  const steps: LightbeamStep[] = []
+  board.puzzle.movable.forEach((_, piece) => {
+    const states = [...board.candidates[piece]]
+    if (states.length < 2) return
+    const walks = states.map(state => walkWith({ piece, state }))
+    const dying = states.filter((_, index) => DEATHS.has(walks[index].end))
+    if (!dying.length || dying.length === states.length) return
+    for (const state of dying) {
+      const walk = walks[states.indexOf(state)]
+      steps.push({
+        technique,
+        variant: DEATH_VARIANT[walk.end],
+        piece,
+        beam: walk.path,
+        decisions: [{ kind: "eliminate", piece, states: [state] }],
+      })
+    }
+  })
+  return steps
+}
+
+const deadEnd = (board: LightbeamBoard): LightbeamStep[] =>
+  pinnedEliminations(board, "deadEnd", pin => knownForward(board, pin))
+
+const feedsExit = (board: LightbeamBoard): LightbeamStep[] => {
+  const entry = board.shrineEntry
+  if (entry === undefined) return []
+  return pinnedEliminations(board, "feedsExit", pin => knownBackward(board, entry, pin))
+}
+
+// ---------------------------------------------------------------------------------------------------
+// T4 / T5 — the exhaustive pair. The configuration space is the product of the pieces' state counts, so
+// at nine pieces it is under 20 000 walks of at most 49 cells: this family can afford to enumerate,
+// which none of the arithmetic families can (§5).
+//
+// Both reason over the winning configurations only. That is not peeking: "the shrine can be lit" is the
+// premise of the puzzle, and the player has it too.
+// ---------------------------------------------------------------------------------------------------
+
+// Far above any tier's real space (a 7x7 wizard board tops out near 20 000); the cap is the guard
+// against a malformed board, not a budget.
+const MAX_ENUMERATION = 200_000
+
+type Survey = {
+  /** Per piece, the states that appear in some winning configuration. */
+  states: Set<number>[]
+  /** Per piece, whether any state of it could stand in a winning beam's way. */
+  blocking: boolean[]
+  winners: number
+}
+
+const surveyWinners = (board: LightbeamBoard): Survey | undefined => {
+  const { puzzle } = board
+  const options = board.candidates.map(set => [...set])
+  const states = puzzle.movable.map(() => new Set<number>())
+  const blocking = puzzle.movable.map(() => false)
+  let winners = 0
+  const ran = eachConfig(
+    options,
+    config => {
+      const walk = traceBeam(puzzle, config)
+      if (walk.end !== "lit") return
+      winners++
+      const onPath = new Set(walk.path.map(segment => cellKey(segment.at)))
+      puzzle.movable.forEach((piece, index) => {
+        states[index].add(config[index])
+        if (blocking[index]) return
+        // A piece only matters if one of the states it could still be in could stand in this beam's
+        // way. Otherwise no tap on it can change where the light goes, whatever the player does.
+        blocking[index] = options[index].some(state => onPath.has(cellKey(pieceOccupant(piece, state).at)))
+      })
+    },
+    MAX_ENUMERATION
+  )
+  return ran && winners > 0 ? { states, blocking, winners } : undefined
+}
+
+/**
+ * The decoys. This is the family's own skill — the catalogue names "elimination of irrelevant pieces"
+ * — and the only conclusion in any family that reads "this piece does not matter".
+ */
+const neverReached = (board: LightbeamBoard): LightbeamStep[] => {
+  const survey = surveyWinners(board)
+  if (!survey) return []
+  const steps: LightbeamStep[] = []
+  board.puzzle.movable.forEach((_, piece) => {
+    if (board.free.has(piece) || survey.blocking[piece]) return
+    steps.push({ technique: "neverReached", piece, beam: [], decisions: [{ kind: "free", piece }] })
+  })
+  return steps
+}
+
+const onlySurvivor = (board: LightbeamBoard): LightbeamStep[] => {
+  const survey = surveyWinners(board)
+  if (!survey) return []
+  const steps: LightbeamStep[] = []
+  board.puzzle.movable.forEach((_, piece) => {
+    const dying = [...board.candidates[piece]].filter(state => !survey.states[piece].has(state))
+    if (!dying.length || dying.length === board.candidates[piece].size) return
+    steps.push({ technique: "onlySurvivor", piece, beam: [], decisions: [{ kind: "eliminate", piece, states: dying }] })
+  })
+  return steps
+}
+
+const IMPLEMENTATIONS: Record<TechniqueId, (board: LightbeamBoard) => LightbeamStep[]> = {
+  entryRun,
+  exitRun,
+  deadEnd,
+  feedsExit,
+  neverReached,
+  onlySurvivor,
+}
+
+export const techniquesUpTo = (cap: TechniqueId): TechniqueId[] => TECHNIQUES.slice(0, TECHNIQUES.indexOf(cap) + 1)
+
+const applyDecision = (board: LightbeamBoard, decision: LightbeamDecision) => {
+  if (decision.kind === "carries") {
+    for (const segment of decision.segments) board.forced.set(forcedKey(segment), segment)
+    return
+  }
+  if (decision.kind === "shrineEntry") {
+    board.shrineEntry = decision.direction
+    return
+  }
+  if (decision.kind === "free") {
+    board.free.add(decision.piece)
+    return
+  }
+  // Never down to nothing: a piece with no state left is a broken board, and the honest outcome is a
+  // board that fails to settle rather than one that quietly contradicts itself.
+  const candidates = board.candidates[decision.piece]
+  for (const state of decision.states) if (candidates.size > 1) candidates.delete(state)
+}
+
+export const applyLightbeamDecisions = (board: LightbeamBoard, decisions: LightbeamDecision[]) => {
+  for (const decision of decisions) applyDecision(board, decision)
+}
+
+/**
+ * The cheapest technique that has something to say, and everything it found in one go. Short-circuiting
+ * matters: running the whole ladder on every pass would spend two enumerations per step for a
+ * conclusion the first rung had already reached.
+ */
+export const applyLightbeamTechniques = (
+  board: LightbeamBoard,
+  allowed: readonly TechniqueId[]
+): LightbeamStep[] | undefined => {
+  for (const technique of allowed) {
+    const found = IMPLEMENTATIONS[technique](board)
+    if (found.length) return found
+  }
+  return undefined
+}
+
+export const nextLightbeamStep = (board: LightbeamBoard, cap: TechniqueId): LightbeamStep | undefined =>
+  applyLightbeamTechniques(board, techniquesUpTo(cap))?.[0]
+
+// What the board knows, boiled down. Compared before and after a harvest so a technique that reports a
+// conclusion the board already held ends the solve instead of looping on it forever.
+const signature = (board: LightbeamBoard): string =>
+  [
+    board.candidates.map(set => [...set].sort().join("")).join("|"),
+    board.forced.size,
+    board.shrineEntry ?? "-",
+    board.free.size,
+  ].join("/")
+
+export type LightbeamSolve = {
+  settled: boolean
+  board: LightbeamBoard
+  /** Which techniques the board actually demanded — the difficulty signal generation reads. */
+  used: Set<TechniqueId>
+  /** The reasons in the order they fired, which is the order hints walk. */
+  steps: LightbeamStep[]
+}
+
+export const solveLightbeamByTechniques = (puzzle: LightbeamPuzzleData, cap: TechniqueId): LightbeamSolve => {
+  const board = createLightbeamBoard(puzzle)
+  const allowed = techniquesUpTo(cap)
+  const used = new Set<TechniqueId>()
+  const steps: LightbeamStep[] = []
+  while (!lightbeamSettled(board)) {
+    const harvest = applyLightbeamTechniques(board, allowed)
+    if (!harvest) break
+    const before = signature(board)
+    for (const step of harvest) {
+      used.add(step.technique)
+      steps.push(step)
+      applyLightbeamDecisions(board, step.decisions)
+    }
+    if (signature(board) === before) break
+  }
+
+  // `neverReached` is the one rung whose conclusion the answer does not need: a decoy is free precisely
+  // because the light never touches it, so settling the board never required settling it. Left inside the
+  // loop above it would therefore never fire at all — the board is already done by the time it is asked.
+  // It runs here instead, once, so the family's own skill has something to say to the player even though
+  // it had nothing to contribute to the route.
+  if (allowed.includes("neverReached") && lightbeamSettled(board))
+    for (const step of IMPLEMENTATIONS.neverReached(board)) {
+      used.add(step.technique)
+      steps.push(step)
+      applyLightbeamDecisions(board, step.decisions)
+    }
+
+  return { settled: lightbeamSettled(board), board, used, steps }
+}
+
+/** The one state each piece is left in once the deduction has run, where it was pinned down at all. */
+export const settledStates = (board: LightbeamBoard): (number | undefined)[] =>
+  board.candidates.map(set => (set.size === 1 ? [...set][0] : undefined))
+
+/** Cells a piece could ever stand in that lie inside the grid — the track a sliding piece draws. */
+export const trackCells = (puzzle: LightbeamPuzzleData, piece: number): CellRef[] => {
+  const movable = puzzle.movable[piece]
+  const cells = movable.kind === "turnMirror" ? [movable.at] : movable.stops
+  return cells.filter(at => insideGrid(puzzle.size, at))
+}

--- a/src/mods/puzzle/index.ts
+++ b/src/mods/puzzle/index.ts
@@ -2,10 +2,11 @@ import type { ModDescriptor } from "../modDescriptor"
 import { SUMPLETE_META } from "./game/sumplete/meta"
 import { BALANCE_META } from "./game/balanceScale/meta"
 import { FUTOSHIKI_META } from "./game/futoshiki/meta"
+import { LIGHTBEAM_META } from "./game/lightbeam/meta"
 import { CROCODILE_META } from "./game/crocodile/meta"
 
 // The puzzle mod descriptor. Owns the general math-puzzle families (sumplete, balance-scale,
-// futoshiki) and the crocodile capstone. A root mod: it stays on in production (turning it off leaves
+// futoshiki, lightbeam) and the crocodile capstone. A root mod: it stays on in production (turning it off leaves
 // puzzle/capstone rooms with no family, so they only auto-resolve via the family-absence pass-through
 // — a degenerate world, not a playable one). It is a real REGISTERED_MODS entry anyway so its family
 // metadata flows through MOD_FAMILY_META like every other mod's — adding a new puzzle family is then a
@@ -20,5 +21,5 @@ import { CROCODILE_META } from "./game/crocodile/meta"
 // (src/mods/puzzle/app, pulled in by registerModApps), each gated on this mod being enabled.
 export const puzzleMod: ModDescriptor = {
   id: "puzzle",
-  families: [SUMPLETE_META, BALANCE_META, FUTOSHIKI_META, CROCODILE_META],
+  families: [SUMPLETE_META, BALANCE_META, FUTOSHIKI_META, LIGHTBEAM_META, CROCODILE_META],
 }


### PR DESCRIPTION
Bend the sunlight from the disc to the shrine. Tap a mirror to turn it, tap a sliding piece to move it, and the beam redraws itself with every tap.

Design doc: `docs/game-design/puzzles/lightbeam.md`. Catalogue §4.15 flipped from "spec locked, not yet built" to `(have)`.

## The question this family had to answer first

A beam puzzle's natural solving mode is trial — flip a mirror, look, flip another — and `puzzle-screens.md` §5 wants a board reachable by deduction, with hints drawn from techniques rather than from the answer. So the ladder came before anything else, and it holds: two facts (where the light must go before it meets anything movable; which side the shrine can be lit from) and four eliminations on top, ordered by how well each explains itself rather than by strength.

The exhaustive rung subsumes the two local ones outright and is still ranked last, for the same reason Sumplete ranks its candidate-intersection last. "I tried the alternatives and they all failed" teaches nothing. _"Face it that way and the light dies in the stone"_ is a sentence a child repeats back and checks by eye.

This is also the one family where the enumeration is affordable: the whole configuration space is a few hundred walks over at most 81 cells, so every generation gate enumerates exactly rather than sampling.

## Four things building it changed

**Loops are unreachable.** A 90° mirror maps `(cell, direction)` one-to-one, so every beam state has exactly one predecessor and the disc's first has none — a beam from the disc walks a path and can never join a ring. A search over 200k random boards found no counterexample, which is what sent me looking for the reason. The design doc had claimed a looping beam was a board state to render; it now records the proof instead. Loop detection stays as the guard that keeps the walk total, and becomes load-bearing the day the deferred prism lands.

**The technique cap meant nothing until generation earned it.** Built plainly, every board is a chain of "the light visibly dies there", so a wizard board solves exactly like a starter one, only longer. Shadow pieces fix it from the other end: a decoy placed in the very stretch a wrong setting would light, so the light disappears into something unsettled instead of dying where you can see it. At wizard over 40 seeds, the exhaustive rung fires on 3 boards without them and 28 with three.

**Every board was the average board for its tier.** The tier config turned every dial a little, so the wizard row was five turns AND a set mirror AND two sliding mirrors AND a sliding wall AND a decoy AND three shadows, every time. It is now a lean baseline plus one or two **goals** drawn per board that turn their own dials hard — a long winding beam, a board full of pieces that turn out not to matter, stone to shift, or wrong turns that vanish into the dark. No new piece type: all four are a re-scheduling of dials the generator already had. The board records which it drew, so a fallback cannot fire quietly, and the puzzle lab captions it (`9×9 · cap onlySurvivor · goals sortTheWheat + blindAlleys`).

**The 44px bar is about tap targets, not cells** — and this family had been applying it to cells. The other grid families cap at 7 wide for a good reason: every cell of a Sumplete grid is tappable, so cell size *is* target size. Here only the movable pieces are, a handful out of eighty-one. Generation now refuses to place two of them touching, so a piece owns the empty squares around it and its hit area reaches into them: at 9 wide a cell is 36px and its tap target 46px, with no two targets meeting. Worth having at 7×7 anyway — before the rule, essentially every board had adjacent tappable pieces, up to ten pairs on one wizard grid.

## Controls

One gesture, and **no pad, no eraser and no undo**. A cycle is its own inverse, so nothing a tap does is unrecoverable — the Futoshiki argument for undo was that a placement destroyed pencilled work elsewhere, and there is no counterpart here.

Every square a piece can reach cycles that piece, vacant stops included. A vacant stop carries a **ghost of the piece** rather than an empty dashed outline: an outline says only "something can come here", and whether the thing that arrives bends the light or swallows it is the entire difference between the two sliding pieces.

## A hint here is not a correction

New for this game. Every setting is a legal setting, so there is nothing to be wrong about the way a misplaced digit is wrong. Instead the deduction is replayed from a blank board and the hint is the earliest reason the board in front of the player contradicts; follow it and the hint moves on by itself. "This piece does not matter" gets the second pass only, so the game never tells you to ignore a piece while the route is still broken — which makes it the one hint in the catalogue whose advice is to leave something alone.

## Tiers

Measured means over 40 seeds a tier, after each board's goals are applied. Retuned three times against measurement rather than intent: the first pass shipped junior boards **smaller** than starter ones, and the first goal pool let two goals add four pieces on top of baselines that already carried some, putting five pieces on a starter board and collapsing the top three tiers into one ten-piece blur.

| Tier | Grid | Cell | Movable pieces | Configurations | Cap |
| --- | --- | --- | --- | --- | --- |
| starter | 7×7 | 46px | 3.0 | 8 | dead end |
| junior | 7×7 | 46px | 3.9 | 15 | + shrine-side elimination |
| expert | 8×8 | 40px | 5.3 | 42 | + never reached |
| master | 8×8 | 40px | 5.9 | 70 | + only one survives |
| wizard | 9×9 | 36px | 7.9 | 288 | + only one survives |

**Grid size is capacity, not difficulty**, and the doc was wrong to list it as a knob. It barely moves how hard a board is — the configuration space is piece count, the reasoning is the cap. What it decides is whether the board has room, which is measurable: the spacing rule at the old 5×5 made *every* starter board fall back to no goal at all, while the same rule at 7×7 costs nothing.

Every tier gets a full configuration rather than a debut tier, because a starter corridor can sit behind a ward gate deep inside a wizard pyramid — so starter is gentle, not empty.

## Verification

- **1771 specs pass** — 169 of them lightbeam's, 463 across the puzzle mod and the dev bench. Lint and typecheck clean.
- Generation: no failures and **no goal falling back** on any tier; worst case 50ms at 9×9.
- Screen checked in the encounter modal at 360×640 and 390×780: board 318px, cell and tap-target sizes as tabled above.
- `generatedWorld.ts` regenerated; the allocator gives the family 158 nodes.

## Recorded, not built

§12 of the design doc holds the next two steps with their reasoning: **switch nodes** (a point you must touch before you can solve, earning that "must" from the geometry rather than from a rule — including the paradox they create and the one restriction that keeps the drawn beam honest), and the two goals that need them. Deliberately not in this PR: the base family has not been played yet.