### PR TITLE
A site can dress its puzzles, and the room knows which skin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- The Lighthouse of Alexandria now serves light and sky puzzles on its main path: the beam puzzle, the new sun-and-moon grid, and the new star map.
+- The Lighthouse of Alexandria now serves light and sky puzzles on its main path — the beam puzzle, the new sun-and-moon grid and the new star map — and it runs at night: its grids are drawn as stars against a dark sky.
 - A second kind of trap: a clock face, and four times to pick from before the countdown runs out.
 - A new puzzle: join the stars with lines of light, as many at each star as its number says, never crossing another line, until every star hangs in one constellation. Drag from a star to draw a line, on a night sky of its own.
 - A new puzzle: fill a grid with suns and moons so no three sit in a row, every line holds as many of each, no two rows or columns read alike, and the signs between squares are obeyed. Hints name the reason, and an undo button takes back your last tap.

--- a/docs/game-design/puzzles/eclipse.md
+++ b/docs/game-design/puzzles/eclipse.md
@@ -292,7 +292,14 @@ Beyond the shared screen bar:
 
 The family emits logical state only — `mark(sun|moon) | sign(same|different) |
 given` — and the skin decides what any of it looks like. Sun and moon are the
-default pair; a night site swaps in star and dark sky and changes nothing else.
+default pair; a site authored `theme: "night"` swaps in star and dark sky and changes
+nothing else, which is the first thing built on the theme chain
+(`worldgen-dsl-redesign.md` §"Puzzle skin") and what the Lighthouse of Alexandria serves.
+
+**The second pair is drawn to the same rule as the first** (§8): the two marks differ in
+OUTLINE — a filled star against a ring of empty sky — so the board stays readable without
+colour. That rule is what makes another skin cheap; a pair that differed only in hue would
+not be a skin, it would be a bug in two colours.
 
 ## 10. Open questions
 

--- a/docs/game-design/worldgen-dsl-redesign.md
+++ b/docs/game-design/worldgen-dsl-redesign.md
@@ -167,11 +167,15 @@ puzzleFamily?: PuzzleFamily | Partial<Record<PuzzleFamily, number>> | { tag: Fam
 
 `{ tag: "time" }` expands to a uniform weight map over every family carrying that tag, _at build time, before sampling runs_ — it's sugar for the weight map, not a second sampling mechanism. If you need to weight within a tag (e.g. favor sundial over water-clock among "time" families), just write the weight map by hand; the tag form is for the common case of "any of these, no preference."
 
-### Puzzle skin — widen `theme`'s reach, not a new field
+### Puzzle skin — `theme`'s reach, widened — **BUILT**
 
 **Use case:** "a subset of this pyramid's puzzles render in a night theme."
 
-**Decision:** `theme` (`Theme = string`, currently `PyramidConstraint`-only) is promoted into the same chain-resolution pattern `difficulty`/`puzzleFamily` already use — authorable at pyramid, floor, or side-section scope, most-specific wins. A family's `Component` renderer looks up a skin registered for the resolved theme; if none is registered for that theme, it falls back to the family's default skin. No new field, no new authoring concept — `theme` was just missing the override depth every other Population field already has.
+**Decision:** `theme` (`Theme = string`) is authorable at pyramid, floor, or side-section scope, most-specific wins — the same chain resolution `difficulty` and `encounter` use. A family looks up a skin registered for the resolved name; a name it has no skin for silently draws its default. No new authoring concept — `theme` was just missing the override depth every other Population field already had.
+
+**How it reaches a room:** authored on a constraint → `FloorConfig.theme`/`SubSection.theme` (`buildSite`, `sideSections`) → serialized into `generatedWorld.ts` → stamped on each puzzle room by `siteAssembler` → `FamilyContext.theme` (`useEncounter`) → the family's own skin map. The live example is the Lighthouse of Alexandria (`journey("junior_4")`, `theme: "night"`), and eclipse's star-and-dark-sky pair is the first skin drawn from it. A family declares the names it knows in `FamilyMeta.themes`, which is also what the puzzle lab's theme picker offers.
+
+**Two rules worth keeping straight, because a role and a skin travel differently.** A **role** (`encounter`) is handed to side paths only by a caller that knows their rooms are plain puzzle rooms — a role can demand args (a tomb's `tomb-puzzle` reads `encounterArgs.runNr`), and handing one down blindly crashed world generation on the first tableau. A **skin** demands nothing, so every site hands it to every section, trapped ones included: a skin names a look, and a family with no such look draws its own.
 
 ### Per-family difficulty knobs (`puzzleTuning`)
 

--- a/docs/instructions/puzzle-screens.md
+++ b/docs/instructions/puzzle-screens.md
@@ -39,6 +39,18 @@ The same puzzle dresses up per site (`ctx.theme`).
   skin**; more skins are added when a site asks for one, not up front.
 - Unknown `ctx.theme` falls back to the default skin silently.
 
+**`ctx.theme` is the name a site authored, and it arrives from world-gen.** A pyramid, a floor or a
+side section authors `theme` (most-specific wins, `worldgen-dsl-redesign.md` §"Puzzle skin"), the
+world file carries it, and every puzzle room is stamped with the name its own path authored. The
+Lighthouse of Alexandria is the live example — `theme: "night"`, which eclipse draws as star and dark
+sky. A family lists the names it has skins for in `FamilyMeta.themes`; that list is also what the
+puzzle lab's theme picker offers, so a new skin is playable the moment it is declared.
+
+**Naming a skin can never break a room.** The name is opaque to core and to every other family, so a
+site may hand one to a room rendering a family that has never heard of it — that family draws its
+default and nothing is lost. Which is why a skin travels to places a *role* must not (a role can
+demand `encounterArgs`; a skin demands nothing).
+
 ## 3. Controls — all four, all from the shell
 
 | Control | Behavior                                                                                             |

--- a/src/app/SiteMap/useEncounter.ts
+++ b/src/app/SiteMap/useEncounter.ts
@@ -69,6 +69,9 @@ export const useEncounter = ({
       stock: cell?.type === "room" ? cell.stock : undefined,
       pathIndex: cell?.type === "room" ? cell.pathIndex : undefined,
       encounterArgs: cell?.type === "room" ? cell.encounterArgs : undefined,
+      // The skin this room was authored to wear (docs/instructions/puzzle-screens.md §2). Core carries the
+      // name and reads nothing into it; unset means every family draws its default.
+      theme: cell?.type === "room" ? cell.theme : undefined,
       requiredKeyId: cell?.type === "room" ? cell.requiredKeyId : undefined,
       gateVariant: cell?.type === "room" ? cell.gateVariant : undefined,
       keyColor: cell?.type === "room" ? cell.keyColor : undefined,

--- a/src/data/generatedWorld.ts
+++ b/src/data/generatedWorld.ts
@@ -3,7 +3,7 @@
 // World seed: 42195837
 import type { SiteConfig } from "../game/siteTypes"
 
-export const worldContentHash = 1346896288
+export const worldContentHash = 872776555
 
 export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
   starter_1: [
@@ -1574,6 +1574,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             endReward: { type: "hieroglyphFragment", hieroglyphId: "d2", pieceIndex: 2 },
             rewards: [undefined],
             encounter: "constellation",
+            theme: "night",
           },
           {
             pathPuzzles: 1,
@@ -1582,6 +1583,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             endReward: { type: "sellable", itemId: "sell_bronze_5" },
             rewards: [undefined],
             encounter: "constellation",
+            theme: "night",
           },
           {
             pathPuzzles: 1,
@@ -1590,6 +1592,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             endReward: { type: "money", amount: 2 },
             rewards: [undefined],
             encounter: "lightbeam",
+            theme: "night",
           },
           {
             pathPuzzles: 1,
@@ -1598,6 +1601,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             endReward: { type: "money", amount: 2 },
             rewards: [undefined],
             encounter: "eclipse",
+            theme: "night",
           },
           {
             pathPuzzles: 0,
@@ -1605,6 +1609,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "money", amount: 2 },
             encounter: "lightbeam",
+            theme: "night",
           },
           {
             pathPuzzles: 0,
@@ -1613,9 +1618,11 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             endReward: { type: "money", amount: 2 },
             hidden: true,
             encounter: "eclipse",
+            theme: "night",
           },
         ],
         encounter: "constellation",
+        theme: "night",
         mainEndReward: { type: "hieroglyphFragment", hieroglyphId: "p9", pieceIndex: 1 },
         rewards: [undefined, undefined, undefined],
       },
@@ -1635,6 +1642,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             endReward: { type: "hieroglyphFragment", hieroglyphId: "a2", pieceIndex: 1 },
             rewards: [undefined],
             encounter: "eclipse",
+            theme: "night",
           },
           {
             pathPuzzles: 1,
@@ -1643,6 +1651,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             endReward: { type: "hieroglyphFragment", hieroglyphId: "a2", pieceIndex: 2 },
             rewards: [undefined],
             encounter: "constellation",
+            theme: "night",
           },
           {
             pathPuzzles: 1,
@@ -1651,6 +1660,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             endReward: { type: "hieroglyphFragment", hieroglyphId: "d2", pieceIndex: 3 },
             rewards: [undefined],
             encounter: "constellation",
+            theme: "night",
           },
           {
             pathPuzzles: 0,
@@ -1658,6 +1668,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "money", amount: 2 },
             encounter: "eclipse",
