### PR TITLE
Lint warnings: delete the dead className props, silence the rule that cannot read variables

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -52,6 +52,13 @@ export default tseslint.config(
           cssConfigPath: join(process.cwd(), "src", "index.css"),
         },
       },
+      rules: {
+        // The rule cannot see through a variable: interpolate one into a class string and it reports
+        // the VARIABLE NAME as an unknown class. Every hit it produced here was that — a className
+        // passthrough, or a local holding class strings (transitionDuration, buttonCls, tone) — so
+        // its real catch, a typo in a literal class, was buried under 23 false positives.
+        "tailwindcss/no-custom-classname": "off",
+      },
     },
     eslintPluginPrettierRecommended,
   ],

--- a/src/ui/atoms/CategoryGrid.tsx
+++ b/src/ui/atoms/CategoryGrid.tsx
@@ -11,12 +11,6 @@ const gapClasses: Record<Density, string> = {
   compact: "gap-1",
 }
 
-export const CategoryGrid: FC<PropsWithChildren<{ density?: Density; className?: string }>> = ({
-  density = "comfortable",
-  className,
-  children,
-}) => (
-  <div className={clsx("grid grid-cols-[repeat(auto-fill,minmax(3rem,1fr))]", gapClasses[density], className)}>
-    {children}
-  </div>
+export const CategoryGrid: FC<PropsWithChildren<{ density?: Density }>> = ({ density = "comfortable", children }) => (
+  <div className={clsx("grid grid-cols-[repeat(auto-fill,minmax(3rem,1fr))]", gapClasses[density])}>{children}</div>
 )

--- a/src/ui/atoms/JourneyPathView.tsx
+++ b/src/ui/atoms/JourneyPathView.tsx
@@ -202,7 +202,6 @@ export const JourneyPathView: FC<Props> = ({
                           }
                         : undefined
                     }
-                    // eslint-disable-next-line tailwindcss/no-custom-classname -- plain CSS hover class defined above
                     className={onNodeClick ? "jpv-node" : "pointer-events-none fill-transparent"}
                   />
                   <circle

--- a/src/ui/atoms/KeyIcon.tsx
+++ b/src/ui/atoms/KeyIcon.tsx
@@ -1,5 +1,4 @@
 import type { FC } from "react"
-import clsx from "clsx"
 import type { KeyColor } from "@/game/siteTypes"
 import { keyColorHex } from "@/ui/tokens/keyColors"
 
@@ -11,12 +10,11 @@ type KeyIconProps = {
   outlined?: boolean
   /** Accessible name; the shape is decorative without one. */
   title?: string
-  className?: string
 }
 
 // A single floor key, drawn in its own hue. Deliberately a drawn key rather than the 🗝 emoji: an
 // emoji can't be recoloured, and the colour IS the information here.
-export const KeyIcon: FC<KeyIconProps> = ({ color, size = 20, outlined = false, title, className }) => {
+export const KeyIcon: FC<KeyIconProps> = ({ color, size = 20, outlined = false, title }) => {
   const hex = keyColorHex[color].reachable
   return (
     <svg
@@ -26,7 +24,7 @@ export const KeyIcon: FC<KeyIconProps> = ({ color, size = 20, outlined = false, 
       role={title ? "img" : "presentation"}
       aria-label={title}
       aria-hidden={title ? undefined : true}
-      className={clsx("shrink-0", className)}
+      className="shrink-0"
       // Dark halo so a light key stays readable on a light background. drop-shadow follows the drawn
       // shape (unlike box-shadow), so the bow's hole stays open.
       style={{ filter: "drop-shadow(0 0 1px rgba(0,0,0,0.85))" }}

--- a/src/ui/atoms/RevealPlaceholder.tsx
+++ b/src/ui/atoms/RevealPlaceholder.tsx
@@ -6,7 +6,6 @@ type RevealPlaceholderProps = {
   progress: { found: number; required: number }
   /** The host's own silhouette — its ghost takes this shape instead of a dashed ring. */
   clipPath?: string
-  className?: string
 }
 
 // The outline of what a partly-collected thing will become, sitting behind the part of it that
@@ -17,7 +16,7 @@ type RevealPlaceholderProps = {
 // It owns the "complete → no placeholder at all" rule so no call site has to check, and it is
 // absolutely positioned with no wrapper of its own: it renders INSIDE the host, which must be
 // `relative`.
-export const RevealPlaceholder: FC<RevealPlaceholderProps> = ({ progress, clipPath, className }) => {
+export const RevealPlaceholder: FC<RevealPlaceholderProps> = ({ progress, clipPath }) => {
   const { found, required } = progress
   if (required <= 0 || found >= required) return null
 
@@ -29,8 +28,7 @@ export const RevealPlaceholder: FC<RevealPlaceholderProps> = ({ progress, clipPa
       aria-hidden
       className={clsx(
         "pointer-events-none absolute inset-0",
-        clipPath ? "bg-current opacity-10" : "rounded-full border border-dashed border-current opacity-30",
-        className
+        clipPath ? "bg-current opacity-10" : "rounded-full border border-dashed border-current opacity-30"
       )}
       style={{ clipPath }}
     />

--- a/src/ui/atoms/StainedGlassMosaic.tsx
+++ b/src/ui/atoms/StainedGlassMosaic.tsx
@@ -1,5 +1,4 @@
 import type { FC } from "react"
-import clsx from "clsx"
 import { MOSAIC_PIECES, type MosaicPieceDef } from "./mosaicPieces.generated"
 import { MOSAIC_POINTS } from "./mosaicGeometry.generated"
 import stainedGlassUrl from "../../assets/stained-glass.png"
@@ -25,12 +24,11 @@ export const StainedGlassMosaic: FC<{
   revealedPieces?: ReadonlySet<string>
   newPieces?: ReadonlySet<string>
   onPieceClick?: (piece: MosaicPieceDef) => void
-  className?: string
-}> = ({ revealedPieces = new Set(), newPieces, onPieceClick, className }) => {
+}> = ({ revealedPieces = new Set(), newPieces, onPieceClick }) => {
   const litRegisters = REGISTERS.filter(r => r.ids.every(id => revealedPieces.has(id)))
 
   return (
-    <svg viewBox={`0 0 ${VB_W} ${VB_H}`} xmlns="http://www.w3.org/2000/svg" className={clsx("w-full", className)}>
+    <svg viewBox={`0 0 ${VB_W} ${VB_H}`} xmlns="http://www.w3.org/2000/svg" className="w-full">
       <defs>
         {litRegisters.length > 0 && (
           <>

--- a/src/ui/molecules/MapPieceIcon.tsx
+++ b/src/ui/molecules/MapPieceIcon.tsx
@@ -7,7 +7,6 @@ type MapPieceIconProps = {
   /** Pieces of this tomb's map held vs. needed. Omit (or complete) to show the whole scroll. */
   progress?: { found: number; required: number }
   size?: "md" | "lg"
-  className?: string
 }
 
 // A fixed square box, so the sweep's geometry stays put instead of tracking whatever line-height the
@@ -21,8 +20,8 @@ const sizeClasses = {
 // there, inside a dashed ring standing for the finished map. Same partial-collection language as a
 // part-collected hieroglyph tile (RevealPlaceholder + revealMaskStyle), so the two collectibles read
 // alike. The reward popup pairs it with the progress line in words.
-export const MapPieceIcon: FC<MapPieceIconProps> = ({ progress, size = "lg", className }) => (
-  <span className={clsx("relative inline-flex items-center justify-center leading-none", sizeClasses[size], className)}>
+export const MapPieceIcon: FC<MapPieceIconProps> = ({ progress, size = "lg" }) => (
+  <span className={clsx("relative inline-flex items-center justify-center leading-none", sizeClasses[size])}>
     {progress && <RevealPlaceholder progress={progress} />}
     <span className="relative" style={progress && revealMaskStyle(progress)}>
       📜

--- a/src/ui/molecules/NumberChest.tsx
+++ b/src/ui/molecules/NumberChest.tsx
@@ -1,5 +1,4 @@
 import type { FC } from "react"
-import clsx from "clsx"
 import { Chest, type ChestState, type ChestVariant } from "@/ui/atoms/Chest"
 import { NumberLock } from "@/ui/atoms/NumberLock"
 
@@ -12,7 +11,6 @@ type NumberLockProps = {
   disabled?: boolean
   placeholder?: string
   maxLength?: number
-  className?: string
 }
 
 export const NumberChest: FC<NumberLockProps> = ({
@@ -24,7 +22,6 @@ export const NumberChest: FC<NumberLockProps> = ({
   disabled = false,
   placeholder = "Enter code",
   maxLength = 4,
-  className,
 }) => {
   const isDisabled = disabled || state === "open"
 
@@ -35,7 +32,7 @@ export const NumberChest: FC<NumberLockProps> = ({
   }
 
   return (
-    <div className={clsx("flex flex-col items-center gap-6", className)}>
+    <div className="flex flex-col items-center gap-6">
       <Chest
         onClick={handleLockClick}
         state={state}


### PR DESCRIPTION
Two commits, chasing the 29 `tailwindcss/no-custom-classname` warnings back to their causes. They turned out to have two different ones.

## The real finding: className nobody passes

Six components accepted extra classes and **no caller anywhere handed them any** — not app code, not a story, not a spec:

`CategoryGrid` · `KeyIcon` · `RevealPlaceholder` · `StainedGlassMosaic` · `MapPieceIcon` · `NumberChest`

Each of them already composes its own classes from its own props. The escape hatch can come back in one line when something actually needs to escape. Two of the six also drop a `clsx` import that had nothing left to combine.

Two candidates failed the check and kept their prop:

- `TombBackdrop` — unwired in the app so far, but its story is a real consumer and sizes it with `className="w-full h-screen"`.
- `LightbeamBoard`'s internal `Glyph` — passed one at line 235.

## The other 23 were never about className

`tailwindcss/no-custom-classname` cannot see through a variable. Interpolate one into a class string and it reports the *variable's name* as a class that does not exist. The remaining hits, after the dead props were gone:

```
10  className, and a real caller passes one
      Block, GearIcon, Header, Page, StoneFrame, TombDoor,
      HieroglyphTile ×2, TombBackdrop, LightbeamBoard/Glyph
13  not a className at all — locals holding class strings
      transitionDuration ×5 (DesertBackdrop), buttonCls ×4 (FutoshikiPad),
      textColor, tone, color, gradient
```

Zero were a misspelled class, which is the only thing the rule is for. Its one real catch was buried under 23 false positives, so its output was unreadable and unread. Off — which also retires the single inline `eslint-disable` that existed to work around it.

## Result

```
50 warnings → 21, all react-hooks, all real

 8  react-hooks/set-state-in-effect        (PR #187 takes 2 of these)
 5  react-hooks/refs
 5  react-hooks/preserve-manual-memoization
 3  react-hooks/use-memo
```

## Testing

`yarn check-types`, `yarn lint` (0 errors), `yarn vitest run` — 195 files, 2263 tests passing. No user-facing change, so no CHANGELOG entry.

Merges cleanly alongside #187, which touches none of these files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016TDausBqovq27A8D5njK8s