### PR TITLE
A star that has its lines shines

### DIFF
--- a/docs/game-design/puzzles/constellation.md
+++ b/docs/game-design/puzzles/constellation.md
@@ -286,8 +286,14 @@ Beyond the shared screen bar:
   because the nearest another star can sit is two cells away.
 - **A number stays readable with lines touching it.** The digit sits inside the star,
   and the lines stop at its edge rather than under it.
-- **A star that has its lines says so** — its number dims once satisfied, and goes red
-  once exceeded. That is how a Bridges player tracks a board, and it is wordless.
+- **A star that has its lines lights up**, and goes red once it holds too many. That is the
+  whole of this family's feedback and none of it is a word.
+
+  **It lights up rather than greying out, which is the opposite of what Bridges does**, and the
+  inversion is deliberate: giving a star its light is what the player just achieved, so it is what
+  should look like an achievement. The board scans the same either way — the work left is "the stars
+  still showing a plain number" instead of "the stars still lit" — and the finished sky is a
+  constellation that blazes, which is a reward the mechanic hands over for free.
 - **One line and two differ in shape, not only in weight** — two parallel strokes with
   sky visible between them, so a phone in daylight reads the difference.
 - **An illegal line is refused, not drawn red.** A crossing and an over-long reach are
@@ -314,9 +320,9 @@ always carries `sky`. A check that is always true is not a switch. What the skin
   on every render is a backdrop the player keeps looking at.
 - **Lines of light rather than drawn strokes**: each carries a glow, and stops at the edge of the star
   it meets rather than running under its number (§8).
-- **A star burns rather than sitting in a socket** — a soft outer glow, and the disc only exists to keep
-  the number readable. A satisfied star loses the glow and goes quiet, which is the state a Bridges
-  player tracks the board by.
+- **A star burns once it has its lines** — a bright disc with a soft outer glow, where an unlit one is
+  quiet blue-grey and readable and nothing more. The disc exists to keep the number legible with lines of
+  light running into it; the glow is the star itself.
 
 Per-**site** variation — this family starrier on a lighthouse journey than elsewhere — is a different
 job, and not a small one: `ctx.theme` is unset everywhere real gameplay runs (only the puzzle lab sets

--- a/src/mods/puzzle/app/constellation/ConstellationBoard.tsx
+++ b/src/mods/puzzle/app/constellation/ConstellationBoard.tsx
@@ -208,16 +208,19 @@ export const ConstellationBoard: FC<Props> = ({ puzzle, state, highlighted, focu
           >
             <span
               className={clsx(
-                "flex aspect-square w-[77%] items-center justify-center rounded-full border text-[min(4vw,1.1rem)] font-bold transition-colors",
-                // A star burns rather than sits in a socket: the glow is the star, the disc is only what
-                // makes its number readable with lines of light running into it (§8).
+                "flex aspect-square w-[77%] items-center justify-center rounded-full border text-[min(4vw,1.1rem)] font-bold transition-all duration-300",
+                // **A star that has its lines lights up.** Bridges greys a finished island out, and that is
+                // the reading this board deliberately inverts: giving a star its light is the thing the
+                // player just achieved, so it is the thing that should look like an achievement. It scans
+                // the same either way — what is left to do is now "the stars still showing a plain number"
+                // rather than "the stars still lit".
                 held > star.count
                   ? "border-red-400/80 bg-radial from-red-500/35 to-red-950/70 text-red-300 shadow-[0_0_10px_2px_rgb(248_113_113_/_0.35)]"
                   : held === star.count
-                    ? // Satisfied: the star goes quiet and stops drawing the eye, which is how a Bridges
-                      // player tracks a board.
-                      "border-slate-400/50 bg-radial from-slate-700/40 to-slate-950/70 text-slate-300"
-                    : "border-amber-100/70 bg-radial from-amber-100/25 to-indigo-950/70 text-amber-50 shadow-[0_0_12px_2px_rgb(254_243_199_/_0.28)]",
+                    ? "border-amber-100 bg-radial from-amber-100/70 to-amber-200/20 text-amber-950 shadow-[0_0_18px_5px_rgb(254_243_199_/_0.45)]"
+                    : // Unlit: readable and unremarkable. The number has to stay crisp — it is the clue —
+                      // but nothing here draws the eye until the star earns it.
+                      "border-slate-300/40 bg-radial from-slate-800/60 to-indigo-950/80 text-amber-50",
                 litStars?.has(index) && "ring-2 ring-sky-300/80"
               )}
             >


### PR DESCRIPTION
Playtest feedback: a star that reaches its number should light up.

The board did the opposite — it greyed a satisfied star out, copying what Bridges apps do. That is the wrong reading for this family. Giving a star its light is the thing the player just achieved, so it is the thing that should look like an achievement.

Satisfied stars now burn: a bright disc with a soft glow. An unlit one is quiet blue-grey — readable, because the number is the clue, and unremarkable, because it has not earned anything yet. Overfilled stays red.

**It scans the same either way**, which is what makes the inversion free: the work left reads as "the stars still showing a plain number" instead of "the stars still lit". And a finished sky is now a constellation that blazes — a payoff the mechanic hands over without any solve-time animation to build.

Family doc §8/§9 updated to describe the polarity and why it is the opposite of the genre's habit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016TDausBqovq27A8D5njK8s