+            theme: "night",
           },
           {
             pathPuzzles: 0,
@@ -1666,6 +1677,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             endReward: { type: "money", amount: 2 },
             hidden: true,
             encounter: "lightbeam",
+            theme: "night",
           },
           {
             pathPuzzles: 2,
@@ -1674,9 +1686,11 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             endReward: { type: "sellable", itemId: "sell_bronze_3" },
             hidden: true,
             encounter: "arithmetic-reflex",
+            theme: "night",
           },
         ],
         encounter: "lightbeam",
+        theme: "night",
         mainEndReward: { type: "hieroglyphFragment", hieroglyphId: "art2", pieceIndex: 2 },
         rewards: [undefined, undefined, undefined, undefined],
       },
@@ -1694,6 +1708,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "mapPiece", tombId: "junior_treasure_tomb" },
             encounter: "lightbeam",
+            theme: "night",
           },
           {
             pathPuzzles: 1,
@@ -1703,6 +1718,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             endReward: { type: "hieroglyphFragment", hieroglyphId: "p9", pieceIndex: 2 },
             rewards: [undefined],
             encounter: "constellation",
+            theme: "night",
           },
           {
             pathPuzzles: 1,
@@ -1711,6 +1727,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             endReward: { type: "sellable", itemId: "sell_stone_4" },
             rewards: [{ type: "money", amount: 2 }],
             encounter: "eclipse",
+            theme: "night",
           },
           {
             pathPuzzles: 1,
@@ -1719,6 +1736,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             endReward: { type: "hieroglyphFragment", hieroglyphId: "p9", pieceIndex: 3 },
             rewards: [undefined],
             encounter: "constellation",
+            theme: "night",
           },
           {
             pathPuzzles: 1,
@@ -1727,6 +1745,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             endReward: { type: "money", amount: 2 },
             rewards: [undefined],
             encounter: "lightbeam",
+            theme: "night",
           },
           {
             pathPuzzles: 1,
@@ -1735,6 +1754,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             endReward: { type: "money", amount: 2 },
             rewards: [undefined],
             encounter: "lightbeam",
+            theme: "night",
           },
           {
             pathPuzzles: 0,
@@ -1742,6 +1762,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "money", amount: 2 },
             encounter: "eclipse",
+            theme: "night",
           },
           {
             pathPuzzles: 0,
@@ -1750,9 +1771,11 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             endReward: { type: "money", amount: 2 },
             hidden: true,
             encounter: "lightbeam",
+            theme: "night",
           },
         ],
         encounter: "eclipse",
+        theme: "night",
         mainEndReward: { type: "hieroglyphFragment", hieroglyphId: "art12", pieceIndex: 3 },
         rewards: [undefined, undefined, undefined, undefined],
       },
@@ -1771,6 +1794,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "tomb-key", wardKeyId: "starter_a_4" },
             endReward: { type: "hieroglyphFragment", hieroglyphId: "p1", pieceIndex: 3 },
             encounter: "lightbeam",
+            theme: "night",
           },
           {
             pathPuzzles: 1,
@@ -1779,6 +1803,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             endReward: { type: "money", amount: 2 },
             rewards: [undefined],
             encounter: "lightbeam",
+            theme: "night",
           },
           {
             pathPuzzles: 1,
@@ -1787,6 +1812,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             endReward: { type: "money", amount: 2 },
             rewards: [undefined],
             encounter: "lightbeam",
+            theme: "night",
           },
           {
             pathPuzzles: 1,
@@ -1795,6 +1821,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             endReward: { type: "money", amount: 2 },
             rewards: [undefined],
             encounter: "constellation",
+            theme: "night",
           },
           {
             pathPuzzles: 0,
@@ -1802,6 +1829,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "money", amount: 2 },
             encounter: "constellation",
