### PR TITLE
The one-star grid wears the flood plain too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The one-star grid can wear the flood plain too, the same farmland face its two-star twin wears. Both now draw from the same places.
+
 - Re-authoring what a room holds no longer costs you the floor it is on. A pyramid keeps its explored corridors, its found passages and its opened chests when the puzzles inside it are rewritten — traps included. A floor forgets what you did there only when its corridors really change.
 - Building the world now stops on any chest that would hold nothing, rather than working around it. Whether such a chest gets loot or gets removed is an authoring call, so nothing ships until it is made.
 - Changing how long or how winding a pyramid's corridors are now resets the floors it changed, rather than restoring your explored corridors onto a layout that had been re-drawn underneath them.

--- a/docs/game-design/puzzles/star-battle.md
+++ b/docs/game-design/puzzles/star-battle.md
@@ -442,15 +442,22 @@ Beyond the shared screen bar:
 The family emits logical state only — `cell(star | dark | empty) | region(id) | quota(n)` —
 and the skin decides what any of it looks like.
 
-**Two skins, and which family a room is decides whether the second is reachable.** Stars in
-a night sky is the `sky` pool's plainest possible face and the name is the theme; farmsteads
-on a flood plain is the same board drawn for `agriculture` or `water` (§11.3).
+**Two skins, and both families wear both.** Stars in a night sky is the `sky` pool's plainest
+possible face and the name is the theme; farmsteads on a flood plain is the same board drawn
+for `agriculture` or `water` (§11.3). Star battle and twin stars carry the same four tags and
+list the same two themes, because a skin dresses a board and this is the same board.
 
-**Star battle itself has one skin, and that is a fact about ONE star rather than about the
-mechanic.** A lone star reads as the one and only — the single thing a place is allowed —
-which is why counting stars per district is not a waterworks and why this family carries
-`sky` and nothing else. A PAIR is what a place can hold two of, so the second face belongs
-to twin stars and this family cannot wear it.
+**The pair is the strongest fiction the flood plain has, not the only one.** Two households to
+a holding is what the place was written for, and it is twin stars' outright. At one star the
+same holding takes one farmstead — `starBattle.goal.fields_one` says exactly that — and what
+carries the place either way is the no-touching rule: two farmsteads that close would draw on
+the same well. That rule does not change with the count.
+
+**Neither family reaches the flood plain in play yet, and the reason is authoring rather than
+code.** No journey asks for `water` or `agriculture` (`src/worldGen/spec/*.ts` authors
+`sky`, `trade`, `trap`, `shop` and plain `puzzle`), so the pool is empty of rooms rather than
+of families. One line on a journey — the shape `junior_4` already uses for `sky` — is what
+turns the face on.
 
 ## 10. Open questions
 
@@ -558,11 +565,11 @@ a group's legal placements, which the family does not have (§11.5).
 
 ### 11.3 The pair is what a skin can name
 
-This is the family that answers §9's open reading. **A lone star only ever reads as the one
-and only** — which is why star battle wears `sky` and nothing else, and why the watchman
-reading never had anywhere to go. A PAIR reads as a great many things a place can hold two
-of: two watchmen to a district, two torches to a chamber, two royals to a country, two
-households to a field.
+This is the family the flood plain was written for. **A pair reads as a great many things a
+place can hold two of**: two watchmen to a district, two torches to a chamber, two royals to
+a country, two households to a field. A lone star reads as the one and only, which is a
+narrower fiction but not an unusable one — one farmstead to a holding is a sentence that
+works, and it is the sentence star battle shows on the same skin (§9).
 
 A theme fits this mechanic when it can name three things: something straight that crosses the
 whole world (the rows and columns), something bounded and ragged (the regions), and a reason

