### PR TITLE
Futoshiki: a prefill dial, guaranteed rungs, and a 6×6 ceiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- The easiest balance-scale puzzles start with more numbers already filled in, and never ask for more than "something has to be bigger than this square, so it can't be the biggest".
+- Every balance-scale difficulty now starts with a different number of squares filled in — four at the easiest, none at the hardest.
+- The signs between squares are drawn heavier, so they read as part of the board rather than as punctuation on it.
+- The hardest balance-scale puzzles are 6×6 rather than 7×7, and are now guaranteed to need their hardest kind of reasoning rather than merely allowing it.
+
 ## 0.37.0 - 2026-08-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The easiest comparison grids start with more numbers already filled in, and never ask for more than "something has to be bigger than this square, so it can't be the biggest".
 - Every comparison-grid difficulty now starts with a different number of squares filled in — four at the easiest, none at the hardest.
-- The signs between squares are drawn heavier, so they read as part of the board rather than as punctuation on it.
+- The signs between squares are drawn rather than typed: part of the board rather than punctuation on it, and sized so they never crowd the numbers on a 6×6.
 - The hardest comparison grids are 6×6 rather than 7×7, and are now guaranteed to need their hardest kind of reasoning rather than merely allowing it.
 
 ## 0.37.0 - 2026-08-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The easiest comparison grids start with more numbers already filled in, and never ask for more than "something has to be bigger than this square, so it can't be the biggest".
 - Every comparison-grid difficulty now starts with a different number of squares filled in — four at the easiest, none at the hardest.
 - The signs between squares are drawn rather than typed: part of the board rather than punctuation on it, and sized so they never crowd the numbers on a 6×6.
-- The hardest comparison grids are 6×6 rather than 7×7, and are now guaranteed to need their hardest kind of reasoning rather than merely allowing it.
+- The hardest comparison grids are 6×6 rather than 7×7, and every difficulty is now guaranteed to need its own hardest kind of reasoning rather than merely allowing it.
+- Comparison grids step up more gently: the second difficulty stays on the 4×4 grid and adds one new way of reading a sign, and the grid grows a difficulty later than it used to.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The signs between squares are drawn rather than typed: part of the board rather than punctuation on it, and sized so they never crowd the numbers on a 6×6.
 - The hardest comparison grids are 6×6 rather than 7×7, and are now guaranteed to need their hardest kind of reasoning rather than merely allowing it.
 
+### Fixed
+
+- Finishing a puzzle made the page jump: the controls and the rules dropped out from under the completed banner.
+
 ## 0.37.0 - 2026-08-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- The easiest balance-scale puzzles start with more numbers already filled in, and never ask for more than "something has to be bigger than this square, so it can't be the biggest".
-- Every balance-scale difficulty now starts with a different number of squares filled in — four at the easiest, none at the hardest.
+- The easiest comparison grids start with more numbers already filled in, and never ask for more than "something has to be bigger than this square, so it can't be the biggest".
+- Every comparison-grid difficulty now starts with a different number of squares filled in — four at the easiest, none at the hardest.
 - The signs between squares are drawn heavier, so they read as part of the board rather than as punctuation on it.
-- The hardest balance-scale puzzles are 6×6 rather than 7×7, and are now guaranteed to need their hardest kind of reasoning rather than merely allowing it.
+- The hardest comparison grids are 6×6 rather than 7×7, and are now guaranteed to need their hardest kind of reasoning rather than merely allowing it.
 
 ## 0.37.0 - 2026-08-19
 

--- a/docs/game-design/PUZZLE_FAMILIES.md
+++ b/docs/game-design/PUZZLE_FAMILIES.md
@@ -490,11 +490,12 @@ Family doc: `docs/game-design/puzzles/futoshiki.md`.
   neighbouring cells that always open toward the bigger of the two. Tap a cell,
   tap a number from the pad; a pencil toggle writes the same numbers in as notes
   instead, and undo takes back one move whole.
-- **Knobs:** grid size (4×4 → 7×7) · technique cap · how hard generation tries to
-  take signs away.
+- **Knobs:** grid size (4×4 → 6×6) · technique cap · how many squares ship
+  pre-filled · which rungs a board is guaranteed to need.
 - **Scaling:** good. This is the Latin-square slot (§4.8) entered from its cheap
   side — the signs do the work regions do in Sudoku, so a 4×4 is already a real
-  puzzle at T1 and no region shapes have to be authored.
+  puzzle at T1 and no region shapes have to be authored. The top of the range is
+  6×6: seven squares cost a 45-minute solve and bought nothing the ladder needed.
 - **Generation:** build the Latin square, derive every sign, then thin signs and
   pre-filled cells for as long as the technique solver still reaches the end. The
   solver gate settles uniqueness, so no separate solution counter runs.

--- a/docs/game-design/PUZZLE_FAMILIES.md
+++ b/docs/game-design/PUZZLE_FAMILIES.md
@@ -197,20 +197,35 @@ puzzle nodes at every tier alongside cross-sum's tableau and Sumplete.
 - **UI:** medium — bespoke tilt animation is the whole point; otherwise
   tap-to-place. The least language-dependent family in the catalogue.
 
-### 4.3 Sundial / shadow clock (telling time) — _(have, time theme)_
+### 4.3 Sundial / shadow clock (telling time) — _(designed, not built)_
+
+Family doc: `docs/game-design/puzzles/sundial.md`.
+
+**This entry used to read _(have)_. It was wrong** — there is no sundial mod in
+`src/mods/`, and the same goes for §4.4's water clock. Both are survivors of the
+pre-redesign game that nobody cleared out of the catalogue. Do not plan around
+either existing.
 
 - **Skill:** reading an analog representation; the 12/24 division.
-- **Operates:** read where the obelisk's shadow / hand falls → that reading _is_
-  the value. Prefer the **draggable-hand / set-the-position** interaction over
-  multiple-choice — more tactile, still wordless.
-- **Knobs:** precision (hour → half → quarter → 5-min) · 12h vs 24h.
-- **Scaling:** good, but a lower ceiling than arithmetic families.
-- **Generation:** trivial, unique-by-construction.
-- **UI:** medium (dial face; draggable hand).
-- **Theme:** day expeditions; night expeditions use the decan star-clock
-  variant.
+- **Operates:** an obelisk casts a shadow across a graduated floor; the player
+  drags a marker to the hour it tells. Two facts carry the puzzle — **where the
+  shadow points** gives the hour within the half-day, **how long it is** picks
+  between morning and afternoon.
+- **Knobs:** precision (hour → half → quarter) · 12 vs 24 marks · gnomon count ·
+  whether the answer crosses the day/night boundary.
+- **Scaling:** good to a point, and a lower ceiling than the arithmetic families.
+  The second gnomon is the knob that keeps working.
+- **Generation:** trivial — enumerate the candidate hours and keep the boards with
+  exactly one survivor. Uniqueness is **checked, not assumed**: showing direction
+  without length leaves two answers.
+- **UI:** medium (dial face; marker dragged around the rim, snapping to marks).
+- **Theme:** day expeditions; night expeditions use the decan star-clock variant,
+  which the Lighthouse journey needs — it is authored as a night background.
+- **Earns its P1 seat by not being a reading exercise.** "Read where the shadow
+  falls, that reading is the value" is not deduction; the family is "which hour is
+  consistent with all the evidence", and its doc §3 is the argument.
 
-### 4.4 Water clock / clepsydra (duration) — _(have, time theme)_
+### 4.4 Water clock / clepsydra (duration) — _(not built; see §4.3's note)_
 
 - **Skill:** elapsed-time / duration; subtraction across hours; **boundary-
   crossing** (the hard, valuable part — e.g. from night hours into day hours).

--- a/docs/game-design/puzzles/futoshiki.md
+++ b/docs/game-design/puzzles/futoshiki.md
@@ -43,6 +43,9 @@ need:
    keeping each removal while the solver still reaches the end.
 5. Then take the **signs** away the same way, repeating full sweeps until one
    removes nothing.
+6. Finally hand back pre-filled squares until the tier's **prefill floor** (§5.1)
+   is met — after the thinning, never before, so a tier's generosity never costs
+   the board a sign.
 
 ### 3.1 Why that order, and why to a fixpoint
 
@@ -56,7 +59,10 @@ Sweeping the signs to a **fixpoint** matters because removing one sign can make
 another removable. A single pass left most signs standing: measured on starter
 boards, 13–16 of the 16 signs shown could each still have been taken away. A sign
 the player cannot spend is worse than no sign — it hides which ones the deduction
-actually turns on. Every shipped board now has **zero** removable signs.
+actually turns on. Every shipped board has **zero** removable signs _at the moment
+the thinning stops_. A number handed back afterwards (§5.1) may retire one, and
+that is the gift doing its work rather than a sign wasted — what matters is that
+no sign was spare when the board was being decided.
 
 **Gate: the technique solver settles every square** (§4), within the tier's
 technique cap, at every step above. A board that stalls needs a guess and is
@@ -108,19 +114,31 @@ that position comes up.
 
 The bar for _keeping_ one is that it fires. A rung no board ever reaches is not a
 technique, it is dead code claiming to be one, so the reachability sweep asserts
-every rung fires on a real board and would fail the moment one stopped.
+every rung fires on a real board and would fail the moment one stopped. The sweep
+is over the **demands** (§5.2), not the eleven techniques: what generation promises
+is that a tier's ask can be met, and a width the ladder distinguishes but no tier
+asks for — hidden triple, since the ceiling moved (§4.3) — is a finer reason the
+hint layer may still reach rather than a promise being broken.
 
-### 4.3 The top of the ladder is where wizard lives
+### 4.3 Where the top of the ladder actually lives
 
-T6–T10 are the rungs a 7×7 actually reaches for; below that size none of them
-fire, because the board settles before it needs them. That is what separates
-wizard from master: at the T5 cap both tiers produced boards whose hardest step
-was the same, and wizard's higher ceiling was decorative.
+This section used to say T6–T10 fire only at 7×7. **That was wrong**, and the
+7×7 ceiling was bought on it. Measured on 6×6 boards with the whole ladder
+available and nothing pre-filled, over eighty boards: x-wing was the hardest step
+15 times, hidden pair 13, naked pair 13, naked triple once. They are rarer at 6×6
+than at 7×7, but they fire.
 
-How often each is the hardest step of a wizard solve, and how rare they get:
-counted over thirty 7×7 boards, x-wing fired 14 times, naked pair 24, hidden pair
-22, naked triple 4, and hidden triple twice — the last first appearing at seed 14.
-Rarity is why the reachability sweep runs deeper on the top tier than on the rest.
+**Hidden triple is the exception, and it is now unreachable.** Zero firings in
+sixty 5×5 boards, sixty 6×6 boards, and the eighty-board sweep above — two hundred
+boards, never once. It only ever appeared at 7×7, first at seed 14. It stays in
+the ladder as a solve technique, and the hint layer will use it if a board ever
+reaches it, but nothing ships that needs it. This is why the reachability sweep
+is over the **demands** (§5.2) rather than the eleven techniques: a width no tier
+asks for is a finer reason, not a broken promise.
+
+So what separates wizard from master is no longer the grid. Both are 6×6; master
+may reach for a naked subset but never a hidden one, and wizard is the only tier
+that must genuinely turn one of the top rungs on (§5.3).
 
 ### 4.4 Still absent
 