+            theme: "night",
           },
           {
             pathPuzzles: 0,
@@ -1810,6 +1838,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             endReward: { type: "money", amount: 2 },
             hidden: true,
             encounter: "eclipse",
+            theme: "night",
           },
           {
             pathPuzzles: 2,
@@ -1821,9 +1850,11 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
               { type: "consumable", consumable: "bandage" },
             ],
             encounter: "eclipse",
+            theme: "night",
           },
         ],
         encounter: "constellation",
+        theme: "night",
         mainEndReward: { type: "hieroglyphFragment", hieroglyphId: "p11", pieceIndex: 2 },
         rewards: [undefined, undefined, undefined, undefined, undefined],
       },
@@ -1835,6 +1866,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
         sideSections: [],
         entrance: { stairId: "junior_4:p3:wing0" },
         encounter: "constellation",
+        theme: "night",
         mainEndReward: { type: "hieroglyphFragment", hieroglyphId: "p4", pieceIndex: 0 },
         rewards: [
           { type: "money", amount: 1 },
@@ -1856,6 +1888,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "tomb-key", wardKeyId: "starter_a_4" },
             endReward: { type: "money", amount: 2 },
             encounter: "constellation",
+            theme: "night",
           },
           {
             pathPuzzles: 1,
@@ -1864,6 +1897,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             endReward: { type: "money", amount: 2 },
             rewards: [undefined],
             encounter: "constellation",
+            theme: "night",
           },
           {
             pathPuzzles: 1,
@@ -1872,6 +1906,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             endReward: { type: "money", amount: 2 },
             rewards: [undefined],
             encounter: "lightbeam",
+            theme: "night",
           },
           {
             pathPuzzles: 1,
@@ -1880,6 +1915,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             endReward: { type: "money", amount: 2 },
             rewards: [undefined],
             encounter: "constellation",
+            theme: "night",
           },
           {
             pathPuzzles: 0,
@@ -1887,6 +1923,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             end: "treasure",
             endReward: { type: "money", amount: 2 },
             encounter: "lightbeam",
+            theme: "night",
           },
           {
             pathPuzzles: 0,
@@ -1895,6 +1932,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             endReward: { type: "money", amount: 2 },
             hidden: true,
             encounter: "eclipse",
+            theme: "night",
           },
           {
             pathPuzzles: 1,
@@ -1903,9 +1941,11 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
             gate: { type: "tomb-key", wardKeyId: "junior_a_1" },
             rewards: [undefined],
             encounter: "lightbeam",
+            theme: "night",
           },
         ],
         encounter: "eclipse",
+        theme: "night",
         mainEndReward: { type: "money", amount: 2 },
         rewards: [undefined, undefined, undefined, undefined, undefined],
       },
@@ -1917,6 +1957,7 @@ export const generatedWorldConfigs: Record<string, SiteConfig[]> = {
         sideSections: [],
         entrance: { stairId: "junior_4:p4:wing0" },
         encounter: "lightbeam",
+        theme: "night",
         mainEndReward: { type: "money", amount: 2 },
         rewards: [undefined],
       },

--- a/src/game/siteAssembler.spec.ts
+++ b/src/game/siteAssembler.spec.ts
@@ -78,6 +78,34 @@ describe(assembleFloor, () => {
     expect(validateSite(result.grid)).toEqual({ valid: true })
   })
 