--- a/src/mods/puzzle/app/starBattle/skins.ts
+++ b/src/mods/puzzle/app/starBattle/skins.ts
@@ -85,18 +85,20 @@ const SKINS: Record<string, StarBattleSkin> = {
   },
   /**
    * **Farmsteads on the flood plain** (PUZZLE_FAMILIES.md §11.1, Water & Agriculture, and the family doc
-   * §11.3). The rules read straight across and the reason for each one is the place: a holding takes two
-   * households, a row of plots takes two, and two farmsteads may not sit within reach of each other because
-   * that close they would be drawing on the same well.
+   * §11.3). The rules read straight across and the reason for each one is the place: a holding takes its
+   * quota of households, a row of plots takes the same, and two farmsteads may not sit within reach of each
+   * other because that close they would be drawing on the same well.
    *
    * **Daylight, which is the deliberate opposite of the sky the same board wears by default** — you work a
    * field under the sun. Everything follows from the ground being LIGHT: the walls are the water in the
    * channels between holdings, the sheaf is dark against the soil rather than glowing on it, and the hint
    * rings are drawn in ink instead of light.
    *
-   * This is the skin that makes the mechanic's second reading real rather than theoretical: **a pair is what
-   * a place can hold two of.** A lone star only ever reads as the one and only, which is why star battle
-   * wears `sky` and nothing else and why this skin belongs to twin stars.
+   * Worn by both families on this board. Two households to a holding is the fiction the place was written
+   * for, and it is twin stars' outright; at one star the same holding takes one farmstead, which the copy
+   * already says in the singular (`starBattle.goal.fields_one`). What makes the place read is the
+   * no-touching rule — two farmsteads that close would share a well — and that rule is the same at either
+   * count.
    */
   fields: {
     name: "fields",
@@ -126,9 +128,9 @@ const SKINS: Record<string, StarBattleSkin> = {
  * The same resolution constellation uses, for the same reason: core hands over both and decides nothing,
  * because any precedence rule core picked would be wrong for some family.
  *
- * **No ambience overlay exists here yet.** The default skin already IS night, and no site authors an
- * agricultural room, so a `night` theme over farmland is a combination no world can currently produce. When
- * one does, it wants a `night` partial on `fields` rather than a fallback to the sky.
+ * **No ambience overlay exists here yet.** The default skin already IS night, so a `night` theme over
+ * farmland is the one combination that would want one — a `night` partial on `fields` rather than a fallback
+ * to the sky. Nothing authors it yet.
  */
 const ROLE_SKINS: Record<string, string> = {
   sky: "default",

--- a/src/mods/puzzle/game/starBattle/meta.ts
+++ b/src/mods/puzzle/game/starBattle/meta.ts
@@ -5,16 +5,15 @@ import { STAR_BATTLE_CONFIG } from "./starBattleConfig"
 export const STAR_BATTLE_META: FamilyMeta = {
   id: "star-battle",
   ownerMod: "puzzle",
-  // `sky` and nothing else. The catalogue is explicit that this mechanic does not read as several places
-  // (PUZZLE_FAMILIES.md §4.24): counting stars per district is not a haul road or a waterworks, so unlike
-  // constellation it carries one tag and wears one face. NOT `light` either — that is the narrower pool for
-  // the families about light itself, and this one is about where things sit.
-  tags: ["puzzle", "sky"],
+  // The same pools twin stars draws from, and the same two faces, because a skin dresses a board and this
+  // is the same board (design doc §9). NOT `light` — that is the narrower pool for the families about light
+  // itself, and this one is about where things sit.
+  tags: ["puzzle", "sky", "water", "agriculture"],
   // Configured for every tier (docs/game-design/puzzles/star-battle.md §5).
   minTier: "starter",
-  // One skin, and the design doc §9 says why: the name is the theme. A site authored `theme: "night"` gets
-  // the same board, which is the eclipse arrangement — no roles, one ambience — rather than
-  // constellation's.
+  // A sky and a farm, the same two twin stars lists, so the lab can show both. A site never names a skin, it
+  // names a role; `theme: "night"` is an ambience the default skin already is.
+  themes: ["default", "fields"],
   icon: "⭐",
   color: "indigo",
   seedable: seedable({

--- a/src/mods/puzzle/game/starBattle/twinStars.ts
+++ b/src/mods/puzzle/game/starBattle/twinStars.ts
@@ -15,20 +15,18 @@ import type { StarBattleOptions } from "./generateStarBattle"
  * What the second star buys is the reason this exists. At one star a group is answered the moment its star
  * is found; at two, a group stays a capacity argument until its last star lands — `groupTight` fires ten
  * times a board here against eight at one star, and it fires on squares rather than on a single square. It
- * also gives the mechanic a PAIR to name, which is what a skin can hang a fiction on (§11.3): two watchmen
- * to a district, two torches to a chamber. A lone star only ever reads as the one and only, which is why
- * star battle wears `sky` and nothing else.
+ * also gives the mechanic a PAIR to name, which is the strongest fiction a skin on this board can hang on
+ * (§11.3): two watchmen to a district, two torches to a chamber, two households to a field. Strongest, not
+ * only — one farmstead to a holding reads perfectly well, which is why both families wear both faces.
  */
 export const TWIN_STARS_META: FamilyMeta = {
   id: "twin-stars",
   ownerMod: "puzzle",
-  // The same `sky` cluster star battle carries — this is about where things sit, not about light — and
-  // **the Water & Agriculture pool as well**, which star battle cannot join. Those two roles held exactly
-  // one family (constellation's irrigation skin), so a journey authoring them got the same puzzle five
-  // times; this is the second member, and unlike a second skin on an existing family it brings different
-  // reasoning rather than a different dress. The face it wears there is `fields` (app/starBattle/skins.ts).
+  // The same pools star battle carries. What this family adds to Water & Agriculture is not a face — it
+  // wears the same `fields` (app/starBattle/skins.ts) — but different reasoning: a holding that takes two
+  // households stays a capacity argument until its second one lands.
   tags: ["puzzle", "sky", "water", "agriculture"],
-  // A farm and a sky. Listed so the lab can show both — a site never names a skin, it names a role.
+  // A farm and a sky, the same two star battle lists. A site never names a skin, it names a role.
   themes: ["default", "fields"],
   // 8×8 is the SMALLEST grid this rule has boards on — 7×7 and 6×6 admit no legal star set at all (two to
   // a row and two to a column that never touch does not fit). The debut is a junior one anyway, because the


### PR DESCRIPTION
Star battle and twin stars are the same board with a different quota, so they now carry the same four tags and list the same two themes.

Most of the parity was already there: `skinFor` is shared between the two families, and the copy was already written in both numbers — `starBattle.goal.fields_one` reads *"Every row, every column and every holding has exactly one farmstead."* The only thing keeping the farm face off the one-star board was the meta.

```diff
 export const STAR_BATTLE_META: FamilyMeta = {
-  tags: ["puzzle", "sky"],
+  tags: ["puzzle", "sky", "water", "agriculture"],
+  themes: ["default", "fields"],
```

## Against the design doc, deliberately

§9 argued the other way: a pair is what a place can hold two of, a lone star reads as the one and only, so the flood plain belonged to twin stars and star battle "cannot wear it". That is still the strongest reading of the skin and it stays twin stars' outright — but strongest is not only. What carries the place is the no-touching rule, two farmsteads that close would draw on the same well, and that does not change with the count. §9 and §11.3 say this now, and the file comments that repeated the old claim are corrected.

## No effect on the world, and that is the finding

The generated world is byte-identical and star-battle placements are unchanged at 75, because **nothing authors `water` or `agriculture`**:

```
role: "puzzle"  531
role: "trap"    122
role: "trade"    42
role: "sky"      40
role: "shop"      8
```

So the flood plain is unreachable in play for **both** families — twin stars has only ever appeared as a night sky. The pool is empty of rooms, not of families. §9 records that and names what would turn it on: one line on a journey, the shape `junior_4` already uses.

```ts
journey("junior_4").pyramid("1-5", { encounter: "sky", theme: "night" }),   // exists
journey("expert_?").pyramid("1-5", { encounter: "water" }),                 // would turn the face on
```

Which journey becomes a farming pyramid is an authoring call, so it is not in here.

## Testing

`yarn check-types`, `yarn lint` (0 errors), `yarn vitest run` — 197 files, 2295 tests passing. World regenerated: no diff.

Based on #217 so the regen could not collide with it; rebase to `main` once that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016TDausBqovq27A8D5njK8s