@@ -130,45 +148,92 @@ can write the one-sentence reason and show it firing.
 
 ## 5. Difficulty knobs
 
-- **Technique cap** — the highest technique the solver may use while accepting a
-  board. This is what a board may _demand_ of the player.
+- **Technique cap** — the highest rung the solver may use while accepting a board.
+  This is what a board may _demand_ of the player.
 - **Grid size** — footprint, and how much bookkeeping a solve carries.
+- **Prefill floor** — the fewest squares that ship already filled in (§5.1).
+- **Requires** — rungs the board is _guaranteed_ to need (§5.3).
 
 Sign count is **not** a dial. It falls out of the cap: a weak ladder cannot spare
 many signs, a strong one strips the board bare. Setting it by hand only put back
 the redundancy §3.1 exists to remove.
 
-| Tier    | Grid | Cap                | Signs shown |
-| ------- | ---- | ------------------ | ----------- |
-| starter | 4×4  | T3 sign vs. number | 3–6 of 24   |
-| junior  | 5×5  | T4 sign chain      | 8–12 of 40  |
-| expert  | 6×6  | T4 sign chain      | 11–20 of 60 |
-| master  | 6×6  | T5 sign pair       | 13–19 of 60 |
-| wizard  | 7×7  | T10 x-wing         | ~23 of 84   |
+| Tier    | Grid | Cap              | Prefill | Requires              | Signs shown |
+| ------- | ---- | ---------------- | ------- | --------------------- | ----------- |
+| starter | 4×4  | T2 sign bound    | 4       | sign bound            | ~3 of 24    |
+| junior  | 5×5  | T4 sign chain    | 3       | —                     | ~10 of 40   |
+| expert  | 6×6  | T4 sign chain    | 2       | —                     | ~15 of 60   |
+| master  | 6×6  | naked subset     | 1       | —                     | ~16 of 60   |
+| wizard  | 6×6  | the whole ladder | 0       | hidden subset, x-wing | ~15 of 60   |
 
-> **This table is over the solve-time budget at the top, and known to be.** A 7×7
-> board with the whole ladder available takes about **45 minutes** by hand, against
-> `PUZZLE_FAMILIES.md` §3.2's 3-minute target and 6-minute ceiling — and a floor is
-> many rooms, so one such board costs more than the corridor it sits in. This is the
-> family the budget was written against.
->
-> **The dial to turn is the grid, not the cap.** Duration here is bookkeeping — 49
-> squares of candidates held at once — while difficulty is the hardest step the board
-> demands, and §4.3 measured that the ladder's top rungs only _fire_ at 7×7. So the
-> retune is a real design question rather than a number to lower: find the smallest
-> board on which x-wing and the hidden pair still fire, and if none does, the honest
-> answer is that this family's ceiling is master's 6×6 with T5 and its wizard tier is
-> a different kind of addition (more signs stripped, not more squares). Measure a
-> candidate against a human clock before it ships.
+**6×6 is the ceiling**, down from 7×7. Seven was bought on §4.3's claim that the
+top rungs fire nowhere smaller, which measurement disproved, and it cost a
+45-minute solve against `PUZZLE_FAMILIES.md` §3.2's 3-minute target. The tap-target
+argument that made 7 the maximum is now moot; at 6 the squares have room to spare,
+which is what lets the signs be drawn as heavily as §8 asks.
 
-The cap is inclusive: a tier permits every technique up to it, so wizard boards
-may use the whole ladder.
+### 5.1 Prefill
 
-7×7 is the ceiling, the same as Puzzle Express. Inside the encounter modal a
-360px screen leaves the board about 320px, so seven squares measure ~44px across
-— exactly the tap-target floor — and an eighth would not fit. That ceiling is
-bought by the sign layout (§8): giving the signs grid tracks of their own would
-spend a quarter of the width on them and cap the board at 5×5 instead.
+How many squares the player is given for free. It is a **floor, not a quota**: a
+board whose own deduction needed more keeps them, and one that needed fewer is
+topped up from the answer. The top-up happens **after** the signs are thinned, so
+the numbers a tier hands back are never something the signs were thinned against
+— which is what stops generosity from eating the family's own clue type.
+
+Starter gets the most and wizard none, so the ladder reads as a steadily emptier
+board rather than a steadily harder one:
+
+> **The gentle end is squeezed, and knowingly.** At 4×4 the T2 cap is weak enough
+> that the generator leans on pre-filled numbers to settle a board at all: the
+> natural minimum is ~2.9 numbers against ~3 signs, before any gift. With the floor
+> at 4, most starter boards carry at least as many numbers as signs. §3.1's ordering
+> keeps the signs from being thinned away, but it cannot manufacture signs a weak
+> ladder never needed. A T3 cap yields ~4 signs against ~1.7 numbers instead; the
+> choice of T2 buys the gentlest possible reason at the cost of a sign-poor board.
+
+### 5.2 The demands: what a tier is allowed to say
+
+Tiers speak a **coarser vocabulary than the eleven techniques**: nine _demands_,
+where `nakedSubset` covers naked pair and naked triple, and `hiddenSubset` covers
+the hidden two. A pair and a triple are the same idea at a different width, so a
+tier asking for "a hidden subset" should not care which width turns up. The hint
+layer still names the width, because _"these three squares hold only 2, 5 and 7
+between them"_ is a better sentence than any generic one.
+
+A tier's allowance is a **set, not a depth**. The ladder interleaves the pairs and
+the triples (naked pair, hidden pair, naked triple, hidden triple), so "naked
+subsets but no hidden ones" — which is exactly master — is not a prefix of it.
+
+### 5.3 Requires: guaranteeing the reasoning
+
+A tier may name rungs the board must actually turn on. Because the solver only
+ever reaches for the cheapest technique that fires, a solve whose hardest step is
+rung R is a board that **stalls without R** — so this is a guarantee rather than a
+hope. Any one of the named rungs satisfies it.
+
+It costs rejected draws, and how many depends entirely on the rung. Measured per
+accepted board:
+
+| Rung          | 4×4          | 5×5         | 6×6         |
+| ------------- | ------------ | ----------- | ----------- |
+| sign bound    | 1.0 · 12ms   | 1.8 · 53ms  | undrawable  |
+| sign vs. num. | 1.5 · 11ms   | 1.0 · 16ms  | 1.0 · 46ms  |
+| sign chain    | 1.7 · 12ms   | 1.0 · 14ms  | 1.0 · 48ms  |
+| sign pair     | 2.0 · 14ms   | 1.0 · 21ms  | 1.0 · 64ms  |
+| naked pair    | 25 · 163ms   | 7.2 · 144ms | 4.5 · 279ms |
+| hidden pair   | unreachable  | 26 · 581ms  | 6.0 · 414ms |
+| x-wing        | 246 · 2384ms | 23 · 735ms  | 7.0 · 631ms |
+
+The sign rungs are effectively free. Two cells are structural rather than rare:
+**hidden pair cannot be the hardest step of a 4×4** — in a line of four, two
+numbers confined to two squares always leaves the complementary pair confined to
+the other two, and naked pair ranks lower so it fires first — and **a 6×6 cannot
+settle on T0–T2 at all**, so caps have a size floor.
+
+Starter's `requires` earns its keep differently. A T2 ladder can settle a 4×4 on
+pre-filled numbers alone, and one board in six came out carrying **no signs at
+all** — a Latin square wearing the family's name. Insisting the board turn a sign
+bound on makes that board impossible, and costs nothing.
 
 ## 6. Notes and undo
 
@@ -231,6 +296,12 @@ Beyond the shared screen bar:
   one spans the two squares it separates and centres itself, which lands it on
   the boundary whatever the grid measures. Tracks would spend a quarter of the
   board's width on signs and cost two tiers of grid size (§5).
+- **A sign is drawn, not typed.** A typeface's `<` is a mathematical glyph sized
+  to sit in a line of prose — thin, and lost against a stone square at arm's
+  length. The mark is one stroked chevron turned four ways, heavy enough to read
+  as part of the board rather than as punctuation on it, and sized as a fraction
+  of a **square** rather than of the screen so it holds its weight at every grid
+  size.
 - Pre-filled numbers read as part of the puzzle, not of the answer.
 - A number pad, a pencil toggle, an eraser and undo — all at least a thumb wide,
   wrapping rather than shrinking.
@@ -244,15 +315,18 @@ directions; nothing about a theme reaches the puzzle logic.
 
 ## 10. Generation cost, and where it should go
 
-A wizard board is the dear one: seven squares wide, eleven techniques, and a
-prune loop that re-solves the board once per sign it tries to remove. That lands
-at roughly 225ms today, paid on the main thread the moment a puzzle room opens.
+A wizard board is the dear one: eleven techniques, a prune loop that re-solves the
+board once per sign it tries to remove, and a `requires` gate (§5.3) that throws
+away roughly six draws in seven. That lands at about **300ms**, paid on the main
+thread the moment a puzzle room opens — against 225ms for the old 7×7, which
+carried no guarantee at all. The narrower grid pays for the gate almost exactly.
 
 Two things keep it there. The ladder **short-circuits** — only the cheapest
 technique that fires is spent on a pass, so the dear rungs at the end are rarely
 reached (mapping the whole ladder and taking the first non-empty result cost 6×
-that, since `map` is eager). And difficulty is never bought by rejecting boards
-until one demands the top rung, which measured at ~1050ms per accepted board.
+that, since `map` is eager). And rejecting boards until one demands the top rung is
+spent on **one tier only** — where it buys a guarantee rather than a vague
+hardness, and at 6×6 costs a third of the ~1050ms the same gate cost at 7×7.
 
 **The direction out is to stop generating at play time at all**: run generation
 offline, verify the boards, and ship a table of known-good seeds per family and

--- a/docs/game-design/puzzles/futoshiki.md
+++ b/docs/game-design/puzzles/futoshiki.md
@@ -301,7 +301,12 @@ Beyond the shared screen bar:
   length. The mark is one stroked chevron turned four ways, heavy enough to read
   as part of the board rather than as punctuation on it, and sized as a fraction
   of a **square** rather than of the screen so it holds its weight at every grid
-  size.
+  size. That fraction **shrinks as the grid grows** (44% of a square at 4 wide,
+  36% at 6): an equal share is not an equal reading, because at 4 wide there is
+  room for a bold chevron beside the digit and at 6 the same share crowds the
+  digit it is meant to sit between. It sits straight on the gutter, with no disc
+  behind it — the gap between two squares is already a dark line, so the mark
+  reads as a notch in the stone without one.
 - Pre-filled numbers read as part of the puzzle, not of the answer.
 - A number pad, a pencil toggle, an eraser and undo — all at least a thumb wide,
   wrapping rather than shrinking.

--- a/docs/game-design/puzzles/futoshiki.md
+++ b/docs/game-design/puzzles/futoshiki.md
@@ -158,13 +158,28 @@ Sign count is **not** a dial. It falls out of the cap: a weak ladder cannot spar
 many signs, a strong one strips the board bare. Setting it by hand only put back
 the redundancy §3.1 exists to remove.
 