+  /**
+   * The skin follows the room, not the floor it happens to sit on.
+   *
+   * A skin is stamped on every puzzle room it was authored for, main path and side path alike, so the family
+   * rendering that room can read it without knowing anything about world-gen. Rooms of a site that authored
+   * no skin carry none, and every family then draws its default.
+   */
+  it("stamps each puzzle room with the skin its own path authored", () => {
+    const config: FloorConfig = {
+      ...basicConfig(),
+      pathPuzzles: 2,
+      theme: "night",
+      sideSections: [{ pathPuzzles: 1, difficulty: "starter", end: "treasure", theme: "day" }],
+    }
+    const result = assembleFloor("site-1", config, 42)
+    if (!result.success) throw new Error("assembly failed")
+    const rooms = result.grid.cells.flat().filter((c): c is RoomCell => c.type === "room" && isPuzzleRoom(c))
+    expect(rooms.filter(r => r.theme === "night")).toHaveLength(2)
+    expect(rooms.filter(r => r.theme === "day")).toHaveLength(1)
+  })
+
+  it("leaves rooms of an unthemed site carrying no skin at all", () => {
+    const result = assembleFloor("site-1", { ...basicConfig(), pathPuzzles: 2 }, 42)
+    if (!result.success) throw new Error("assembly failed")
+    const rooms = result.grid.cells.flat().filter((c): c is RoomCell => c.type === "room" && isPuzzleRoom(c))
+    expect(rooms.every(r => r.theme === undefined)).toBe(true)
+  })
+
   it("resolves a main-path puzzle room's own key requirement via the injected resolver, tagged with its path index and the floor's encounterArgs", () => {
     const config: FloorConfig = { ...basicConfig(), pathPuzzles: 2, encounter: "tableau", encounterArgs: { runNr: 7 } }
     const result = assembleFloor("starter_treasure_tomb:2", config, 42, undefined, {

--- a/src/game/siteAssembler.ts
+++ b/src/game/siteAssembler.ts
@@ -1052,6 +1052,7 @@ export const assembleFloor = (
           tags: family.tags,
           pathIndex: k,
           ...(config.encounterArgs !== undefined ? { encounterArgs: config.encounterArgs } : {}),
+          ...(config.theme !== undefined ? { theme: config.theme } : {}),
           ...(requiredKeyIds?.length ? { requiredKeyIds } : {}),
           ...(reward ? { reward } : {}),
         })
@@ -1134,6 +1135,7 @@ export const assembleFloor = (
           tags: family.tags,
           pathIndex: pi,
           ...(section.encounterArgs !== undefined ? { encounterArgs: section.encounterArgs } : {}),
+          ...(section.theme !== undefined ? { theme: section.theme } : {}),
           ...(requiredKeyIds?.length ? { requiredKeyIds } : {}),
           ...(reward ? { reward } : {}),
         })
@@ -1228,6 +1230,7 @@ export const assembleFloor = (
           tags: family.tags,
           pathIndex: pi,
           ...(subSection.encounterArgs !== undefined ? { encounterArgs: subSection.encounterArgs } : {}),
+          ...(subSection.theme !== undefined ? { theme: subSection.theme } : {}),
           ...(requiredKeyIds?.length ? { requiredKeyIds } : {}),
           ...(reward ? { reward } : {}),
         })

--- a/src/game/siteTypes.ts
+++ b/src/game/siteTypes.ts
@@ -66,6 +66,10 @@ export type RoomCell = {
   // resolved (which authored TableauLevel this is). Opaque to core; each family reads it via its
   // own zod schema. Mirrors FloorConfig/SideSection.encounterArgs.
   encounterArgs?: unknown
+  // Which skin this room's family should wear (docs/instructions/puzzle-screens.md §2), carried from the
+  // FloorConfig/SideSection that authored it. A NAME, not a look: core knows nothing about what it means,
+  // and a family with no skin registered under it draws its default one.
+  theme?: string
   // Registered family id (src/app/families/familyRegistry.ts) — open string, not a closed
   // union, since mods register their own families. Always set for roomType "encounter".
   family?: string
@@ -115,6 +119,8 @@ export type SubSection = {
    * `{runNr}`) — validated by that family's own ResolveKeyRequirements resolver, never
    * interpreted here. See ResolveKeyRequirements in siteAssembler.ts. */
   encounterArgs?: unknown
+  /** Skin name for this section's puzzle rooms — inherited from the site where the section authors none. */
+  theme?: string
 }
 export type SideSection = SubSection & {
   sideSections?: SubSection[]
@@ -148,6 +154,8 @@ export type FloorConfig = {
    * `{runNr}`) — validated by that family's own ResolveKeyRequirements resolver, never
    * interpreted here. See ResolveKeyRequirements in siteAssembler.ts. */
   encounterArgs?: unknown
+  /** Skin name for this floor's puzzle rooms. Unset inherits the site's; a floor may override it. */
+  theme?: string
 }
 
 // A site is one or more floors. Index 0 = surface.

--- a/src/mods/puzzle/app/eclipse/EclipseBoard.tsx
+++ b/src/mods/puzzle/app/eclipse/EclipseBoard.tsx
@@ -19,6 +19,8 @@ type Props = {
   highlighted?: ReadonlySet<number>
   /** The one square the current hint is ABOUT, drawn stronger than its evidence. */
   focus?: number
+  /** The skin this room was authored to wear; an unknown name draws the default pair. */
+  theme?: string
   onTapCell: (cell: number) => void
 }
 
@@ -56,6 +58,38 @@ const Moon: FC = () => (
     <path d="M 14 -34 A 36 36 0 1 0 14 34 A 30 30 0 1 1 14 -34 Z" className="fill-sky-200" />
   </svg>
 )
+
+/**
+ * The night pair, for a site authored `theme: "night"` (docs/game-design/puzzles/eclipse.md §9).
+ *
+ * The rule the default pair is drawn to holds here too, and it is the whole reason a second skin is cheap:
+ * two marks that differ in OUTLINE, so the board is readable without colour. A star against an empty sky
+ * reads the same way a sun against a crescent does.
+ */
+const Star: FC = () => (
+  <svg viewBox="-50 -50 100 100" className="size-full">
+    <path
+      d="M 0 -42 L 11 -13 L 42 -13 L 17 6 L 26 36 L 0 18 L -26 36 L -17 6 L -42 -13 L -11 -13 Z"
+      className="fill-amber-100"
+    />
+  </svg>
+)
+
+const DarkSky: FC = () => (
+  <svg viewBox="-50 -50 100 100" className="size-full">
+    {/* Sky with no star in it: a ring rather than a shape, so it reads as the absence the rules give it. */}
+    <circle r={30} strokeWidth={8} className="fill-indigo-950 stroke-indigo-300/70" />
+  </svg>
+)
+
+/**
+ * Which pair of glyphs a skin draws. The family emits `Mark`; a skin decides what a mark looks like
+ * (docs/instructions/puzzle-screens.md §2), and an unknown skin name silently falls back to the default.
+ */
+const SKINS: Record<string, Record<Mark, FC>> = {
+  default: { sun: Sun, moon: Moon },
+  night: { sun: Star, moon: DarkSky },
+}
 
 // A sign takes a smaller share of a square as the grid grows (34% at 4 wide, 26% at 6): an equal share is
 // not an equal reading, since the gap it sits in shrinks with the squares while a mark that keeps its share
@@ -107,9 +141,13 @@ const Sign: FC<{ puzzle: EclipsePuzzle; link: Link; broken: boolean }> = ({ puzz
 
 const linkKey = (link: Link) => `${link.a}-${link.b}`
 
-const mark = (value: Mark | undefined) => (value === "sun" ? <Sun /> : value === "moon" ? <Moon /> : null)
+const markGlyph = (value: Mark | undefined, theme: string | undefined) => {
+  if (!value) return null
+  const Glyph = (theme && SKINS[theme] ? SKINS[theme] : SKINS.default)[value]
+  return <Glyph />
+}
 
-export const EclipseBoard: FC<Props> = ({ puzzle, state, highlighted, focus, onTapCell }) => {
+export const EclipseBoard: FC<Props> = ({ puzzle, state, highlighted, focus, theme, onTapCell }) => {
   const { size } = puzzle
   // Held back a beat: a tap on the way to the other mark is not a mistake (see the hook).
   const conflicts = useDelayedConflicts(puzzle, state)
@@ -141,7 +179,7 @@ export const EclipseBoard: FC<Props> = ({ puzzle, state, highlighted, focus, onT
                 cell === focus && "ring-4 ring-amber-300"
               )}
             >
-              {mark(value)}
+              {markGlyph(value, theme)}
             </button>
           )
         })}

--- a/src/mods/puzzle/app/eclipse/EclipsePuzzle.spec.tsx
+++ b/src/mods/puzzle/app/eclipse/EclipsePuzzle.spec.tsx
@@ -50,6 +50,40 @@ describe("EclipsePuzzle", () => {
     expect(derive).toHaveBeenCalled()
   })
 
+  /**
+   * A skin decides pixels and nothing else, which is the property that makes a second one safe to add.
+   *
+   * The night pair draws the same board from the same state — so the test is that the GLYPHS changed and the
+   * squares did not, and that a skin name no family has silently falls back to the default rather than
+   * rendering an empty board.
+   */
+  describe("skins", () => {
+    const puzzle = generateEclipse(4, ECLIPSE_CONFIG.starter)
+    // The star's own outline. A skin is only ever pixels, so what a skin test can check is which glyph the
+    // board drew for the same logical mark.
+    const stars = (root: HTMLElement) => root.querySelectorAll('path[d^="M 0 -42"]').length
+    const board = (theme?: string) => {
+      const { container } = render(
+        <EclipsePuzzle puzzle={puzzle} difficulty="starter" theme={theme} onSolved={() => {}} onCancel={() => {}} />
+      )
+      act(() => cellsIn(container)[0].click()) // one tap = one mark = one glyph to look at
+      return container
+    }
+
+    it("draws the night pair for a night room, on the same board", () => {
+      const plain = board()
+      const night = board("night")
+      // Same board either way: a skin never changes what the puzzle is, only what it looks like.
+      expect(cellsIn(night).length).toBe(cellsIn(plain).length)
+      expect(stars(night)).toBe(1)
+      expect(stars(plain)).toBe(0)
+    })
+
+    it("falls back to the default pair for a skin it does not have", () => {
+      expect(stars(board("lava"))).toBe(0)
+    })
+  })
+
   it("reports the board solved once every square matches the answer", { timeout: 120_000 }, async () => {
     const puzzle = generateEclipse(4, ECLIPSE_CONFIG.starter)
     let solved = false

--- a/src/mods/puzzle/app/eclipse/EclipsePuzzle.tsx
+++ b/src/mods/puzzle/app/eclipse/EclipsePuzzle.tsx
@@ -19,11 +19,13 @@ import { EclipseRules } from "./EclipseRules"
 type Props = {
   puzzle: EclipsePuzzleWithAnswer
   difficulty?: Difficulty
+  /** The skin the site authored for this room; unknown or unset draws the default pair. */
+  theme?: string
   onSolved: () => void
   onCancel: () => void
 }
 
-export const EclipsePuzzle: FC<Props> = ({ puzzle, difficulty, onSolved, onCancel }) => {
+export const EclipsePuzzle: FC<Props> = ({ puzzle, difficulty, theme, onSolved, onCancel }) => {
   const { t } = useTranslation("common")
   const [state, setState] = useState(() => createEclipseState(puzzle))
 
@@ -60,6 +62,7 @@ export const EclipsePuzzle: FC<Props> = ({ puzzle, difficulty, onSolved, onCance
           <EclipseBoard
             puzzle={puzzle}
             state={state}
+            theme={theme}
             highlighted={hintVisible ? hint?.cells : undefined}
             focus={hintVisible ? hint?.focus : undefined}
             onTapCell={cell => {

--- a/src/mods/puzzle/app/eclipse/plugin.tsx
+++ b/src/mods/puzzle/app/eclipse/plugin.tsx
@@ -7,7 +7,13 @@ import { ECLIPSE_META } from "@/mods/puzzle/game/eclipse/meta"
 import { EclipsePuzzle } from "./EclipsePuzzle"
 
 const EclipseComponent: FamilyPlugin<EclipsePuzzleWithAnswer>["Component"] = ({ puzzle, ctx, onSolved, onCancel }) => (
-  <EclipsePuzzle puzzle={puzzle} difficulty={ctx.difficulty} onSolved={onSolved} onCancel={onCancel} />
+  <EclipsePuzzle
+    puzzle={puzzle}
+    difficulty={ctx.difficulty}
+    theme={ctx.theme}
+    onSolved={onSolved}
+    onCancel={onCancel}
+  />
 )
 
 if (isModEnabled("puzzle"))

--- a/src/mods/puzzle/game/eclipse/meta.ts
+++ b/src/mods/puzzle/game/eclipse/meta.ts
@@ -8,6 +8,9 @@ export const ECLIPSE_META: FamilyMeta = {
   // it — no journey ever names a family.
   tags: ["puzzle", "light", "sky"],
   minTier: "starter",
+  // The skins this family has (docs/instructions/puzzle-screens.md §2): the default sun-and-moon pair, and
+  // star-and-dark-sky for a site authored `theme: "night"`. Listed so the puzzle lab can offer both.
+  themes: ["default", "night"],
   icon: "🌘",
   color: "sky",
   rewardPriority: 60, // fills only once treasure's guaranteed slots are spoken for

--- a/src/worldGen/buildSite.spec.ts
+++ b/src/worldGen/buildSite.spec.ts
@@ -178,4 +178,43 @@ describe("a site theme handed down", () => {
     const plain = buildSite({ ...ctx, constraint: { ...theme, sideSections: [section] } })
     expect(plain.floors[0].sideSections[0].encounter).toBeUndefined()
   })
+
+  /**
+   * A skin travels further than a role, and on purpose.
+   *
+   * A role can demand args (a tomb's `tomb-puzzle` reads `encounterArgs.runNr`), which is why only a caller
+   * that knows its rooms are plain puzzle rooms hands one down. A skin demands nothing — it is a name a
+   * family may recognise — so any site may hand it to any section, including a trapped one.
+   */
+  describe("a site's skin", () => {
+    const night = { theme: "night" }
+
+    it("reaches a floor that authors none, and yields to one that does", () => {
+      expect(buildSite({ ...ctx, constraint: night }).floors[0].theme).toBe("night")
+      const overridden = buildSite({ ...ctx, constraint: { ...night, floors: [{ theme: "day" }] } })
+      expect(overridden.floors[0].theme).toBe("day")
+    })
+
+    it("reaches a side path that authors none, even one that authors its own role", () => {
+      const trapped = { pathPuzzles: 1, difficulty: "starter" as const, end: "treasure" as const, encounter: "trap" }
+      const { floors } = buildSite({
+        ...ctx,
+        constraint: { ...night, sideSections: [trapped] },
+        sideTheme: "night",
+      })
+      expect(floors[0].sideSections[0].encounter).toBe("trap")
+      expect(floors[0].sideSections[0].theme).toBe("night")
+    })
+
+    it("leaves a section that authors its own skin alone", () => {
+      const section = {
+        pathPuzzles: 1,
+        difficulty: "starter" as const,
+        end: "treasure" as const,
+        theme: "day",
+      }
+      const { floors } = buildSite({ ...ctx, constraint: { ...night, sideSections: [section] }, sideTheme: "night" })
+      expect(floors[0].sideSections[0].theme).toBe("day")
+    })
+  })
 })

--- a/src/worldGen/buildSite.ts
+++ b/src/worldGen/buildSite.ts
@@ -95,6 +95,7 @@ export type BuildFloorOptions = {
   packing?: number
   sealed?: boolean
   encounterArgs?: unknown
+  theme?: string
 }
 
 // The common FloorConfig skeleton shared by every pyramid and tomb floor — defaults to a
@@ -115,6 +116,7 @@ export const buildFloor = (opts: BuildFloorOptions): FloorConfig => ({
   ...(opts.packing !== undefined ? { packing: opts.packing } : {}),
   ...(opts.sealed ? { sealed: true } : {}),
   ...(opts.encounterArgs !== undefined ? { encounterArgs: opts.encounterArgs } : {}),
+  ...(opts.theme !== undefined ? { theme: opts.theme } : {}),
 })
 
 // Sequentially links floors[fi] → floors[fi+1] via a stairhead: floor fi's exitOrStaircase
@@ -164,6 +166,8 @@ export type BuildSiteContext<TExtra extends string = never> = {
   sideEncounter?: string | string[]
   /** Encounter args for side sections that carry none — set by the pyramid builder only. */
   sideEncounterArgs?: unknown
+  /** Skin for side sections that author none. Safe for any site to hand down (see sideSections.ts). */
+  sideTheme?: string
 }
 
 // Builds one site's floors (the 3 floor-shape branches: authored floors[], auto multi-floor
@@ -175,7 +179,15 @@ export type BuildSiteContext<TExtra extends string = never> = {
 // (pyramid-interior-design.md §8), just always taking this one branch.
 export const buildSite = <TExtra extends string = never>(ctx: BuildSiteContext<TExtra>): { floors: FloorConfig[] } => {
   const { journeyId, tier, pyramidIndex: i, levelCount, pathPuzzles: pp, constraint, difficulty, resolveReward } = ctx
-  const { hasMapPieceBranch, hasWardGate, nextTier, resolveMainEndReward, sideEncounter, sideEncounterArgs } = ctx
+  const {
+    hasMapPieceBranch,
+    hasWardGate,
+    nextTier,
+    resolveMainEndReward,
+    sideEncounter,
+    sideEncounterArgs,
+    sideTheme,
+  } = ctx
 
   const mainEndReward: TreasureReward = constraint.mainEndReward
     ? resolveMainEndReward(constraint.mainEndReward)
@@ -212,6 +224,7 @@ export const buildSite = <TExtra extends string = never>(ctx: BuildSiteContext<T
         pyramidIndex: i,
         sideEncounter,
         sideEncounterArgs,
+        sideTheme,
       })
       const floorStraightness = fc.corridorStraightness ?? resolveCorridorStraightness(constraint, journeyId, i)
       const floorPacking = fc.packing ?? resolvePacking(constraint, journeyId, i)
@@ -243,6 +256,8 @@ export const buildSite = <TExtra extends string = never>(ctx: BuildSiteContext<T
           packing: floorPacking,
           sealed: floorSealed,
           encounterArgs: fc.encounterArgs ?? constraint.encounterArgs,
+          // A floor may wear its own skin inside a plainer pyramid; unset, it wears the site’s.
+          theme: fc.theme ?? constraint.theme,
         })
       )
     }
@@ -279,6 +294,7 @@ export const buildSite = <TExtra extends string = never>(ctx: BuildSiteContext<T
             mainEndReward: { type: "fragmentSlot" },
             encounter: constraint.encounter,
             encounterArgs: constraint.encounterArgs,
+            theme: constraint.theme,
           })
         )
         continue
@@ -297,6 +313,7 @@ export const buildSite = <TExtra extends string = never>(ctx: BuildSiteContext<T
         pyramidIndex: i,
         sideEncounter,
         sideEncounterArgs,
+        sideTheme,
         declaredSidePaths: constraint.sidePaths,
         declaredHiddenPaths: constraint.hiddenPaths,
       })
@@ -308,6 +325,7 @@ export const buildSite = <TExtra extends string = never>(ctx: BuildSiteContext<T
           mainEndReward,
           encounter: constraint.encounter,
           encounterArgs: constraint.encounterArgs,
+          theme: constraint.theme,
           corridorStraightness: resolveCorridorStraightness(constraint, journeyId, i),
           packing: resolvePacking(constraint, journeyId, i),
           sealed: resolveSealed(constraint),
@@ -363,6 +381,7 @@ export const buildSite = <TExtra extends string = never>(ctx: BuildSiteContext<T
             // The stairs up to a wing are rooms of this pyramid, so they wear its theme too. Built here
             // rather than by buildSideSections, which is why the role is applied by hand.
             ...(sideEncounter !== undefined ? { encounter: sideEncounter } : {}),
+            ...(sideTheme !== undefined ? { theme: sideTheme } : {}),
           },
         ]
         floorConfigs.push(
@@ -375,6 +394,7 @@ export const buildSite = <TExtra extends string = never>(ctx: BuildSiteContext<T
             // A wing is a floor of this pyramid, so it wears the pyramid's theme too.
             encounter: constraint.encounter,
             encounterArgs: constraint.encounterArgs,
+            theme: constraint.theme,
           })
         )
       })
