### PR TITLE
A place asks for everything standing in the way of it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- A tomb kept saying it had something left when it did not. A chest behind a tableau you cannot read yet was counted as if only its own door stood in the way, so the map lit up on hieroglyphs that were never enough — and walking the whole tomb again found nothing. A place now asks for everything standing between you and it.
+
 ## 0.38.0 - 2026-08-23
 
 ### Added

--- a/src/app/SiteMap/floorExploration.spec.ts
+++ b/src/app/SiteMap/floorExploration.spec.ts
@@ -4,6 +4,7 @@ import { resolveEncounter, getFamilyPlugin } from "@/app/families/familyRegistry
 import { generatedWorldConfigs } from "@/data/generatedWorld"
 import { floorAssemblySeed, persistentInteriorSeed } from "@/game/siteSeed"
 import { computeFloorExploration } from "./floorExploration"
+import type { FloorGrid, GridCell, RoomCell } from "@/game/siteTypes"
 // Populate the family registry (families, their meta.rewardPriority + resolveKeyRequirements) —
 // exactly what SiteMapScreen/useAssembledFloor rely on. Without this every family resolves to
 // nothing and the test would be meaningless.
@@ -48,6 +49,51 @@ describe("computeFloorExploration", () => {
     expect(hieroglyphBundles.length).toBeGreaterThan(0)
     // A tableau needs several hieroglyphs at once — a bundle, not a single key.
     expect(hieroglyphBundles.some(ks => ks.length > 1)).toBe(true)
+  })
+
+  // A tester walked a tomb floor to its end, opened every door that opens, and the marker still said
+  // there was something to do. There was — a tableau needing hieroglyphs found in a pyramid, and the
+  // chest behind it — and neither was anything they could act on from inside the tomb. The floor did
+  // not claim to be `open`; it advertised a key bundle that named the chest's own section and not the
+  // tableau standing in front of it, so it lit on keys that were never enough.
+  const playedOut = (grid: FloorGrid): FloorGrid => ({
+    ...grid,
+    cells: grid.cells.map(row =>
+      row.map(cell => {
+        if (cell.type === "empty") return cell
+        const asksForKeys = cell.type === "room" && ((cell as RoomCell).requiredKeyIds?.length ?? 0) > 0
+        return asksForKeys ? cell : ({ ...cell, state: "completed" } as GridCell)
+      })
+    ),
+  })
+
+  it("a tomb floor played out to its end stops claiming to be open", () => {
+    const grid = playedOut(assemble("junior_treasure_tomb", 0, 0))
+    const result = computeFloorExploration(grid)
+
+    // Nothing here is available for the asking any more.
+    expect(result.open).toBe(false)
+    // What is left is named, so the travel screen lights it the moment those hieroglyphs are held.
+    expect(result.keySets.length).toBeGreaterThan(0)
+    expect(result.keySets.every(ks => ks.every(k => k.startsWith("hieroglyph:")))).toBe(true)
+  })
+
+  it("a chest behind an unsolved tableau inherits the tableau's hieroglyphs", () => {
+    // This is the guard for the tester's report — it fails without the inheritance, where the bundle
+    // named only the chest's own section.
+    const grid = playedOut(assemble("junior_treasure_tomb", 0, 0))
+    const blockers = grid.cells
+      .flat()
+      .filter((c): c is RoomCell => c.type === "room" && (c.requiredKeyIds?.length ?? 0) > 0)
+    const blockerKeys = new Set(blockers.flatMap(b => b.requiredKeyIds ?? []))
+    expect(blockerKeys.size).toBeGreaterThan(0)
+
+    // Every bundle draws only on keys some blocker on this floor asks for — nothing invented.
+    for (const ks of computeFloorExploration(grid).keySets)
+      for (const key of ks) expect(blockerKeys.has(key)).toBe(true)
+    // And at least one bundle is bigger than any single tableau's own set: that is the inheritance.
+    const widest = Math.max(...blockers.map(b => (b.requiredKeyIds ?? []).length))
+    expect(computeFloorExploration(grid).keySets.some(ks => ks.length > widest)).toBe(true)
   })
 
   it("shop and gate/trap nodes never produce content on their own (fill-order 0)", () => {

--- a/src/app/SiteMap/floorExploration.ts
+++ b/src/app/SiteMap/floorExploration.ts
@@ -1,4 +1,4 @@
-import type { FloorGrid } from "@/game/siteTypes"
+import type { Direction, FloorGrid, GridCell } from "@/game/siteTypes"
 import { getFamilyPlugin } from "@/app/families/familyRegistry"
 
 // The per-floor "still stuff to find here" summary that drives the Travel marker. Computed from an
@@ -12,12 +12,59 @@ import { getFamilyPlugin } from "@/app/families/familyRegistry"
 // player can't tell from outside) and only while unvisited (state !== "completed"). Hidden corridors
 // are excluded — the 👁 marker owns them.
 //
-// Each content node's keys = the tomb-key ward key(s) gating its section + its own requiredKeyIds.
-// A node with no keys is `open` (always lights). One with keys becomes a keySet the travel screen
+// **Each content node's keys also include everything standing in the way of it.** A chest behind an
+// unsolved tableau is no more available than the tableau is, and a bundle that names only the chest's
+// own section lights the moment the player holds those keys — even though a tableau further up the
+// corridor still wants hieroglyphs they have not found. That is a tester walking a tomb out to its
+// end, every door that opens open, with the marker still promising something: 39 of the 40 tomb
+// floors that carry a blocked node advertised a bundle smaller than the way in really costs.
+//
+// So requirements are inherited along the route from the entrance, and a node is `open` only when
+// SOME route to it asks for nothing.
+//
+// Each content node's keys = the tomb-key ward key(s) gating its section + its own requiredKeyIds +
+// whatever the route in still asks for. A node with no keys is `open` (always lights). One with keys
+// becomes a keySet the travel screen
 // re-checks against the live held-keys set (ward keys + completed hieroglyphs + whatever future mods
 // provide); ALL keys in a bundle must be held. Floor-key gates aren't external keys (found in-floor),
 // so their content stays `open`.
 export type FloorExploration = { open: boolean; keySets: string[][] }
+
+const DIR_MOVES: Record<Direction, [number, number]> = { n: [-1, 0], s: [1, 0], e: [0, 1], w: [0, -1] }
+
+// What an unsolved node still asks of the player before they can pass it: a tableau's hieroglyphs, a
+// ward door's key. A puzzle or a trap asks for nothing — the player can just do it — and a completed
+// room is a doorway like any other.
+const blockingKeys = (cell: GridCell): readonly string[] => {
+  if (cell.type !== "room" || cell.state === "completed") return []
+  const own = cell.requiredKeyIds ?? []
+  const gate = cell.gateVariant === "tomb-key" && cell.requiredKeyId ? [cell.requiredKeyId] : []
+  return [...own, ...gate]
+}
+
+// The cheapest set of keys each cell can be stood in with, walking out from the entrance. "Cheapest"
+// is by subset rather than by count: two routes can ask for different things and neither be the
+// lesser, so a cell is re-expanded whenever a route arrives that is not already covered.
+const routeRequirements = (grid: FloorGrid): Map<string, ReadonlySet<string>> => {
+  const best = new Map<string, ReadonlySet<string>>()
+  const work: Array<[number, number, ReadonlySet<string>]> = [[grid.entrancePos[0], grid.entrancePos[1], new Set()]]
+  while (work.length > 0) {
+    const [r, c, req] = work.pop()!
+    const cell = grid.cells[r]?.[c]
+    if (!cell || cell.type === "empty" || cell.hidden) continue
+    const k = `${r},${c}`
+    const known = best.get(k)
+    // Already reachable asking for no more than this: nothing to learn from this route.
+    if (known && [...known].every(key => req.has(key))) continue
+    best.set(k, req)
+    const onward = new Set([...req, ...blockingKeys(cell)])
+    for (const dir of cell.dirs) {
+      const [dr, dc] = DIR_MOVES[dir]
+      work.push([r + dr, c + dc, onward])
+    }
+  }
+  return best
+}
 
 export const computeFloorExploration = (grid: FloorGrid): FloorExploration => {
   const sectionGateKeys = new Map<string, Set<string>>()
@@ -28,11 +75,13 @@ export const computeFloorExploration = (grid: FloorGrid): FloorExploration => {
         ;(sectionGateKeys.get(h) ?? sectionGateKeys.set(h, new Set()).get(h)!).add(cell.requiredKeyId)
       }
 
+  const routeKeys = routeRequirements(grid)
+
   let open = false
   const keySets: string[][] = []
   const seen = new Set<string>()
-  const addContent = (sectionHash: string, ownKeys: readonly string[] = []) => {
-    const keys = new Set([...(sectionGateKeys.get(sectionHash) ?? []), ...ownKeys])
+  const addContent = (sectionHash: string, route: ReadonlySet<string>, ownKeys: readonly string[] = []) => {
+    const keys = new Set([...(sectionGateKeys.get(sectionHash) ?? []), ...ownKeys, ...route])
     if (keys.size === 0) {
       open = true
       return
@@ -44,20 +93,24 @@ export const computeFloorExploration = (grid: FloorGrid): FloorExploration => {
     }
   }
 
-  for (const row of grid.cells) {
-    for (const cell of row) {
-      if (cell.type === "empty" || cell.hidden) continue
+  grid.cells.forEach((row, r) =>
+    row.forEach((cell, c) => {
+      if (cell.type === "empty" || cell.hidden) return
+      // Not reachable from the entrance at all on this grid — behind a hidden corridor nobody has
+      // found. Those belong to the 👁 marker, not to this one.
+      const route = routeKeys.get(`${r},${c}`)
+      if (!route) return
       const h = cell.sectionHash ?? ""
       if (cell.type === "corridor") {
-        if (cell.state === "fogged") addContent(h)
-        continue
+        if (cell.state === "fogged") addContent(h, route)
+        return
       }
-      if (cell.state === "completed") continue
+      if (cell.state === "completed") return
       const priority = cell.family ? (getFamilyPlugin(cell.family)?.meta.rewardPriority ?? 0) : 0
       const ownKeys = cell.requiredKeyIds ?? []
-      if (priority > 0 || ownKeys.length > 0) addContent(h, ownKeys)
-    }
-  }
+      if (priority > 0 || ownKeys.length > 0) addContent(h, route, ownKeys)
+    })
+  )
 
   return { open, keySets }
 }


### PR DESCRIPTION
Tester report, previous release:

> Ik was net in een tombe op 3de niveau daar was een puzzel die ik niet af kon maken, omdat ik een deel van hyroglief mis. Hij blijft wel aangeven dat ik nog iets kan doen daar op de kaart. Maar alle vloeren zijn verkend en alle deuren die open kunnen zijn open.

They were right that something was left — a tableau wanting hieroglyphs found in a pyramid, and the chest behind it — and right that neither was anything they could act on. The marker was wrong to send them.

## What actually lit it

Not `open`. On a played-out floor that was already `false`. It was the **key bundle**: `computeFloorExploration` gave each content node its own section's gate keys plus its own `requiredKeyIds`, and nothing about what stood in front of it. So a chest in an ungated section advertised an empty-or-small bundle, and the travel screen lights a bundle the moment every key in it is held.

Measured over the world, played out to a stop:

```
tomb floors with a hieroglyph-blocked node: 40
  played out, open: 0            ← never the problem
  floors advertising a bundle smaller than the route really costs: 39
```

One of them, concretely:

```
starter_treasure_tomb L1f1
  lit on        ["hieroglyph:art1","hieroglyph:d1"]
  really needs  [["hieroglyph:a8","hieroglyph:p10"],
                 ["hieroglyph:a8","hieroglyph:art1","hieroglyph:d1","hieroglyph:p10"]]
```

Hold `art1` and `d1` and the tomb lights up. Travel there, walk the floor, and the first tableau still wants `a8` and `p10`. Nothing to do.

## The fix

Requirements are inherited along the route. Walking out from the entrance, each cell keeps the cheapest set of keys it can be stood in with — cheapest **by subset**, not by count, since two routes can ask for different things and neither be the lesser, so a cell is re-expanded whenever a route arrives that is not already covered. A content node's bundle is then its section's gate keys, its own `requiredKeyIds`, and whatever the way in still wants. `open` means some route asks for nothing.

What blocks: an unsolved room with `requiredKeyIds` (a tableau) or an unopened tomb-key ward door. What does not: a puzzle or a trap — the player can simply do those — or any completed room.

One incidental change, same rule by a different road: cells the entrance cannot reach at all are now skipped rather than counted. Those sit behind hidden corridors nobody has found, which the 👁 marker owns.

## Testing

Two new tests in `floorExploration.spec.ts`. The inheritance one is the guard and fails without the fix (`expected false to be true`); the played-out one pins that a finished floor stops advertising anything. `yarn check-types`, `yarn lint` (0 errors), `yarn vitest run` — 197 files, 2269 tests passing.

Branched off `main`, so it is independent of #217 and can go in first.

Worth checking against the tester's save if it is around: that tomb should go dark until they hold the hieroglyphs the whole way in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016TDausBqovq27A8D5njK8s