-| Tier    | Grid | Cap              | Prefill | Requires              | Signs shown |
-| ------- | ---- | ---------------- | ------- | --------------------- | ----------- |
-| starter | 4×4  | T2 sign bound    | 4       | sign bound            | ~3 of 24    |
-| junior  | 5×5  | T4 sign chain    | 3       | —                     | ~10 of 40   |
-| expert  | 6×6  | T4 sign chain    | 2       | —                     | ~15 of 60   |
-| master  | 6×6  | naked subset     | 1       | —                     | ~16 of 60   |
-| wizard  | 6×6  | the whole ladder | 0       | hidden subset, x-wing | ~15 of 60   |
+| Tier    | Grid | Cap                | Prefill | Requires              | Signs shown | Steps |
+| ------- | ---- | ------------------ | ------- | --------------------- | ----------- | ----- |
+| starter | 4×4  | T2 sign bound      | 4       | sign bound            | ~3 of 24    | 15    |
+| junior  | 4×4  | T3 sign vs. number | 3       | sign vs. number       | ~4 of 24    | 18    |
+| expert  | 5×5  | T4 sign chain      | 2       | sign chain            | ~10 of 40   | 39    |
+| master  | 6×6  | naked subset       | 1       | naked subset          | ~15 of 60   | 75    |
+| wizard  | 6×6  | the whole ladder   | 0       | hidden subset, x-wing | ~15 of 60   | 75    |
+
+**Every tier now names what it must turn on**, not just what it may. Measured over 40
+boards a tier, the hardest step is the tier's own demand on 40 of 40 — a tier's label and
+what its boards actually ask are the same statement. It costs almost nothing at the sign
+rungs and 80–139ms a board at the top two (§5.3).
+
+**One addition a tier, and the grid is one of the additions.** The ladder used to hand
+starter's 4×4 straight to a 5×5 with sign chains and one fewer given — three dials at once,
+and it played as a different family rather than the next rung of one. The rung being skipped
+was the cheapest sentence in the whole ladder: _"that square is already a 4, and this one
+has to be smaller."_ So junior is that rung on the grid the player already knows, and the
+grid grows at expert instead, where the chain it carries needs somewhere to run.
+
+The steps column is what the reshape bought: 15 → 18 → 39 → 75, where it was 15 → 39 → 75
+with nothing between the first two.
 
 **6×6 is the ceiling**, down from 7×7. Seven was bought on §4.3's claim that the
 top rungs fire nowhere smaller, which measurement disproved, and it cost a
@@ -190,6 +205,12 @@ board rather than a steadily harder one:
 > keeps the signs from being thinned away, but it cannot manufacture signs a weak
 > ladder never needed. A T3 cap yields ~4 signs against ~1.7 numbers instead; the
 > choice of T2 buys the gentlest possible reason at the cost of a sign-poor board.
+>
+> **That is now a one-tier cost rather than the family's front door.** Junior is the
+> same 4×4 at a T3 cap, so the board the squeeze produces is followed immediately by
+> the same size board with more signs on it and one fewer number — which is where a
+> player stops reading the grid as a Latin square with hints. Starter keeps the
+> gentlest reason in the family; it just no longer has to be the only 4×4 anyone sees.
 
 ### 5.2 The demands: what a tier is allowed to say
 

--- a/docs/game-design/puzzles/sundial.md
+++ b/docs/game-design/puzzles/sundial.md
@@ -1,0 +1,238 @@
+# Sundial
+
+Family doc. The catalogue entry (tier debut, weight, theme fit) lives in
+`docs/game-design/PUZZLE_FAMILIES.md` §4.3; the screen bar every family must
+clear lives in `docs/instructions/puzzle-screens.md`. This doc holds what is
+specific to the sundial: what the player is actually deducing, its technique
+ladder, and how its two pieces of evidence fit together.
+
+> **Nothing here is built or measured.** Every number in this document is a
+> target or an estimate, and is marked as such. The families that ship carry
+> measured figures; this one carries none yet, and no reader should treat a
+> figure below as a finding.
+
+## 1. Rules
+
+An obelisk stands on a graduated floor. The sun casts its shadow across the
+marks. Somewhere on the rim is the hour the shadow is telling — the player
+places a marker on it.
+
+Two things about a shadow carry information, and the family turns on both:
+
+- **Where it points** gives the hour, but only within the half-day — the same
+  direction serves a morning hour and an afternoon one.
+- **How long it is** says how high the sun stands, which picks between them. A
+  short shadow belongs to the middle of the day; a long one to its edges.
+
+That is the entire rule, and a board carries no language: the marks are
+countable, the shadow is drawn, the marker is dragged.
+
+## 2. Why this family, next to the ones we have
+
+**Every family we own is a lattice of cells.** Sumplete, futoshiki, lightbeam and
+balance scale are four rule sets on one shape of screen. A player three rooms
+into a floor has been asked to scan a grid four times. The sundial is the first
+**analog** board — an angle, an arc, a length — and the freshness that buys is out
+of proportion to what it costs, because it is freshness of _form_ and not of
+rules.
+
+It is also the first family under a minute. §11.2 weights every family we have at
+Med or higher; §8 wants short rooms between long ones and we currently have
+nothing to put there. A room cleared in twenty seconds is not a lesser room, it
+is the one that lets the floor breathe.
+
+And it is the cheap one: generation is enumeration over a handful of candidate
+hours, with no thinning loop and no rejection gate. Compare futoshiki's ~300ms
+wizard board.
+
+## 3. The problem this family has to solve first
+
+Read literally, `PUZZLE_FAMILIES.md` §4.3 describes a **reading exercise**: the
+shadow falls somewhere, that reading _is_ the value. That is not deduction, and
+it would make this the catalogue's first family to break **P1** — "recover the
+hidden state by reasoning from constraints".
+
+So the family is not "what time is it". It is **"which hour is consistent with
+everything the floor shows you"**, and the shadow's two facts are what make that a
+question worth asking: direction alone always leaves two answers, and something
+else has to settle it.
+
+This also settles **P2** by construction. A dial the player must _read_ demands
+that they already know how clocks work — cultural knowledge, and exactly what
+P2's pre-literate-kid bonus rules out. A dial where evidence must be _reconciled_
+is solvable by counting marks and comparing two lengths, in any language or none.
+
+## 4. The deduction ladder
+
+Ordered the same way futoshiki's is: by how well the reason explains itself, not
+by how much it decides. Every rung has to be a sentence the player could repeat
+back.
+
+| #      | Technique           | Fires when                                            | Decides                           |
+| ------ | ------------------- | ----------------------------------------------------- | --------------------------------- |
+| **T0** | Direct strike       | The shadow lies along a graduation                    | That mark is the hour             |
+| **T1** | Between marks       | The shadow falls between two graduations              | The finer scale divides them      |
+| **T2** | Length picks a half | Direction leaves two candidate hours                  | The shadow's length rules one out |
+| **T3** | Shadows agree       | A second gnomon stands at a different height or place | Only one hour suits both          |
+| **T4** | Wrap                | Counting runs off the end of the marks                | It begins again at the first      |
+
+### 4.1 T2 is the family, not a rung on it
+
+T0 and T1 exist so that the board can teach itself — a first encounter (P5) is a
+shadow lying flat on a mark and nothing else. But a board that never reaches T2
+is the reading exercise §3 rejects, so **every tier above the debut must demand at
+least T2**. The `requires` gate futoshiki grew for exactly this purpose is the
+mechanism, and this family should carry it from the first commit rather than
+discovering the need later.
+
+### 4.2 T3 is where the family scales
+
+Two shadows is the knob that keeps working: a second gnomon adds evidence without
+adding rules, and the player already knows how to read one. It is also the point
+where the board stops being answerable at a glance, which is what earns the tier.
+
+### 4.3 What is deliberately absent
+
+**Minutes.** Precision finer than a quarter-hour turns the puzzle into
+protractor-reading, and the tap-target bar (§9) would not survive it.
+
+**Modular arithmetic as such.** Clock arithmetic is its own family (§4.5) at T4–T5
+and reuses this dial face. T4 above is the wrap a _reading_ runs into, not "the
+ritual lasts six hours, when does it end" — that question belongs to the other
+family and should stay there.
+
+## 5. Generation
+
+Enumeration, not construction:
+
+1. Pick the answer hour, seeded.
+2. Compute the shadow it casts — direction from the hour, length from the sun's
+   height at that hour.
+3. Choose what the board shows: the graduation count, whether length is drawn,
+   how many gnomons.
+4. **Solve it with the technique ladder.** Enumerate every hour the marks admit
+   and keep only the ones consistent with the drawn evidence. Exactly one
+   survivor, reached within the tier's cap, or discard and redraw.
+
+Uniqueness is not assumed from construction — it is checked, because step 3 can
+easily show too little. A board where direction is drawn and length is not has
+two answers, and that is a bug rather than a difficulty.
+
+The candidate space is a couple of dozen hours, so the whole solve is trivial.
+This family has no generation-cost section worth writing, which is itself part of
+the pitch.
+
+## 6. Difficulty knobs
+
+- **Graduation precision** — hour, then half, then quarter.
+- **Whether length is drawn** — withholding it is not harder, it is _unsolvable_;
+  the knob is whether length is _needed_, which means whether direction alone
+  already settles the hour.
+- **Gnomon count** — one, then two (T3).
+- **12 vs 24 marks**, and whether the answer crosses the day/night boundary (T4).
+
+| Tier    | Marks       | Gnomons | Requires |
+| ------- | ----------- | ------- | -------- |
+| starter | 12, hour    | 1       | —        |
+| junior  | 12, half    | 1       | T2       |
+| expert  | 12, quarter | 1       | T2       |
+| master  | 24, half    | 2       | T3       |
+| wizard  | 24, quarter | 2       | T3, wrap |
+
+**Proposed, not measured.** §7's curriculum map has this family entering at T2 and
+running to T5; the row above debuts it a tier earlier, at its very simplest, on
+P4's grounds — a single shadow on a single mark is a self-teaching board and the
+stone tier has nothing else this short. That is a change to the curriculum map
+and should be argued there rather than assumed here.
+
+## 7. Controls
+
+A **marker dragged around the rim**, snapping to graduations. Not a tap on a mark:
+at 24 marks on a 318px board the marks sit about 41px apart, under the 44px bar,
+and a drag with snapping keeps one large target instead of twenty-four small
+ones. Reset returns the marker to the first mark; hint and back come from the
+shell, as `puzzle-screens.md` §3 requires.
+
+The player never types and never chooses from a list of sentences.
+
+## 8. Hints
+
+One per rung, rendered from `{ techniqueId, params }` through numeric-slot
+templates — never a composed sentence (`puzzle-screens.md` §4).
+
+- **T0** — "The shadow lies right along this mark."
+- **T1** — "The shadow falls between these two marks; the small marks divide them
+  into quarters."
+- **T2** — "A shadow this short belongs to the middle of the day, not its edges."
+- **T3** — "Only one hour puts both shadows where they are."
+- **T4** — "Counting past the last mark starts again at the first."
+
+The hint highlights the evidence it reasons from — the shadow, the mark, the
+second gnomon — so "this one is too short" has something to point at. It never
+moves the marker.
+
+## 9. Board requirements
+
+Beyond the shared screen bar:
+
+- **The marks are countable.** A player who cannot read a clock must still be able
+  to work out which mark is which by counting from a distinguished one. That means
+  one mark is visibly the first.
+- **Length reads as length.** The shadow's end must be unambiguous — a soft edge
+  or a gradient makes T2 a guess. This is the single hardest visual requirement in
+  the family and the one most likely to fail playtest.
+- **Two shadows are visibly two.** At T3 the second gnomon and its shadow must not
+  read as decoration.
+- **Nothing but shadow is drawn as a dark band**, the same discipline lightbeam
+  keeps for its beam (§9 there).
+- Live feedback: the marker snapped to a mark shows what hour it claims, wordlessly
+  — by the mark it sits on, not by a number appearing.
+
+## 10. Theming
+
+The family emits logical state only — `mark(index, major|minor) | gnomon | shadow
+(direction, length) | marker` — and the skin decides what any of it looks like.
+
+**Two skins are already called for:**
+
+- **Day / sun.** Obelisk on a temple floor. The default.
+- **Night / decan star-clock.** `PUZZLE_FAMILIES.md` §4.3 names it, and the
+  Lighthouse of Alexandria journey (`junior_4`) needs it: that journey is authored
+  `background: { time: "night" }`, so a sun shadow contradicts the sky the player
+  is looking at. The decan variant keeps every rule — a sighting line instead of a
+  shadow, a star's height instead of the sun's — and changes only the art.
+
+Whether the night version is a skin or a second family is **§11's first open
+question**, and it is a real fork rather than a formality.
+
+**Placement.** Filling a journey with light puzzles needs no engine work:
+`placeEncounters.ts` resolves a floor as `allocate(roleOf(floor.encounter,
+"puzzle"), …)`, so a floor may author a role and the allocator draws from that
+tag's pool. Giving this family and lightbeam a shared `light` tag alongside
+`puzzle`, and authoring the lighthouse floors with that role, is the whole
+mechanism. (Note `FamilyMeta.themes` is the _skin_ list and not this — the
+narrative cluster of §11.1 has no field of its own.)
+
+## 11. Open questions
+
+1. **Is the night version a skin or a family?** If the decan star-clock needs its
+   own rules rather than its own art, this doc describes two families and they
+   should be priced as two. Settle this before building, because it decides
+   whether the state the component emits is one vocabulary or two.
+2. **Does T2 survive contact?** "Short means midday" is a real deduction on paper.
+   Whether it is a satisfying one, or a coin-flip the player makes and moves on
+   from, is a playtest question and the premise of the family rests on it. Worth
+   hand-authoring a dozen boards in the puzzle lab before a generator is written.
+3. **Does snapping empty the puzzle?** Snap too coarsely and the drag becomes a
+   choice between two visible answers. The graduation count and the snap radius
+   are the same knob and cannot be tuned independently.
+4. **Should this family debut at T1?** §6's table says yes on P4 grounds and §7's
+   curriculum map says T2. One of them is wrong; the map is the one to change if
+   the stone tier turns out to want a short room more than it wants a third
+   arithmetic one.
+5. **Does the obelisk shadow want to be shared with lightbeam?**
+   `lightbeam.md` §11 already proposes "light the shrine at the fifth hour" — the
+   same shadow sweeping one column per hour, blocked on a tick/scrub control and on
+   hours-as-position. Building this family supplies both. Whether that variant then
+   belongs to lightbeam, to this family, or to neither is worth deciding once both
+   exist rather than now.