@@ -395,6 +415,9 @@ export const buildSite = <TExtra extends string = never>(ctx: BuildSiteContext<T
           gate: { type: "tomb-key" as const, wardKeyId: TOMB_PERK_IDS[tombId][idx] },
           // A trapped ward path stays a trap; an untrapped one wears the pyramid's theme.
           ...(trapWardPath ? { encounter: "trap" } : sideEncounter !== undefined ? { encounter: sideEncounter } : {}),
+          // A trapped path keeps its own role but still wears the site’s skin: a skin decides nothing
+          // about which family renders the room.
+          ...(sideTheme !== undefined ? { theme: sideTheme } : {}),
         })),
       ]
     }
@@ -417,6 +440,7 @@ export const buildSite = <TExtra extends string = never>(ctx: BuildSiteContext<T
     pyramidIndex: i,
     sideEncounter,
     sideEncounterArgs,
+    sideTheme,
     declaredSidePaths: constraint.sidePaths,
     declaredHiddenPaths: constraint.hiddenPaths,
   })
@@ -427,6 +451,7 @@ export const buildSite = <TExtra extends string = never>(ctx: BuildSiteContext<T
     mainEndReward,
     encounter: constraint.encounter,
     encounterArgs: constraint.encounterArgs,
+    theme: constraint.theme,
     corridorStraightness: resolveCorridorStraightness(constraint, journeyId, i),
     packing: resolvePacking(constraint, journeyId, i),
     sealed: resolveSealed(constraint),

--- a/src/worldGen/configBuilder.ts
+++ b/src/worldGen/configBuilder.ts
@@ -137,6 +137,9 @@ const buildSiteConfigs = (
         // reads as an accident. Tombs never opt in: their role wants encounterArgs a side path lacks.
         sideEncounter: constraint.encounter,
         sideEncounterArgs: constraint.encounterArgs,
+        // The skin reaches side paths under a weaker rule than the role does: a skin is a name a family
+        // may recognise, so handing one to a section rendering a different family costs nothing.
+        sideTheme: constraint.theme,
       })
       pyramidConfigs.push(floors)
     }
