### PR TITLE
docs(testing): never assert a wall-clock duration

### DIFF
--- a/docs/instructions/testing.md
+++ b/docs/instructions/testing.md
@@ -59,6 +59,37 @@ A component that just renders its props needs no render test. A component that h
 
 ---
 
+## Never assert a wall-clock duration
+
+**Count whether the expensive work ran; do not time it.** A machine cannot answer "was this cheap" — a
+shared CI runner in jsdom least of all — so a millisecond bound is a lottery whose stakes are a red build,
+and it passes for the wrong reason on a fast machine.
+
+The invariant is almost always "did this work happen at all", which is exact:
+
+```ts
+// ✗ — a lottery. This exact bound failed CI at 83ms.
+const started = performance.now()
+act(() => cell.click())
+expect(performance.now() - started).toBeLessThan(80)
+
+// ✓ — mock the expensive function around the real one and count the calls
+vi.mock("./eclipseHint", async importOriginal => {
+  const actual = await importOriginal<typeof import("./eclipseHint")>()
+  return { ...actual, buildEclipseHint: vi.fn(actual.buildEclipseHint) }
+})
+// ...
+act(() => cell.click())
+expect(vi.mocked(buildEclipseHint)).not.toHaveBeenCalled()
+act(() => hintButton.click())
+expect(vi.mocked(buildEclipseHint)).toHaveBeenCalled()
+```
+
+Keep the measurement that made the code lazy — lightbeam's "185ms a tap eagerly against 19ms lazily" — as a
+**comment**. It is why the code has its shape; it is not an assertion.
+
+---
+
 ## File placement
 
 Spec files live **next to the source file**, in the same directory. No `__tests__/` directories.


### PR DESCRIPTION
One section in `docs/instructions/testing.md`.

The "a tap must not cost a solve" invariant lived in two puzzle families as a millisecond bound on a tap. In #206 one of them failed CI at **83ms against a threshold of 80**, and the other was carrying the same bound waiting its turn. Both were changed to mock the expensive function and count its calls — exact, and it tests the actual claim rather than the machine it ran on.

That reasoning only existed in those two files' comments, which is precisely where someone writing a third such test would not look. So it is now a rule with the wrong and right shape side by side.

Nothing else changes: there are no `performance.now` assertions left in `src` as of #206.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016TDausBqovq27A8D5njK8s