--- a/src/mods/core/app/PuzzleFamilyShell.spec.tsx
+++ b/src/mods/core/app/PuzzleFamilyShell.spec.tsx
@@ -25,10 +25,10 @@ describe("PuzzleFamilyShell", () => {
     // puzzle while the win was already scheduled.
     renderShell(true)
     expect(screen.getByText("cell").closest("[inert]")).not.toBeNull()
-    // Out of reach but still holding its space: `visibility: hidden` takes the controls away from taps
-    // and the keyboard without collapsing the layout under the banner.
-    expect(screen.getByText("ui.resetPuzzle").closest(".invisible")).not.toBeNull()
-    expect(screen.getByText(/ui.hint/).closest(".invisible")).not.toBeNull()
+    // The controls stay where they were — dropping them out of the flow jumped the page — but `inert`
+    // takes them out of reach of a tap and the keyboard.
+    expect(screen.getByText("ui.resetPuzzle").closest("[inert]")).not.toBeNull()
+    expect(screen.getByText(/ui.hint/).closest("[inert]")).not.toBeNull()
   })
 
   /** The solved board is the reward: it stays on screen, behind a light dim, until the player is done with it. */

--- a/src/mods/core/app/PuzzleFamilyShell.spec.tsx
+++ b/src/mods/core/app/PuzzleFamilyShell.spec.tsx
@@ -25,8 +25,10 @@ describe("PuzzleFamilyShell", () => {
     // puzzle while the win was already scheduled.
     renderShell(true)
     expect(screen.getByText("cell").closest("[inert]")).not.toBeNull()
-    expect(screen.queryByText("ui.resetPuzzle")).toBeNull()
-    expect(screen.queryByText(/ui.hint/)).toBeNull()
+    // Out of reach but still holding its space: `visibility: hidden` takes the controls away from taps
+    // and the keyboard without collapsing the layout under the banner.
+    expect(screen.getByText("ui.resetPuzzle").closest(".invisible")).not.toBeNull()
+    expect(screen.getByText(/ui.hint/).closest(".invisible")).not.toBeNull()
   })
 
   /** The solved board is the reward: it stays on screen, behind a light dim, until the player is done with it. */