@@ -222,6 +225,7 @@ const buildTombConfigs = (resolveTombTreasure?: TombTreasureResolver): Record<st
         packing: authored?.packing ?? constraint.packing,
         sealed: authored?.sealed ?? constraint.sealed,
         encounterArgs: authored?.encounterArgs ?? { runNr: i + 1 },
+        theme: authored?.theme ?? constraint.theme,
       }
     })
 
@@ -240,6 +244,9 @@ const buildTombConfigs = (resolveTombTreasure?: TombTreasureResolver): Record<st
       nextTier: null,
       resolveReward: resolveTombReward,
       resolveMainEndReward: () => ({ type: "fragmentSlot" }),
+      // A tomb hands its skin down where its role must not be (a role can demand args a side path has no
+      // reason to carry; a skin demands nothing).
+      sideTheme: constraint.theme,
     })
     configs[tomb.id] = [floorConfigs]
   }

--- a/src/worldGen/dsl.ts
+++ b/src/worldGen/dsl.ts
@@ -104,6 +104,10 @@ export type SideSectionConstraint<TExtra extends string = never> = {
    * (siteAssembler.ts's ResolveKeyRequirements). Lets a tableau corridor be authored
    * anywhere (main path or a ward-gated side path) instead of being tied to floor position. */
   encounterArgs?: unknown
+  /** Which skin this section's puzzle rooms wear — a name a family may recognise (`FamilyMeta.themes`),
+   * not a look this layer knows anything about. Unset inherits the site's, and a family with no skin
+   * for the resolved name silently draws its default. */
+  theme?: Theme
   endReward?: RewardSpec | TExtra
   sideSections?: SideSectionConstraint<TExtra>[]
   /** Pool of decoration kinds this section's fork/endpoint rooms may draw from. */
@@ -138,6 +142,9 @@ export type FloorConstraint<TExtra extends string = never> = {
   /** Opaque payload for whichever family renders the main path's rooms — see
    * SideSectionConstraint.encounterArgs above for the full rationale. */
   encounterArgs?: unknown
+  /** Which skin this floor's puzzle rooms wear. Unset inherits the site's — so one floor can be a night
+   * floor inside a plain pyramid, most-specific winning the same way `difficulty` and `encounter` do. */
+  theme?: Theme
   /** Pool of decoration kinds the main path's fork/endpoint rooms may draw from. */
   decorations?: DecorationKind[]
   /**

--- a/src/worldGen/serializer.spec.ts
+++ b/src/worldGen/serializer.spec.ts
@@ -15,11 +15,13 @@ describe("generateFile — serializeSideSection field coverage", () => {
       end: "treasure",
       exitOrStaircase: "exit",
       sealed: true,
+      theme: "night",
       sideSections: [
         {
           pathPuzzles: 1,
           difficulty: "junior",
           end: "treasure",
+          theme: "day",
           endReward: { type: "mosaicPiece" },
           rewards: [{ type: "mosaicPiece" }, { type: "consumable", consumable: "oil" }],
           sealed: true,
@@ -51,5 +53,12 @@ describe("generateFile — serializeSideSection field coverage", () => {
 
   it("keeps encounter on a serialized side section", () => {
     expect(output).toContain('encounter: "tableau"')
+  })
+
+  // The same hand-enumeration hazard, and a skin is the field most likely to fall down it: a dropped skin
+  // does not fail — every family just quietly draws its default, everywhere, forever.
+  it("keeps the skin on both a serialized floor and a serialized side section", () => {
+    expect(output).toContain('theme: "night"')
+    expect(output).toContain('theme: "day"')
   })
 })

--- a/src/worldGen/serializer.ts
+++ b/src/worldGen/serializer.ts
@@ -57,6 +57,7 @@ const serializeSideSection = (s: SideSection): string => {
   if (s.sealed) parts.push(`sealed: true`)
   if (s.encounter) parts.push(`encounter: ${serializeEncounter(s.encounter)}`)
   if (s.encounterArgs !== undefined) parts.push(`encounterArgs: ${JSON.stringify(s.encounterArgs)}`)
+  if (s.theme) parts.push(`theme: ${JSON.stringify(s.theme)}`)
   if (s.encountersByIndex && Object.keys(s.encountersByIndex).length)
     parts.push(`encountersByIndex: ${serializeEncountersByIndex(s.encountersByIndex)}`)
   if (s.sideSections?.length)
@@ -84,6 +85,7 @@ const serializeFloor = (c: FloorConfig): string => {
   }
   if (c.encounter) lines.push(`    encounter: ${serializeEncounter(c.encounter)},`)
   if (c.encounterArgs !== undefined) lines.push(`    encounterArgs: ${JSON.stringify(c.encounterArgs)},`)
+  if (c.theme) lines.push(`    theme: ${JSON.stringify(c.theme)},`)
   if (c.encountersByIndex && Object.keys(c.encountersByIndex).length)
     lines.push(`    encountersByIndex: ${serializeEncountersByIndex(c.encountersByIndex)},`)
   if (c.corridorStraightness !== undefined) lines.push(`    corridorStraightness: ${c.corridorStraightness},`)

--- a/src/worldGen/sideSections.ts
+++ b/src/worldGen/sideSections.ts
@@ -72,6 +72,7 @@ const buildDslSection = <TExtra extends string>(
     ...(cs.encounter !== undefined ? { encounter: cs.encounter } : {}),
     ...(Object.keys(encountersByIndex).length ? { encountersByIndex } : {}),
     ...(cs.encounterArgs !== undefined ? { encounterArgs: cs.encounterArgs } : {}),
+    ...(cs.theme !== undefined ? { theme: cs.theme } : {}),
   }
 }
 
@@ -100,6 +101,14 @@ export type BuildSideSectionsOptions<TExtra extends string = never> = {
   sideEncounter?: string | string[]
   /** Args for sections that carry none, handed down by the same caller under the same rule. */
   sideEncounterArgs?: unknown
+  /**
+   * The skin for sections that author none — the site’s, handed down.
+   *
+   * Safe for every caller, unlike the role above: a skin is a name a family may recognise and nothing
+   * more, so handing one to a section that renders a different family costs nothing. A family with no
+   * skin under that name draws its default.
+   */
+  sideTheme?: string
   /** Pyramid-only: prepends a hardcoded mapPiece branch pointing at this tier's tomb. */
   hasMapPieceBranch?: boolean
   /** Pyramid-only: prepends a hardcoded tier-unlock ward-key gate. */
@@ -122,7 +131,8 @@ export type BuildSideSectionsOptions<TExtra extends string = never> = {
 const wearSiteRole = (
   sections: SideSection[],
   sideEncounter: string | string[] | undefined,
-  sideEncounterArgs: unknown
+  sideEncounterArgs: unknown,
+  sideTheme: string | undefined
 ): SideSection[] =>
   sections.map(section => ({
     ...section,
@@ -130,6 +140,7 @@ const wearSiteRole = (
     ...(sideEncounterArgs !== undefined && section.encounterArgs === undefined
       ? { encounterArgs: sideEncounterArgs }
       : {}),
+    ...(sideTheme !== undefined && section.theme === undefined ? { theme: sideTheme } : {}),
   }))
 
 export const buildSideSections = <TExtra extends string = never>(
@@ -150,6 +161,7 @@ export const buildSideSections = <TExtra extends string = never>(
     declaredHiddenPaths,
     sideEncounter,
     sideEncounterArgs,
+    sideTheme,
   } = opts
 
   const sections: SideSection[] = []
@@ -223,5 +235,5 @@ export const buildSideSections = <TExtra extends string = never>(
     }
   })
 
-  return wearSiteRole(sections, sideEncounter, sideEncounterArgs)
+  return wearSiteRole(sections, sideEncounter, sideEncounterArgs, sideTheme)
 }

--- a/src/worldGen/spec/junior.ts
+++ b/src/worldGen/spec/junior.ts
@@ -61,13 +61,18 @@ export const juniorRules: Rule[] = [
     .settings({ pathPuzzles: 2, end: "junk", encounter: "trap", chance: 0.4 }),
 
   // **The Lighthouse of Alexandria runs on sky.** Every main-path room in its five pyramids draws from the
-  // `sky` pool rather than the general `puzzle` one — today the beam family and the sun-and-moon grid, and
-  // a star-map family would join it by carrying the tag rather than by an edit here.
+  // `sky` pool rather than the general `puzzle` one — the beam family, the sun-and-moon grid and the star
+  // map, each of which joined that pool by carrying the tag rather than by an edit here.
   //
   // `sky` rather than `["light", "sky"]` on purpose. A list is a union — the allocator draws from any tag in
   // it — so the list would only widen the pool back to what `sky` already covers. Narrowing is a narrower
-  // tag's job: `sky` is the wide cluster and `light` the narrow one inside it.
-  journey("junior_4").pyramid("1-5", { encounter: "sky" }),
+  // tag’s job: `sky` is the wide cluster and `light` the narrow one inside it.
+  //
+  // **And it runs at night**, which is a separate axis: `encounter` decides which family renders a room,
+  // `theme` decides which skin that family wears. A family with no skin registered under "night" draws its
+  // default one, so naming a skin here can never leave a room unrenderable. It reaches this pyramid’s floors
+  // and its side paths, including the trapped ones — half a themed pyramid reads as an accident.
+  journey("junior_4").pyramid("1-5", { encounter: "sky", theme: "night" }),
 
   // Ward wings on back-half pyramids, difficulty cycling expert→master→wizard.
   journey("junior_1").pyramid(3, { wardWings: [WING.expert()] }),

--- a/src/worldGen/types.ts
+++ b/src/worldGen/types.ts
@@ -31,6 +31,9 @@ export type SubSection = {
   /** Opaque payload for whichever family renders this section's rooms (e.g. a tableau's
    * `{runNr}`) — mirrors game/siteTypes.ts's SubSection.encounterArgs. */
   encounterArgs?: unknown
+  /** Skin name for this section's puzzle rooms, inherited from the site where the section is silent.
+   * Mirrors game/siteTypes.ts's SubSection.theme. */
+  theme?: string
 }
 export type SideSection = SubSection & {
   sideSections?: SubSection[]
@@ -57,6 +60,8 @@ export type FloorConfig = {
   /** Opaque payload for whichever family renders the main path's rooms (e.g. a tableau's
    * `{runNr}`) — mirrors game/siteTypes.ts's FloorConfig.encounterArgs. */
   encounterArgs?: unknown
+  /** Skin name for this floor's puzzle rooms — mirrors game/siteTypes.ts's FloorConfig.theme. */
+  theme?: string
 }
 
 export type SiteConfig = FloorConfig[]


### PR DESCRIPTION
`theme` was declared on `PyramidConstraint` and deliberately left unwired — the shape was known and wanted, and there was no consumer yet to build it against. There is one now, so this is the deferred half: no site authored a skin, no layer carried one, and `ctx.theme` was populated only by the puzzle lab, so no family could dress for a place. Built along the path the design already specified (`worldgen-dsl-redesign.md` §"Puzzle skin") rather than a path invented here.

```
authored constraint → FloorConfig/SubSection.theme → generatedWorld.ts
  → stamped on each puzzle room (siteAssembler) → FamilyContext.theme → the family's skin map
```

Authorable at pyramid, floor or side-section scope, most-specific winning — the same chain resolution `difficulty` and `encounter` already use.

## A skin travels further than a role, and that asymmetry is the point

A **role** can demand args: a tomb's `tomb-puzzle` reads `encounterArgs.runNr`, and handing that to a side path once crashed world generation on the first tableau. That is why only a caller who knows its rooms are plain puzzle rooms hands a role down.

A **skin** demands nothing. It is a name a family may recognise, and a family with no skin under that name draws its default — so every site hands its skin to every section, trapped paths included, and **naming a skin can never leave a room unrenderable**. The two rules sit next to each other in `sideSections.ts` for exactly that reason.

## Proven rather than asserted

The wire has a first site and a first consumer in the same PR, because plumbing with no consumer is plumbing nobody has run water through:

- **The Lighthouse of Alexandria** authors `theme: "night"` (41 configs in the regenerated world, all `junior_4`).
- **Eclipse draws it** as star and dark sky — the pair its own family doc has described since it shipped. The second pair is built to the same rule as the first (§8: differ in *outline*, not hue), which is what makes another skin cheap; a pair differing only in colour would not be a skin, it would be a bug in two colours.
- `FamilyMeta.themes` lists the names a family knows, and the lab's theme picker reads that list — so a new skin is playable the moment it is declared. Verified in the lab at expert: the picker offers `default` / `night`, and night draws stars.

## The serializer gets its own test

`serializer.ts` hand-enumerates fields, and this is the field most likely to fall down that hole: a dropped skin **does not fail**. Every family quietly draws its default, everywhere, forever, and nothing in the pipeline notices. The existing spec exists because `rewards` and nested `sideSections` were silently dropped once already; the skin now sits in it too.

## Checked

`yarn test` (1961 pass), `yarn check-types`, `yarn lint` (0 errors), `yarn generate-world` + `yarn validate-world`. New specs: theme inheritance and override in `buildSite`, a trapped path still wearing the site skin, per-room stamping in `siteAssembler` (and rooms of an unthemed site carrying none), serializer round-trip, and eclipse drawing the night pair — plus falling back to the default for a skin name it does not have.

**Note on overlap with #208:** both branches edit the same Lighthouse bullet in `CHANGELOG.md`. One line, trivial to resolve whichever lands first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016TDausBqovq27A8D5njK8s