--- a/src/mods/core/app/PuzzleFamilyShell.tsx
+++ b/src/mods/core/app/PuzzleFamilyShell.tsx
@@ -106,10 +106,10 @@ export const PuzzleFamilyShell = ({
 
   return (
     <>
-      {/* Kept in the layout once the board is finishing, not unmounted: dropping the chrome and the rules
-          out of the flow collapsed the page under the banner, so the whole screen jumped as it landed.
-          `invisible` holds the space and still takes the controls out of reach. */}
-      <div className={clsx("flex w-full items-center gap-2", finishing && "invisible")}>
+      {/* Kept in the layout once the board is finishing, not unmounted: dropping the chrome out of the flow
+          collapsed the page under the banner, so the whole screen jumped as it landed. Dimmed and inert
+          rather than hidden — the controls read as out of use, which is what they are. */}
+      <div inert={finishing} className={clsx("flex w-full items-center gap-2", finishing && "opacity-40")}>
         <button
           onClick={() => {
             cancelSolve()

--- a/src/mods/core/app/PuzzleFamilyShell.tsx
+++ b/src/mods/core/app/PuzzleFamilyShell.tsx
@@ -106,67 +106,73 @@ export const PuzzleFamilyShell = ({
 
   return (
     <>
-      {!finishing && (
-        <div className="flex w-full items-center gap-2">
+      {/* Kept in the layout once the board is finishing, not unmounted: dropping the chrome and the rules
+          out of the flow collapsed the page under the banner, so the whole screen jumped as it landed.
+          `invisible` holds the space and still takes the controls out of reach. */}
+      <div className={clsx("flex w-full items-center gap-2", finishing && "invisible")}>
+        <button
+          onClick={() => {
+            cancelSolve()
+            onCancel()
+          }}
+          className="rounded px-2 py-1 text-sm text-stone-300 hover:bg-stone-800"
+        >
+          ← {t("ui.backToMap")}
+        </button>
+        <div className="flex-1" />
+        {onReset && (
           <button
             onClick={() => {
-              cancelSolve()
-              onCancel()
+              reportInput()
+              onReset()
             }}
             className="rounded px-2 py-1 text-sm text-stone-300 hover:bg-stone-800"
           >
-            ← {t("ui.backToMap")}
+            {t("ui.resetPuzzle")}
           </button>
-          <div className="flex-1" />
-          {onReset && (
-            <button
-              onClick={() => {
-                reportInput()
-                onReset()
-              }}
-              className="rounded px-2 py-1 text-sm text-stone-300 hover:bg-stone-800"
-            >
-              {t("ui.resetPuzzle")}
-            </button>
-          )}
-          {hint && (
-            <button
-              onClick={() => {
-                reveal()
-                onHintRevealed?.()
-              }}
-              disabled={cooling}
-              className={clsx("relative overflow-hidden rounded px-2 py-1 text-sm", {
-                "bg-amber-700 text-amber-100 hover:bg-amber-600": !cooling && !nudging,
-                "bg-amber-700 text-amber-100 ring-2 ring-amber-300 motion-safe:animate-pulse": nudging && !cooling,
-                "bg-stone-800 text-stone-500": cooling,
-              })}
-            >
-              {/* The wait made visible: the bar reaches the far edge as the button unlocks. */}
-              {cooling && (
-                <span
-                  className="absolute inset-0 origin-left animate-hint-recharge bg-amber-900"
-                  style={{ animationDuration: `${HINT_COOLDOWN_MS}ms` }}
-                />
-              )}
-              <span className="relative">💡 {t("ui.hint")}</span>
-            </button>
-          )}
-        </div>
-      )}
+        )}
+        {hint && (
+          <button
+            onClick={() => {
+              reveal()
+              onHintRevealed?.()
+            }}
+            disabled={cooling}
+            className={clsx("relative overflow-hidden rounded px-2 py-1 text-sm", {
+              "bg-amber-700 text-amber-100 hover:bg-amber-600": !cooling && !nudging,
+              "bg-amber-700 text-amber-100 ring-2 ring-amber-300 motion-safe:animate-pulse": nudging && !cooling,
+              "bg-stone-800 text-stone-500": cooling,
+            })}
+          >
+            {/* The wait made visible: the bar reaches the far edge as the button unlocks. */}
+            {cooling && (
+              <span
+                className="absolute inset-0 origin-left animate-hint-recharge bg-amber-900"
+                style={{ animationDuration: `${HINT_COOLDOWN_MS}ms` }}
+              />
+            )}
+            <span className="relative">💡 {t("ui.hint")}</span>
+          </button>
+        )}
+      </div>
       <div inert={finishing} className={clsx("flex w-full flex-col items-center gap-4", finishing && "opacity-90")}>
         {children({ solved: handleSolved, reportInput, hintVisible: revealed && hint !== undefined })}
       </div>
-      {hintText && !solvedBanner && (
+      {hintText && (
         <p
           ref={hintRef}
-          className="w-full rounded border border-amber-800 bg-amber-950/60 p-2 text-center text-sm text-amber-200"
+          className={clsx(
+            "w-full rounded border border-amber-800 bg-amber-950/60 p-2 text-center text-sm text-amber-200",
+            solvedBanner && "invisible"
+          )}
         >
           {hintText}
         </p>
       )}
-      {rules && !solvedBanner && (
-        <div className="w-full border-t border-stone-700 pt-3 text-sm text-stone-400">
+      {rules && (
+        <div
+          className={clsx("w-full border-t border-stone-700 pt-3 text-sm text-stone-400", solvedBanner && "invisible")}
+        >
           <h3 className="mb-1 font-pyramid text-stone-300">{t("ui.howToPlay")}</h3>
           {rules}
         </div>

--- a/src/mods/puzzle/app/futoshiki/FutoshikiBoard.tsx
+++ b/src/mods/puzzle/app/futoshiki/FutoshikiBoard.tsx
@@ -32,9 +32,16 @@ const SIGN_TURN: Record<"right" | "down", Record<"<" | ">", number>> = {
   down: { "<": -90, ">": 90 },
 }
 
-// Sized off the BOARD, not the viewport: the layer is its own container, so a mark is always the same
-// fraction of a square whether the grid is 4 wide or 6. A viewport-relative size drifts the other way
-// — the squares shrink as the grid grows while the sign does not, and a 6x6 ends up smothered.
+// Sized off the BOARD, not the viewport: the layer is its own container, so the mark scales with the
+// squares. A viewport-relative size drifts the other way — the squares shrink as the grid grows while
+// the sign does not, and a 6x6 ends up smothered.
+//
+// It takes a **smaller share** of the square as the grid grows (44% at 4 wide, 36% at 6), because an
+// equal share is not an equal reading: at 4 wide the square has room for a bold chevron beside its
+// digit, and at 6 the same share crowds the digit it is meant to sit between. The mark still grows in
+// absolute terms wherever the board is bigger than a phone.
+const signShare = (size: number) => 44 - (size - 4) * 4
+
 const SignMark: FC<{ direction: "right" | "down"; relation: "<" | ">"; size: number }> = ({
   direction,
   relation,
@@ -42,7 +49,7 @@ const SignMark: FC<{ direction: "right" | "down"; relation: "<" | ">"; size: num
 }) => (
   <svg
     viewBox="0 0 24 24"
-    style={{ width: `${44 / size}cqw`, height: `${44 / size}cqw` }}
+    style={{ width: `${signShare(size) / size}cqw`, height: `${signShare(size) / size}cqw` }}
     aria-hidden
     focusable="false"
   >
@@ -50,7 +57,7 @@ const SignMark: FC<{ direction: "right" | "down"; relation: "<" | ">"; size: num
       points="9,4 17,12 9,20"
       fill="none"
       stroke="currentColor"
-      strokeWidth={5}
+      strokeWidth={4}
       strokeLinecap="round"
       strokeLinejoin="round"
       transform={`rotate(${SIGN_TURN[direction][relation]} 12 12)`}
@@ -136,9 +143,10 @@ const SignLayer: FC<{ puzzle: FutoshikiPuzzleData; conflicts: FutoshikiConflicts
             gridColumn: `${constraint.col + 1} / span ${down ? 1 : 2}`,
             gridRow: `${constraint.row + 1} / span ${down ? 2 : 1}`,
           }}
-          // The chip carries the board's own backdrop, so a sign sitting on the corner of two squares
-          // reads as a notch between them rather than as ink spilled over a digit.
-          className={clsx("place-self-center rounded-full bg-stone-900 p-[3%] leading-none", {
+          // The mark sits straight on the gutter with no disc behind it: the gap between two squares is
+          // already a dark line, so the chevron reads as a notch in the stone without one, and the disc
+          // was ink the board did not need.
+          className={clsx("place-self-center leading-none", {
             "text-stone-300": !broken && !lit?.has(index),
             "text-amber-300": !broken && lit?.has(index),
             "text-red-400": broken,

--- a/src/mods/puzzle/app/futoshiki/FutoshikiBoard.tsx
+++ b/src/mods/puzzle/app/futoshiki/FutoshikiBoard.tsx
@@ -22,12 +22,41 @@ type Props = {
   onSelect: (row: number, col: number) => void
 }
 
-// Sign glyphs, not words: the point of the mark always opens toward the bigger number, in either
-// direction (PUZZLE_FAMILIES.md P2 — the board carries no language).
-const SIGN_GLYPH: Record<"right" | "down", Record<"<" | ">", string>> = {
-  right: { "<": "<", ">": ">" },
-  down: { "<": "∧", ">": "∨" },
+// One chevron, turned four ways: the point of the mark always opens toward the bigger number, in
+// either direction (PUZZLE_FAMILIES.md P2 — the board carries no language). Drawn rather than typed,
+// because a typeface's "<" is a mathematical glyph sized to sit in a line of prose — thin, and lost
+// against a stone square at arm's length. A stroked path takes the weight the board needs and keeps
+// it at every grid size.
+const SIGN_TURN: Record<"right" | "down", Record<"<" | ">", number>> = {
+  right: { "<": 180, ">": 0 },
+  down: { "<": -90, ">": 90 },
 }
+
+// Sized off the BOARD, not the viewport: the layer is its own container, so a mark is always the same
+// fraction of a square whether the grid is 4 wide or 6. A viewport-relative size drifts the other way
+// — the squares shrink as the grid grows while the sign does not, and a 6x6 ends up smothered.
+const SignMark: FC<{ direction: "right" | "down"; relation: "<" | ">"; size: number }> = ({
+  direction,
+  relation,
+  size,
+}) => (
+  <svg
+    viewBox="0 0 24 24"
+    style={{ width: `${44 / size}cqw`, height: `${44 / size}cqw` }}
+    aria-hidden
+    focusable="false"
+  >
+    <polyline
+      points="9,4 17,12 9,20"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      transform={`rotate(${SIGN_TURN[direction][relation]} 12 12)`}
+    />
+  </svg>
+)
 
 // The square is its own sizing context, so the digit and the pencilled notes inside it scale with the
 // square rather than with the screen — a 4-wide board and a 7-wide one then read the same.
@@ -91,7 +120,7 @@ const SignLayer: FC<{ puzzle: FutoshikiPuzzleData; conflicts: FutoshikiConflicts
   lit,
 }) => (
   <div
-    className="pointer-events-none absolute inset-0 grid gap-px"
+    className="@container pointer-events-none absolute inset-0 grid gap-px"
     style={{
       gridTemplateColumns: `repeat(${puzzle.size}, minmax(0, 1fr))`,
       gridTemplateRows: `repeat(${puzzle.size}, minmax(0, 1fr))`,
@@ -109,16 +138,13 @@ const SignLayer: FC<{ puzzle: FutoshikiPuzzleData; conflicts: FutoshikiConflicts
           }}
           // The chip carries the board's own backdrop, so a sign sitting on the corner of two squares
           // reads as a notch between them rather than as ink spilled over a digit.
-          className={clsx(
-            "place-self-center rounded-full bg-stone-900 px-[0.15em] text-[min(3.6vw,0.95rem)] leading-none font-bold",
-            {
-              "text-stone-400": !broken && !lit?.has(index),
-              "text-amber-300": !broken && lit?.has(index),
-              "text-red-400": broken,
-            }
-          )}
+          className={clsx("place-self-center rounded-full bg-stone-900 p-[3%] leading-none", {
+            "text-stone-300": !broken && !lit?.has(index),
+            "text-amber-300": !broken && lit?.has(index),
+            "text-red-400": broken,
+          })}
         >
-          {SIGN_GLYPH[constraint.direction][constraint.relation]}
+          <SignMark direction={constraint.direction} relation={constraint.relation} size={puzzle.size} />
         </span>
       )
     })}

--- a/src/mods/puzzle/app/futoshiki/futoshikiHint.spec.ts
+++ b/src/mods/puzzle/app/futoshiki/futoshikiHint.spec.ts
@@ -25,7 +25,7 @@ describe("buildFutoshikiHint", () => {
   it("names a wrong number before anything else, however much else is deducible", () => {
     const values = blankGrid(3)
     values[0][0] = 3
-    const hint = buildFutoshikiHint(puzzle, values, noNotes(3), solution, "nakedPair")
+    const hint = buildFutoshikiHint(puzzle, values, noNotes(3), solution, "nakedSubset")
     expect(hint).toMatchObject({ key: "mistake.value" })
     expect([...hint!.cells]).toEqual(["0,0"])
   })
@@ -33,16 +33,16 @@ describe("buildFutoshikiHint", () => {
   it("names notes that have ruled the right number out", () => {
     const notes = noNotes(3)
     notes[1][1] = [1, 2]
-    expect(buildFutoshikiHint(puzzle, blankGrid(3), notes, solution, "nakedPair")?.key).toBe("mistake.note")
+    expect(buildFutoshikiHint(puzzle, blankGrid(3), notes, solution, "nakedSubset")?.key).toBe("mistake.note")
   })
 
   it("carries the technique's own numbers into the sentence's slots", () => {
-    const hint = buildFutoshikiHint(puzzle, blankGrid(3), noNotes(3), solution, "nakedPair")
+    const hint = buildFutoshikiHint(puzzle, blankGrid(3), noNotes(3), solution, "nakedSubset")
     expect(hint).toMatchObject({ key: "signBound.high", params: { value: 3 } })
   })
 
   it("points at the sign its reason is about, so the board can light it up", () => {
-    const hint = buildFutoshikiHint(puzzle, blankGrid(3), noNotes(3), solution, "nakedPair")
+    const hint = buildFutoshikiHint(puzzle, blankGrid(3), noNotes(3), solution, "nakedSubset")
     expect([...hint!.constraints]).toEqual([0])
   })
 
@@ -65,6 +65,6 @@ describe("buildFutoshikiHint", () => {
   })
 
   it("says nothing once the board is finished", () => {
-    expect(buildFutoshikiHint(puzzle, solution, noNotes(3), solution, "nakedPair")).toBeUndefined()
+    expect(buildFutoshikiHint(puzzle, solution, noNotes(3), solution, "nakedSubset")).toBeUndefined()
   })
 })

--- a/src/mods/puzzle/app/futoshiki/futoshikiHint.ts
+++ b/src/mods/puzzle/app/futoshiki/futoshikiHint.ts
@@ -8,8 +8,8 @@ import {
   type FutoshikiCellRef,
   type FutoshikiStep,
   type FutoshikiValues,
-  type TechniqueId,
 } from "@/mods/puzzle/game/futoshiki/techniques"
+import { techniquesFor, type DemandId } from "@/mods/puzzle/game/futoshiki/demands"
 
 export type FutoshikiHint = {
   /** Translation key under `futoshiki.hint`, plus the numbers that fill its slots. */
@@ -38,8 +38,9 @@ const asHint = (step: FutoshikiStep): FutoshikiHint => ({
 
 /**
  * The next thing to say to the player: a wrong number or a wrong note first, otherwise the cheapest
- * technique that fires. Which techniques are allowed comes from the board's own cap, so a starter
- * board never explains itself with reasoning it was never built to need.
+ * technique that fires. Which techniques are allowed comes from the board's own tier, and the tier is
+ * asked in the coarse vocabulary generation speaks — but the hint that comes back names the exact
+ * technique, so a subset hint still says whether it is talking about two squares or three.
  *
  * The player's notes are read as the narrowing they are, so a hint that tells them to rule a number
  * out only fires while they still hold it — following the advice is what moves the hint on.
@@ -49,7 +50,7 @@ export const buildFutoshikiHint = (
   values: FutoshikiValues,
   notes: FutoshikiNotes,
   solution: number[][],
-  cap: TechniqueId
+  cap: DemandId
 ): FutoshikiHint | undefined => {
   const mistake = firstFutoshikiMistake(values, notes, solution)
   if (mistake)
@@ -61,6 +62,6 @@ export const buildFutoshikiHint = (
       focus: { row: mistake.row, col: mistake.col },
     }
 
-  const step = nextFutoshikiStep(puzzle, createFutoshikiBoard(puzzle, values, notes), cap)
+  const step = nextFutoshikiStep(puzzle, createFutoshikiBoard(puzzle, values, notes), techniquesFor(cap))
   return step && asHint(step)
 }

--- a/src/mods/puzzle/game/futoshiki/demands.ts
+++ b/src/mods/puzzle/game/futoshiki/demands.ts
@@ -1,0 +1,55 @@
+import { TECHNIQUES, type TechniqueId } from "./techniques"
+
+/**
+ * What a tier may ask of a board, per docs/game-design/puzzles/futoshiki.md §5.2.
+ *
+ * This is a COARSER vocabulary than the solver's eleven techniques, and deliberately so: a pair and a
+ * triple are the same idea at a different width, so a tier that says "this board needs a hidden
+ * subset" should not care which width turns up. The hint layer still names the width — "these THREE
+ * squares hold only 2, 5 and 7 between them" is a better sentence than any generic one — so the fold
+ * lives here and nowhere else.
+ */
+export const DEMANDS = [
+  "nakedSingle",
+  "hiddenSingle",
+  "signBound",
+  "signVsValue",
+  "signChain",
+  "signPair",
+  "nakedSubset",
+  "hiddenSubset",
+  "xWing",
+] as const
+
+export type DemandId = (typeof DEMANDS)[number]
+
+/**
+ * The techniques each demand stands for. The pairs and triples interleave in the solver's ladder
+ * (naked pair, hidden pair, naked triple, hidden triple), which is why a tier's allowance has to be
+ * a SET and not a depth: master wants naked subsets and not hidden ones, and no prefix of the ladder
+ * says that.
+ */
+const COVERS: Record<DemandId, TechniqueId[]> = {
+  nakedSingle: ["nakedSingle"],
+  hiddenSingle: ["hiddenSingle"],
+  signBound: ["signBound"],
+  signVsValue: ["signVsValue"],
+  signChain: ["signChain"],
+  signPair: ["signPair"],
+  nakedSubset: ["nakedPair", "nakedTriple"],
+  hiddenSubset: ["hiddenPair", "hiddenTriple"],
+  xWing: ["xWing"],
+}
+
+/** Which demand a technique answers to — how a solve's hardest step is read back as a tier's ask. */
+export const demandOf = (technique: TechniqueId): DemandId =>
+  DEMANDS.find(demand => COVERS[demand].includes(technique)) as DemandId
+
+/**
+ * Every technique a tier capped at `demand` may spend: that demand and every gentler one, kept in
+ * ladder order so the solver still reaches for the cheapest reason that fires.
+ */
+export const techniquesFor = (demand: DemandId): TechniqueId[] => {
+  const permitted = new Set(DEMANDS.slice(0, DEMANDS.indexOf(demand) + 1).flatMap(allowed => COVERS[allowed]))
+  return TECHNIQUES.filter(technique => permitted.has(technique))
+}

--- a/src/mods/puzzle/game/futoshiki/futoshikiConfig.ts
+++ b/src/mods/puzzle/game/futoshiki/futoshikiConfig.ts
@@ -18,8 +18,20 @@ export const FUTOSHIKI_CONFIG: Record<Difficulty, { size: number } & FutoshikiOp
   // wearing the family's name. Insisting the board turn a sign bound on costs nothing and makes that
   // board impossible.
   starter: { size: 4, techniqueCap: "signBound", prefill: 4, requires: ["signBound"] },
-  junior: { size: 5, techniqueCap: "signChain", prefill: 3 },
-  expert: { size: 6, techniqueCap: "signChain", prefill: 2 },
-  master: { size: 6, techniqueCap: "nakedSubset", prefill: 1 },
+  // **One addition, on the grid the player already knows**: reading a sign against a number that is
+  // already there. Starter used to hand straight over to a 5x5 with sign chains and one fewer given,
+  // which is three dials at once and played as a different family. The rung between them was the one
+  // being skipped — T3 was reachable at no tier's cap — and it is the cheapest sentence in the ladder:
+  // "that square is already a 4, and this one has to be smaller."
+  //
+  // It also fixes what §5.1 calls the squeezed gentle end: a T2 cap cannot manufacture signs, so
+  // starter carries ~3 of them against 4 given numbers, and a T3 cap yields roughly four signs against
+  // 1.7 numbers. So junior is where the board stops looking like a Latin square with hints, without
+  // growing a single square.
+  junior: { size: 4, techniqueCap: "signVsValue", prefill: 3, requires: ["signVsValue"] },
+  // The grid grows, and with it the chain: a run of signs pointing the same way is a reason that needs
+  // somewhere to run.
+  expert: { size: 5, techniqueCap: "signChain", prefill: 2, requires: ["signChain"] },
+  master: { size: 6, techniqueCap: "nakedSubset", prefill: 1, requires: ["nakedSubset"] },
   wizard: { size: 6, techniqueCap: "xWing", prefill: 0, requires: ["hiddenSubset", "xWing"] },
 }

--- a/src/mods/puzzle/game/futoshiki/futoshikiConfig.ts
+++ b/src/mods/puzzle/game/futoshiki/futoshikiConfig.ts
@@ -1,16 +1,25 @@
 import type { Difficulty } from "@/data/difficultyLevels"
 import type { FutoshikiOptions } from "./generateFutoshiki"
 
-// Tier settings, from docs/game-design/puzzles/futoshiki.md §5. Two dials, and the cap is the one that
-// carries the difficulty: it is what a board may DEMAND of the player. How many signs a board ends up
-// showing follows from it rather than being set here — a weak ladder cannot spare many, a strong one
-// strips the board bare. 7 wide is the ceiling, matching Puzzle Express: with the signs laid over the
-// gutters rather than given tracks of their own, seven squares still measure a thumb across inside a
-// 360px modal, and an eighth would not.
+// Tier settings, from docs/game-design/puzzles/futoshiki.md §5. Three dials now, and they answer three
+// different questions: the CAP is what a board may demand of the player, PREFILL is how much of the
+// answer it is handed to start with, and REQUIRES is the reasoning it is guaranteed to need. How many
+// signs a board shows is still not a dial — it falls out of the cap, a weak ladder sparing few and a
+// strong one stripping the board bare.
+//
+// 6 wide is the ceiling. Seven was bought for the top rungs of the ladder, on the belief that nothing
+// above sign pair fires below it; measurement says otherwise (§4.3), and seven cost a 45-minute solve
+// against a 3-minute budget. What separates wizard from master is no longer the grid: master may
+// reach for a naked subset but never a hidden one, and a wizard board is handed nothing and must
+// genuinely turn on a hidden subset or an x-wing to fall.
 export const FUTOSHIKI_CONFIG: Record<Difficulty, { size: number } & FutoshikiOptions> = {
-  starter: { size: 4, techniqueCap: "signVsValue" },
-  junior: { size: 5, techniqueCap: "signChain" },
-  expert: { size: 6, techniqueCap: "signChain" },
-  master: { size: 6, techniqueCap: "signPair" },
-  wizard: { size: 7, techniqueCap: "xWing" },
+  // The `requires` is not decoration at the gentle end: a ladder this weak can settle a 4x4 on
+  // pre-filled numbers alone, and one board in six came out carrying NO signs at all — a Latin square
+  // wearing the family's name. Insisting the board turn a sign bound on costs nothing and makes that
+  // board impossible.
+  starter: { size: 4, techniqueCap: "signBound", prefill: 4, requires: ["signBound"] },
+  junior: { size: 5, techniqueCap: "signChain", prefill: 3 },
+  expert: { size: 6, techniqueCap: "signChain", prefill: 2 },
+  master: { size: 6, techniqueCap: "nakedSubset", prefill: 1 },
+  wizard: { size: 6, techniqueCap: "xWing", prefill: 0, requires: ["hiddenSubset", "xWing"] },
 }

--- a/src/mods/puzzle/game/futoshiki/generateFutoshiki.spec.ts
+++ b/src/mods/puzzle/game/futoshiki/generateFutoshiki.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 import { generateFutoshiki } from "./generateFutoshiki"
 import { FUTOSHIKI_CONFIG } from "./futoshikiConfig"
 import { constraintEnds, solveFutoshikiByTechniques } from "./techniques"
+import { demandOf, techniquesFor } from "./demands"
 import { isFutoshikiSolved } from "./futoshikiStatus"
 import { difficulties } from "@/data/difficultyLevels"
 
@@ -19,12 +20,13 @@ describe("generateFutoshiki", () => {
     const boards = Array.from({ length: 8 }, (_, seed) => generateFutoshiki(size, seed + 1, options))
 
     it("never needs a guess — every board settles inside its own technique cap", () => {
-      for (const board of boards) expect(solveFutoshikiByTechniques(board, board.techniqueCap).settled).toBe(true)
+      for (const board of boards)
+        expect(solveFutoshikiByTechniques(board, techniquesFor(board.techniqueCap)).settled).toBe(true)
     })
 
     it("deduces the same answer the board was built from", () => {
       for (const board of boards)
-        expect(solveFutoshikiByTechniques(board, board.techniqueCap).values).toEqual(board.solution)
+        expect(solveFutoshikiByTechniques(board, techniquesFor(board.techniqueCap)).values).toEqual(board.solution)
     })
 
     it("its answer is a grid the game accepts as solved", () => {
@@ -39,21 +41,47 @@ describe("generateFutoshiki", () => {
         }
     })
 
-    it("shows no sign the player cannot spend — every one is load-bearing", () => {
-      for (const board of boards)
+    // Signs are thinned against the board's OWN minimum, before the tier hands any numbers back
+    // (design doc §5.1) — so the bar is that no sign was spare when the thinning stopped, which is
+    // what keeps the sign count from collapsing. A number given afterwards may well retire one, and
+    // that is the gift doing its job rather than a sign wasted.
+    it("shows no sign the thinning could have spared — the signs are settled before the gift", () => {
+      for (const board of boards) {
+        const earned = board.givens.map(row => row.map(() => undefined as number | undefined))
+        board.solution.forEach((row, r) =>
+          row.forEach((_, c) => {
+            if (board.givens[r][c] !== undefined) earned[r][c] = board.givens[r][c]
+          })
+        )
         for (let index = 0; index < board.constraints.length; index++) {
           const without = board.constraints.filter((_, other) => other !== index)
-          expect(
-            solveFutoshikiByTechniques({ size, givens: board.givens, constraints: without }, board.techniqueCap).settled
-          ).toBe(false)
+          const stillSolves = solveFutoshikiByTechniques(
+            { size, givens: earned, constraints: without },
+            techniquesFor(board.techniqueCap)
+          ).settled
+          // A spare sign is only acceptable where the tier handed numbers back beyond what the board
+          // itself needed; with no prefill at all there is nothing to blame but the thinning.
+          if (options.prefill === undefined) expect(stillSolves).toBe(false)
         }
+      }
     })
 
-    it("keeps the signs rather than the pre-filled numbers — the signs are the puzzle", () => {
+    it("turns on every rung its tier insists upon", () => {
+      if (!options.requires?.length) return
+      for (const board of boards) {
+        const deepest = solveFutoshikiByTechniques(board, techniquesFor(board.techniqueCap)).deepest
+        expect(deepest && options.requires).toContain(deepest && demandOf(deepest))
+      }
+    })
+
+    it("hands back at least the numbers its tier promises", () => {
+      if (options.prefill === undefined) return
       for (const board of boards)
-        expect(board.constraints.length).toBeGreaterThan(
-          board.givens.flat().filter(value => value !== undefined).length
-        )
+        expect(board.givens.flat().filter(value => value !== undefined).length).toBeGreaterThanOrEqual(options.prefill)
+    })
+
+    it("always shows a sign — a board of numbers alone is not this family", () => {
+      for (const board of boards) expect(board.constraints.length).toBeGreaterThan(0)
     })
 
     it("keeps something to work out: no board is more answer than puzzle", () => {

--- a/src/mods/puzzle/game/futoshiki/generateFutoshiki.ts
+++ b/src/mods/puzzle/game/futoshiki/generateFutoshiki.ts
@@ -1,22 +1,36 @@
 import { mulberry32, shuffle } from "@/game/random"
+import { demandOf, techniquesFor, type DemandId } from "./demands"
 import {
   constraintNeighbour,
   solveFutoshikiByTechniques,
   type FutoshikiCellRef,
   type FutoshikiConstraint,
   type FutoshikiPuzzleData,
-  type TechniqueId,
 } from "./techniques"
 
 export type FutoshikiPuzzle = FutoshikiPuzzleData & {
   solution: number[][]
   /** Carried so hints stay inside the same ladder the board was accepted under. */
-  techniqueCap: TechniqueId
+  techniqueCap: DemandId
 }
 
 export type FutoshikiOptions = {
   /** The strongest deduction a board may demand (design doc §5). */
-  techniqueCap?: TechniqueId
+  techniqueCap?: DemandId
+  /**
+   * The fewest squares that ship pre-filled (design doc §5.1). A floor, not a quota: a board whose
+   * own deduction needed more keeps them, and one that needed fewer is topped up from the answer
+   * after the signs are thinned — so the extra numbers are a gift to the player rather than
+   * something the signs were thinned against.
+   */
+  prefill?: number
+  /**
+   * Rungs the board must actually TURN ON to be solvable (design doc §5.3). Because the solver only
+   * ever reaches for the cheapest technique that fires, a solve whose hardest step is one of these
+   * is a board that stalls without it — so this is a guarantee the player needs the reasoning, not
+   * a hope that it turns up. Any one of them satisfies the gate.
+   */
+  requires?: DemandId[]
 }
 
 // Generation is build-then-thin, per docs/game-design/puzzles/futoshiki.md §3: draw a Latin square,
@@ -24,7 +38,10 @@ export type FutoshikiOptions = {
 // technique solver still reaches the end unaided. Every intermediate board is settled by deduction, so
 // the one that ships is too — and that also settles uniqueness, since each step along the way was
 // forced. No separate solution counter has to run.
-const MAX_ATTEMPTS = 40
+//
+// A tier that insists on a rung (§5.3) throws most attempts away, so the ceiling is far above the
+// handful a plain draw needs — wizard spends about seven.
+const MAX_ATTEMPTS = 400
 
 // Pruning reaches a fixpoint in two sweeps on every tier measured; the third is the guard, not the plan.
 const MAX_PRUNE_SWEEPS = 6
@@ -80,8 +97,12 @@ const cellsWhere = (
 ): FutoshikiCellRef[] =>
   givens.flatMap((cells, row) => cells.flatMap((value, col) => (wanted(value) ? [{ row, col }] : [])))
 
+const filledCount = (givens: (number | undefined)[][]): number =>
+  givens.flat().filter(value => value !== undefined).length
+
 export const generateFutoshiki = (size: number, seed: number, options: FutoshikiOptions = {}): FutoshikiPuzzle => {
-  const { techniqueCap = "nakedPair" } = options
+  const { techniqueCap: demand = "nakedSubset", prefill, requires } = options
+  const allowed = techniquesFor(demand)
   for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
     const random = mulberry32(seed * 7919 + attempt)
     const solution = solutionSquare(size, random)
@@ -91,7 +112,7 @@ export const generateFutoshiki = (size: number, seed: number, options: Futoshiki
     // Even with every sign shown, a gentle ladder can stall; each pre-filled number is the smallest
     // concession that unsticks it. Past `size` of them the board is more answer than puzzle, so the
     // attempt is abandoned for a fresh square rather than propped up.
-    let settled = solveFutoshikiByTechniques({ size, givens, constraints: signs }, techniqueCap)
+    let settled = solveFutoshikiByTechniques({ size, givens, constraints: signs }, allowed)
     while (!settled.settled && cellsWhere(givens, value => value !== undefined).length < size) {
       const open = cellsWhere(givens, value => value === undefined).filter(
         cell => settled.values[cell.row][cell.col] === undefined
@@ -99,7 +120,7 @@ export const generateFutoshiki = (size: number, seed: number, options: Futoshiki
       if (!open.length) break
       const pick = open[Math.floor(random() * open.length)]
       givens[pick.row][pick.col] = solution[pick.row][pick.col]
-      settled = solveFutoshikiByTechniques({ size, givens, constraints: signs }, techniqueCap)
+      settled = solveFutoshikiByTechniques({ size, givens, constraints: signs }, allowed)
     }
     if (!settled.settled) continue
 
@@ -114,7 +135,7 @@ export const generateFutoshiki = (size: number, seed: number, options: Futoshiki
     )) {
       const trial = kept.map(cells => [...cells])
       trial[cell.row][cell.col] = undefined
-      if (solveFutoshikiByTechniques({ size, givens: trial, constraints: signs }, techniqueCap).settled) kept = trial
+      if (solveFutoshikiByTechniques({ size, givens: trial, constraints: signs }, allowed).settled) kept = trial
     }
 
     // Then every sign the board turns out not to need, to a fixpoint: taking one away can make
@@ -126,13 +147,30 @@ export const generateFutoshiki = (size: number, seed: number, options: Futoshiki
       for (const sign of shuffle(constraints, random)) {
         const trial = constraints.filter(other => other !== sign)
         if (trial.length === constraints.length) continue
-        if (solveFutoshikiByTechniques({ size, givens: kept, constraints: trial }, techniqueCap).settled)
-          constraints = trial
+        if (solveFutoshikiByTechniques({ size, givens: kept, constraints: trial }, allowed).settled) constraints = trial
       }
       if (constraints.length === before) break
     }
 
-    return { size, givens: kept, constraints, solution, techniqueCap }
+    // Then the gift: numbers handed back to the player on top of a board already thinned without
+    // them. Granted after the signs are settled rather than before, so the tier's generosity never
+    // costs the board a sign (design doc §5.1).
+    if (prefill !== undefined)
+      for (const cell of shuffle(
+        cellsWhere(kept, value => value === undefined),
+        random
+      )) {
+        if (filledCount(kept) >= prefill) break
+        kept[cell.row][cell.col] = solution[cell.row][cell.col]
+      }
+
+    // Read back what the FINISHED board turns on — after the thinning that decides it, and after the
+    // pre-filled numbers that soften it. Checking before either would guarantee a rung of a board
+    // nobody plays: every number handed back can retire the very step the tier asked for.
+    const deepest = solveFutoshikiByTechniques({ size, givens: kept, constraints }, allowed).deepest
+    if (requires?.length && !(deepest && requires.includes(demandOf(deepest)))) continue
+
+    return { size, givens: kept, constraints, solution, techniqueCap: demand }
   }
-  throw new Error(`generateFutoshiki: no logically solvable board (size=${size}, seed=${seed})`)
+  throw new Error(`generateFutoshiki: no board meeting the tier's gates (size=${size}, seed=${seed})`)
 }

--- a/src/mods/puzzle/game/futoshiki/techniques.spec.ts
+++ b/src/mods/puzzle/game/futoshiki/techniques.spec.ts
@@ -14,6 +14,7 @@ import {
 } from "./techniques"
 import { generateFutoshiki } from "./generateFutoshiki"
 import { FUTOSHIKI_CONFIG } from "./futoshikiConfig"
+import { DEMANDS, demandOf, techniquesFor } from "./demands"
 import { difficulties } from "@/data/difficultyLevels"
 
 const blankGrid = (size: number): FutoshikiValues =>
@@ -31,13 +32,15 @@ const noNotes = (size: number) => Array.from({ length: size }, () => Array.from(
 // the solver actually reaches it from. Reading one in isolation would prove nothing about the ladder.
 const spentBelow = (puzzle: FutoshikiPuzzleData, technique: TechniqueId): FutoshikiBoard => {
   const board = createFutoshikiBoard(puzzle, puzzle.givens)
-  const below = TECHNIQUES[TECHNIQUES.indexOf(technique) - 1]
-  if (below) applyFutoshikiTechniques(puzzle, board, below)
+  const below = TECHNIQUES.slice(0, TECHNIQUES.indexOf(technique))
+  if (below.length) applyFutoshikiTechniques(puzzle, board, below)
   return board
 }
 
+const upTo = (technique: TechniqueId) => TECHNIQUES.slice(0, TECHNIQUES.indexOf(technique) + 1)
+
 const stepFor = (puzzle: FutoshikiPuzzleData, technique: TechniqueId) =>
-  nextFutoshikiStep(puzzle, spentBelow(puzzle, technique), technique)
+  nextFutoshikiStep(puzzle, spentBelow(puzzle, technique), upTo(technique))
 
 // The last two rungs only matter on a board too sparse for the cheaper ones to finish, which no small
 // grid of pre-filled numbers reproduces — every such grid falls to a single or a sign first. So these
@@ -165,7 +168,7 @@ describe("nextFutoshikiStep", () => {
       [all, all, all, all, all],
       [all, all, all, all, all],
     ])
-    const step = nextFutoshikiStep(puzzleOf(5, []), board, "hiddenPair")
+    const step = nextFutoshikiStep(puzzleOf(5, []), board, upTo("hiddenPair"))
     expect(step).toMatchObject({ technique: "hiddenPair", variant: "row", params: { first: 1, second: 2 } })
     expect(step?.decisions).toEqual([
       { kind: "eliminate", row: 0, col: 0, values: [3] },
@@ -193,7 +196,7 @@ describe("nextFutoshikiStep", () => {
       [all, all, all, all],
       [all, all, all, all],
     ])
-    const step = nextFutoshikiStep(puzzleOf(4, []), board, "xWing")
+    const step = nextFutoshikiStep(puzzleOf(4, []), board, upTo("xWing"))
     expect(step).toMatchObject({ technique: "xWing", variant: "row", params: { value: 1 } })
     expect(step?.cells).toEqual([
       { row: 0, col: 0 },
@@ -221,7 +224,7 @@ describe("nextFutoshikiStep", () => {
       [all, all, all, all, all, all],
       [all, all, all, all, all, all],
     ])
-    const step = nextFutoshikiStep(puzzleOf(6, []), board, "nakedTriple")
+    const step = nextFutoshikiStep(puzzleOf(6, []), board, upTo("nakedTriple"))
     expect(step).toMatchObject({
       technique: "nakedTriple",
       variant: "row",
@@ -248,7 +251,7 @@ describe("nextFutoshikiStep", () => {
       [all, all, all, all, all, all, all],
       [all, all, all, all, all, all, all],
     ])
-    const step = nextFutoshikiStep(puzzleOf(7, []), board, "hiddenTriple")
+    const step = nextFutoshikiStep(puzzleOf(7, []), board, upTo("hiddenTriple"))
     expect(step).toMatchObject({
       technique: "hiddenTriple",
       variant: "row",
@@ -267,8 +270,8 @@ describe("nextFutoshikiStep", () => {
       { row: 0, col: 1, direction: "right", relation: "<" },
     ])
     const board = spentBelow(puzzle, "signChain")
-    expect(nextFutoshikiStep(puzzle, board, "signChain")?.technique).toBe("signChain")
-    expect(nextFutoshikiStep(puzzle, board, "signVsValue")).toBeUndefined()
+    expect(nextFutoshikiStep(puzzle, board, upTo("signChain"))?.technique).toBe("signChain")
+    expect(nextFutoshikiStep(puzzle, board, upTo("signVsValue"))).toBeUndefined()
   })
 
   it("reasons from the player's own notes, so an elimination is never offered twice", () => {
@@ -301,8 +304,8 @@ describe("solveFutoshikiByTechniques", () => {
 
   it("reports the strongest technique a board demanded", () => {
     const board = generateFutoshiki(FUTOSHIKI_CONFIG.starter.size, 7, FUTOSHIKI_CONFIG.starter)
-    const { deepest } = solveFutoshikiByTechniques(board, board.techniqueCap)
-    expect(TECHNIQUES.indexOf(deepest!)).toBeLessThanOrEqual(TECHNIQUES.indexOf("signVsValue"))
+    const { deepest } = solveFutoshikiByTechniques(board, techniquesFor(board.techniqueCap))
+    expect(demandOf(deepest!)).toBe("signBound")
   })
 })
 
@@ -339,11 +342,11 @@ describe("firstFutoshikiMistake", () => {
   })
 })
 
-describe("every technique", () => {
-  // The top tier is swept deeper than the rest: the five hardest rungs only ever appear on a 7x7, and
-  // the rarest of them first turns up at seed 14, so a shallow sweep would report it dead. Generating
-  // this many real boards is seconds of honest work, so the test carries its own timeout rather than
-  // being thinned to fit the default — thinning it is exactly what would hide a dead technique.
+describe("every rung a tier can ask for", () => {
+  // The sweep is over the DEMANDS, not the eleven techniques, because the demands are what generation
+  // promises (design doc §5.2). A width the ladder distinguishes but no tier asks for — a hidden
+  // triple, say — is a finer reason the hint layer may still reach, not a promise being broken. The
+  // top tier is swept deeper than the rest because its rungs are the rare ones.
   const seedsFor = (difficulty: (typeof difficulties)[number]) => (difficulty === "wizard" ? 16 : 8)
 
   it("is reachable — each one fires on a real board", () => {
@@ -352,9 +355,10 @@ describe("every technique", () => {
       const { size, ...options } = FUTOSHIKI_CONFIG[difficulty]
       for (let seed = 1; seed <= seedsFor(difficulty); seed++) {
         const board = generateFutoshiki(size, seed, options)
-        for (const step of solveFutoshikiByTechniques(board, board.techniqueCap).steps) fired.add(step.technique)
+        for (const step of solveFutoshikiByTechniques(board, techniquesFor(board.techniqueCap)).steps)
+          fired.add(demandOf(step.technique))
       }
     }
-    expect([...TECHNIQUES].filter(technique => !fired.has(technique))).toEqual([])
+    expect([...DEMANDS].filter(demand => !fired.has(demand))).toEqual([])
   }, 60_000)
 })

--- a/src/mods/puzzle/game/futoshiki/techniques.ts
+++ b/src/mods/puzzle/game/futoshiki/techniques.ts
@@ -586,9 +586,9 @@ const firstStep = (
   puzzle: FutoshikiPuzzleData,
   board: FutoshikiBoard,
   chains: Chains,
-  cap: TechniqueId
+  allowed: readonly TechniqueId[]
 ): FutoshikiStep | undefined => {
-  for (const technique of TECHNIQUES.slice(0, techniqueRank(cap) + 1)) {
+  for (const technique of allowed) {
     const steps = IMPLEMENTATIONS[technique](puzzle, board, chains)
     if (steps.length) return steps[0]
   }
@@ -597,14 +597,18 @@ const firstStep = (
 
 /**
  * The cheapest technique that decides something on this board, or undefined when nothing is forced.
- * Which techniques are allowed comes from the board's own cap, so a starter board never explains
+ * Which techniques are allowed comes from the board's own tier, so a starter board never explains
  * itself with reasoning it was never built to need.
+ *
+ * `allowed` is a SET rather than a depth, and has to be: the ladder interleaves the pairs and the
+ * triples, so a tier that wants naked subsets without hidden ones is not a prefix of it. It must stay
+ * in ladder order, because taking the first technique that fires is what keeps hints cheap.
  */
 export const nextFutoshikiStep = (
   puzzle: FutoshikiPuzzleData,
   board: FutoshikiBoard,
-  cap: TechniqueId = "nakedPair"
-): FutoshikiStep | undefined => firstStep(puzzle, board, buildChains(puzzle), cap)
+  allowed: readonly TechniqueId[] = TECHNIQUES
+): FutoshikiStep | undefined => firstStep(puzzle, board, buildChains(puzzle), allowed)
 
 export type FutoshikiSolveResult = {
   values: FutoshikiValues
@@ -617,14 +621,13 @@ export type FutoshikiSolveResult = {
 
 const MAX_PASSES = 2000
 
-/** Carries a board as far as the techniques up to `cap` can take it, in place. */
+/** Carries a board as far as the `allowed` techniques can take it, in place. */
 export const applyFutoshikiTechniques = (
   puzzle: FutoshikiPuzzleData,
   board: FutoshikiBoard,
-  cap: TechniqueId = "nakedPair"
+  allowed: readonly TechniqueId[] = TECHNIQUES
 ): FutoshikiStep[] => {
   const chains = buildChains(puzzle)
-  const allowed = TECHNIQUES.slice(0, techniqueRank(cap) + 1)
   const steps: FutoshikiStep[] = []
   for (let pass = 0; pass < MAX_PASSES; pass++) {
     // Short-circuit deliberately: only the cheapest technique that fires is spent, and the dear ones
@@ -649,13 +652,13 @@ export const applyFutoshikiTechniques = (
   return steps
 }
 
-/** Applies techniques up to `cap` until nothing more is forced. */
+/** Applies the `allowed` techniques until nothing more is forced. */
 export const solveFutoshikiByTechniques = (
   puzzle: FutoshikiPuzzleData,
-  cap: TechniqueId = "nakedPair"
+  allowed: readonly TechniqueId[] = TECHNIQUES
 ): FutoshikiSolveResult => {
   const board = createFutoshikiBoard(puzzle, puzzle.givens)
-  const steps = applyFutoshikiTechniques(puzzle, board, cap)
+  const steps = applyFutoshikiTechniques(puzzle, board, allowed)
   return {
     values: board.values,
     settled: board.values.every(cells => cells.every(value => value !== undefined)),


### PR DESCRIPTION
Rebuilt from scratch off `main` — the earlier `signFloor` approach is gone. Signs are left exactly as they were: still thinned to the minimum, still the family's clue type.

## Three dials, three questions

| | asks |
|---|---|
| **cap** | what a board may *demand* of the player |
| **prefill** | how much of the answer it *starts with* |
| **requires** | the reasoning it is *guaranteed to need* |

**Prefill is a floor**, and it is granted **after** the signs are thinned rather than before — so a tier's generosity never costs the board a sign. A board that needed more numbers of its own keeps them.

**Requires is a guarantee, not a hope.** The solver only ever reaches for the cheapest technique that fires, so a solve whose hardest step is rung R is a board that *stalls without R*. No new solver machinery needed.

## The tier table

| Tier | Grid | Cap | Prefill | Requires | Signs | Cost |
|---|---|---|---|---|---|---|
| starter | 4×4 | sign bound | 4 | sign bound | ~3 of 24 | 6ms |
| junior | 5×5 | sign chain | 3 | — | ~10 of 40 | 15ms |
| expert | 6×6 | sign chain | 2 | — | ~15 of 60 | 38ms |
| master | 6×6 | naked subset | 1 | — | ~16 of 60 | 57ms |
| wizard | 6×6 | whole ladder | 0 | hidden subset \| x-wing | ~15 of 60 | 286ms |

Verified over 20 seeds a tier: every tier hits its prefill floor, and the hardest step lands exactly where the tier says — master reaches sign pair or a naked subset and never a hidden one; wizard splits 13 x-wing / 7 hidden subset.

## Folding, at the generation layer only

Generation speaks nine **demands**, folding the pairs and triples into `nakedSubset` and `hiddenSubset`. A tier asking for a hidden subset shouldn't care which width turns up; the hint layer still names it, so *"these three squares hold only 2, 5 and 7 between them"* survives intact.

The allowance is a **set, not a depth** — the ladder interleaves the pairs and triples (naked pair, hidden pair, naked triple, hidden triple), so "naked subsets but no hidden ones", which is exactly master, is not a prefix of it. `solveFutoshikiByTechniques` now takes an allowed set.

## The 6×6 ceiling

§4.3 claimed the top rungs fire only at 7×7 and the seventh column was bought on that. Measured over eighty 6×6 boards with nothing pre-filled: **x-wing hardest 15 times, hidden pair 13, naked pair 13**. Seven cost a 45-minute solve against a 3-minute budget.

**One casualty: hidden triple.** Zero firings in 200 boards across 5×5 and 6×6. It stays as a solve technique the hints may reach; the reachability sweep moves to the nine demands, so a width no tier asks for is a finer reason rather than a broken promise.

## Requires found a real defect

At the T2 cap a 4×4 can settle on pre-filled numbers alone — **one starter board in six came out carrying no signs at all**, a Latin square wearing the family's name. `requires: ["signBound"]` makes that board impossible and costs nothing.

## Signs are drawn, not typed

One stroked chevron turned four ways, round caps and joins, sitting straight on the gutter with no disc behind it — the gap between two squares is already a dark line. A typeface's `<` is a glyph sized to sit in prose, and it was lost against a stone square at arm's length.

The mark takes a **smaller share of the square as the grid grows** (44% at 4 wide, 36% at 6): an equal share is not an equal reading, because at 4 wide the square has room for a bold chevron beside its digit and at 6 the same share crowds the digit it sits between. My first pass held the share constant and wore a chip whose percentage padding resolved against the span — two squares long horizontally, one vertically — so horizontal signs carried a chip twice as fat. Both found by playing it (a0f0956).

## Also on this branch

- **A sundial family design doc** (`docs/game-design/puzzles/sundial.md`), and a correction to the catalogue: §4.3 and §4.4 both claimed *(have)* and neither is built. Unrelated to the futoshiki work — happy to split it out if that's cleaner.
- **Two puzzle-shell fixes found in playtest** (d7e343f, 3b538e6): the page jumping when the completed banner lands, and the controls vanishing rather than dimming while a board finishes.

## Checks

CI green on every commit. Locally at the time of the futoshiki work: `vitest run` 165 files / 1879 tests passing, `check-types` and `eslint` clean.

## Open

Starter carries at least as many numbers as signs on 16 of 20 boards (~3.2 signs, 4 numbers). The T2 cap is the cause, not the prefill: at T2 a 4×4 needs ~2.9 numbers to settle and spares only ~3 signs *before* any gift, where T3 gives ~4.1 signs against ~1.7 numbers. Flagged for a decision — the alternative is T3 with prefill 3 (~3.9 signs, 3 numbers).