### PR TITLE
Every board finishes before it says solved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- A solved star battle board now lights its answers one at a time before the win arrives, the way a finished star map does. Stars in the sky swell as they catch the light; farmsteads on the flood plain only brighten. Asking for less motion skips it.
+- The puzzle lab now offers the tomb's own two boards — the crocodile capstone and the tableau — so they can be played without walking a tomb to the floor that serves them. A tableau still needs the hieroglyphs your save has collected.
+- A solved sumplete board now checks its own sums off before the win arrives: the row totals flash top to bottom, then the column totals left to right. Asking for less motion skips it.
+- A solved futoshiki board now counts itself up before the win arrives: the whole grid rolls to 1, the squares that really are 1 keep it and swell, the rest roll on to 2, and so on to the last number. Asking for less motion skips it.
+- A solved eclipse board now sweeps once from the top-left corner to the far one, each sun and moon swelling as the wave reaches it, before the win arrives. Asking for less motion skips it.
+- A solved balance board now settles: each beam rocks once and comes level with its pans riding it, top to bottom, before the win arrives. Asking for less motion skips it.
+
 ## 0.38.1 - 2026-08-23
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- The crocodile capstone no longer draws on top of itself. Its scene had no height of its own, so the prompt, the chest and the crocodiles all landed on one line; the sums either side of the crocodile were also cut off at the edges of the room. Both are now sized to the room they are in.
+
 ### Changed
 
 - A solved star battle board now lights its answers one at a time before the win arrives, the way a finished star map does. Stars in the sky swell as they catch the light; farmsteads on the flood plain only brighten. Asking for less motion skips it.

--- a/docs/game-design/puzzles/balance-scale.md
+++ b/docs/game-design/puzzles/balance-scale.md
@@ -291,6 +291,36 @@ what the pans and beam are made of, which glyph set the unknowns are drawn from.
 The family emits the glyphs, the numbers, and each scale's `left | level | right |
 unknown` state; nothing about a theme reaches the puzzle logic.
 
+### 8.1 The completion run — the beams settle before the board says so
+
+**A solved board rocks each beam once and settles it, top to bottom, and only then reports the solve.** The
+shell freezes the board and starts its banner the moment it is told (`puzzle-screens.md` §3), so the
+celebration happens before that word is said — the family reports the solve a beat later, and core supplies
+only the clock (`useCelebration.ts`).
+
+**The beam is what this family already teaches with, so the beam is what celebrates.** A tilt reading level
+is the whole feedback loop of the board (§7), and a scale that has just come level settling into it is the
+motion that loop already implies — nothing new is drawn, and nothing lights up that was not already the
+instrument.
+
+Three constraints, the shared ones:
+
+- **The whole run is about a second**, because the shell stops its solve-time clock when it hears "solved"
+  and that number is what `PUZZLE_FAMILIES.md` §3.2's budget is measured with. The stagger tightens with the
+  scale count instead of the total growing with it.
+- **Input is refused while it runs** — re-weighting a glyph mid-run would land a solve on a board that is no
+  longer solved. That is every control here, not just the palette: a trade or a cancel would do the same.
+- **`prefers-reduced-motion` skips it whole**, animation and wait together.
+
+**The pans ride the rock, one either side.** A beam that swings over pans nailed in place reads as a broken
+scale rather than a settling one, so each pan takes the same timing in the opposite phase — the side a
+beam-end drops goes down with it, exactly as their resting tilts already work.
+
+**The rock is small, and for the same reason the tilt is.** The pans hold the numbers the player has just
+worked out, and a beam that swings far enough to be dramatic swings the arithmetic off the screen with it.
+Notes do not take part: a note is a row the player derived rather than a scale standing in the room, so it has
+no beam to settle.
+
 ## 9. Open questions
 
 1. **Coefficient notation.** Three scarabs in a pan are drawn as three scarabs.

--- a/docs/game-design/puzzles/eclipse.md
+++ b/docs/game-design/puzzles/eclipse.md
@@ -301,6 +301,31 @@ OUTLINE — a filled star against a ring of empty sky — so the board stays rea
 colour. That rule is what makes another skin cheap; a pair that differed only in hue would
 not be a skin, it would be a bug in two colours.
 
+### 9.1 The completion run — one sweep across the board
+
+**A solved board sweeps once, top-left corner to bottom-right, and only then reports the solve.** Each mark
+swells and comes back as the wave reaches it. The shell freezes the board and starts its banner the moment it
+is told (`puzzle-screens.md` §3), so the celebration happens before that word is said — the family reports the
+solve a beat later, and core supplies only the clock (`useCelebration.ts`).
+
+**A tick is a DIAGONAL, not a square.** What this board has to say at the end is "all of it is right" — every
+line, in both directions, and every sign between them — and a diagonal sweep is the one motion that touches
+every row and every column without pointing at any of them. Per-square ticks would also spend the whole run
+on a flicker: a wizard board is forty-nine squares inside one second, where its thirteen diagonals read as a
+wave.
+
+Three constraints, the shared ones:
+
+- **The whole run is about a second**, because the shell stops its solve-time clock when it hears "solved" and
+  that number is what `PUZZLE_FAMILIES.md` §3.2's budget is measured with.
+- **Input is refused while it runs** — cycling a mark mid-run would land a solve on a board that is no longer
+  solved. Undo is held shut for the same beat.
+- **`prefers-reduced-motion` skips it whole**, animation and wait together.
+
+**The swell is on the mark rather than on the square**, so the wave stays inside the grid: a square growing
+would push its neighbours, and this board's squares are already as close as its gaps allow. Givens take their
+turn along with the rest — a given is part of the finished board even though it was never part of the answer.
+
 ## 10. Open questions
 
 1. **Does the family want givens at all?** Generation drives them to nought or one,

--- a/docs/game-design/puzzles/futoshiki.md
+++ b/docs/game-design/puzzles/futoshiki.md
@@ -339,6 +339,43 @@ material, what a pre-filled number is carved into, what a sign is drawn as. The
 family emits `given | filled | empty | conflicted` plus the numbers and the sign
 directions; nothing about a theme reaches the puzzle logic.
 
+### 9.1 The completion run — the board counts up
+
+**A solved board counts itself up, and the whole grid counts together.** Every square rolls to 1; the squares
+that really are 1 keep it and swell; the rest roll on to 2, and so on to the width of the grid, until the last
+number lands and the board is the answer again. Only then is the solve reported: the shell freezes the board
+and starts its banner the moment it is told (`puzzle-screens.md` §3), so the celebration happens before that
+word is said — the family reports the solve a beat later, and core supplies only the clock
+(`useCelebration.ts`).
+
+**The roll is why this run says something the swell alone did not.** A square dropping out of the count is the
+board showing where each number belongs, one number at a time — the same reading the player just built out of
+the chevrons, played back at speed. Squares that have settled keep their own digit throughout, so the board
+fills rather than flickers.
+
+**A tick is a NUMBER rather than a square, and that is this family rather than a house style.** What the board
+is about is order: every chevron is a claim about which of two numbers is bigger, and the answer is the one
+arrangement where all of them hold. Counting from 1 to n is that answer read back — the squares light in the
+order the signs argued for, wherever on the grid they stand. A sweep across the board would say nothing about
+order, and eclipse already owns that motion (its §9.1).
+
+Three constraints, the shared ones:
+
+- **The whole run is about a second**, because the shell stops its solve-time clock when it hears "solved" and
+  that number is what `PUZZLE_FAMILIES.md` §3.2's budget is measured with. A tick per number rather than per
+  square also keeps the count legible at 7 wide, where forty-nine ticks inside one second is a flicker.
+- **Input is refused while it runs** — the pad is shut and undo with it, so no number can change under a solve
+  already on its way.
+- **`prefers-reduced-motion` skips it whole**, animation and wait together.
+
+Givens count along with the rest: a given is part of the finished board even though it was never part of the
+answer, and a run that skipped them would read as holes in the count.
+
+**The count is read off the run's `progress`, never off its `done`**, and that is what keeps the reduced-motion
+case honest. A skipped run reports done with progress still at 0, so the count is simply never on — and a
+board that never counts is never showing anything but the numbers the player filled in. Read off `done`, the
+same skip would have frozen the grid mid-roll.
+
 ## 10. Generation cost, and where it should go
 
 A wizard board is the dear one: eleven techniques, a prune loop that re-solves the

--- a/docs/game-design/puzzles/star-battle.md
+++ b/docs/game-design/puzzles/star-battle.md
@@ -459,6 +459,31 @@ code.** No journey asks for `water` or `agriculture` (`src/worldGen/spec/*.ts` a
 of families. One line on a journey — the shape `junior_4` already uses for `sky` — is what
 turns the face on.
 
+### 9.1 The completion run — the board finishes before it says so
+
+**A solved board lights its answers one at a time, in reading order, and only then reports the solve.** The
+shell freezes the board and starts its banner the moment it is told (`puzzle-screens.md` §3), so the
+celebration happens before that word is said — the family reports the solve a beat later, and core supplies
+only the clock (`useCelebration.ts`).
+
+It is constellation's run on constellation's two places, deliberately: the same player meets the same sky and
+the same flood plain across both families, and a board that celebrates in one and goes quiet in the other
+reads as one of the two being unfinished.
+
+Three constraints, each of them the interesting part rather than the animation:
+
+- **The whole run is about a second**, because the shell stops its solve-time clock when it hears "solved"
+  and that number is what §3.2's budget is measured with. The stagger tightens with the star count instead of
+  the total growing with it.
+- **Input is refused while it runs** — a tap on a placed star would clear it, so the solve would land on a
+  board that is no longer solved. Undo is held shut for the same beat.
+- **`prefers-reduced-motion` skips it whole**, animation and wait together.
+
+**What the motion IS belongs to the place, and the two differ.** A star is a point of light, so it swells as
+it brightens and the size is part of the reading. A sheaf standing in a plot is rooted in the ground, and the
+same swell there reads as the plot moving with it — so the flood plain brightens only. The same split
+constellation draws between its sky and its basins, for the same reason.
+
 ## 10. Open questions
 
 1. **Does `spanning`'s hint survive a real board?** §3.1. First thing to look at in the lab,

--- a/docs/game-design/puzzles/sumplete.md
+++ b/docs/game-design/puzzles/sumplete.md
@@ -183,6 +183,30 @@ what a strike looks like (sand poured over it, a scribe's erasure), what the
 target beside a line is drawn on. The family emits `untouched | kept | struck`
 plus the numbers; nothing about a theme reaches the puzzle logic.
 
+### 8.1 The completion run — the board checks its own sums
+
+**A solved board checks its lines off before it reports the solve: the row targets flare top to bottom, then
+the column targets left to right.** The shell freezes the board and starts its banner the moment it is told
+(`puzzle-screens.md` §3), so the celebration happens before that word is said — the family reports the solve a
+beat later, and core supplies only the clock (`useCelebration.ts`).
+
+**A tick is a LINE, and what flares is the TARGET.** The targets are what this board wins by — every row and
+every column landing on its number — and they are already the thing that turns green when a line lands, so a
+run down them is the board making its own claim in the two directions the claim is made in. Flaring the
+numbers instead would celebrate the arithmetic rather than the result, and it would also have to pick a side:
+the struck numbers are as much of the answer as the kept ones.
+
+Three constraints, the shared ones:
+
+- **The whole run is about a second**, because the shell stops its solve-time clock when it hears "solved" and
+  that number is what `PUZZLE_FAMILIES.md` §3.2's budget is measured with. Two ticks per line of grid keeps
+  the count small at every size — fourteen at 7 wide, against forty-nine squares.
+- **Input is refused while it runs** — toggling a number mid-run would land a solve on a board that is no
+  longer solved.
+- **`prefers-reduced-motion` skips it whole**, animation and wait together. The run is read off the clock's
+  `progress` rather than its `done` for exactly this: a skipped run reports done with progress still at 0, so
+  nothing is ever checked off.
+
 ## 9. Open questions
 
 1. **Negative values.** The catalogue wants Sumplete to carry subtraction at

--- a/docs/instructions/puzzle-screens.md
+++ b/docs/instructions/puzzle-screens.md
@@ -266,9 +266,17 @@ The domain solver lives beside the family's state model
 
 `src/app/dev/PuzzleLab.tsx`, on the Travel page in develop mode: pick family,
 theme and tier, play the real screen through the real `EncounterModal`, reroll
-the seed. A family shows up there by being registered and tagged `puzzle`; its
-theme list comes from `FamilyMeta.themes`, its tiers from `minTier` upward.
-Rewards are dropped there — the lab tests the screen, not the economy.
+the seed. A family shows up there by being registered and carrying one of the board tags —
+`puzzle`, `tomb-puzzle` or `capstone` (`playableInLab`); its theme list comes from
+`FamilyMeta.themes`, its tiers from `minTier` upward. Rewards are dropped there — the lab
+tests the screen, not the economy.
+
+**The tomb's own boards are on the list for the same reason the others are**: a family the bench cannot
+reach is a family nobody reviews, and the two that were reachable only by walking a real tomb are the two
+that have had the least of it. Both generate without a tomb around them — a tableau falls back to a draw
+from the tier pool when no floor is resolvable. What the bench does NOT do is grant a save anything: a
+tableau asks the save for completed hieroglyphs to fill its slots, so it plays there only as far as the
+fragments already collected allow. Enough to look at the board; not enough to solve one cold.
 
 It is quick manual quality control, so **it plays the boards that ship**: for a family with a seed list
 (§6.1) the reroll walks that list rather than searching for arbitrary boards, and wraps at its end. A

--- a/src/app/dev/PuzzleLab.tsx
+++ b/src/app/dev/PuzzleLab.tsx
@@ -5,7 +5,7 @@ import { useProgression } from "@/app/state/useProgression"
 import { useJourneys } from "@/app/state/useJourneys"
 import { useInventory } from "@/app/Inventory/useInventory"
 import { DeveloperButton } from "@/ui/atoms/DeveloperButton"
-import { allowedDifficulties, DEFAULT_THEME, NO_ROLE, rolesFor, themesFor } from "./puzzleLabOptions"
+import { allowedDifficulties, DEFAULT_THEME, NO_ROLE, playableInLab, rolesFor, themesFor } from "./puzzleLabOptions"
 
 const selectClass = "rounded-md border border-red-400 bg-stone-900 px-2 py-1 text-sm text-white"
 
@@ -48,7 +48,7 @@ const benchNotes = (puzzle: unknown): string[] => {
 // Rewards are deliberately dropped (applyReward is a no-op): the lab exercises the puzzle screen,
 // not the economy — a bench that hands out loot would corrupt the save it is testing against.
 export const PuzzleLab: FC = () => {
-  const families = useMemo(() => allFamilies().filter(p => p.meta.tags.includes("puzzle")), [])
+  const families = useMemo(() => allFamilies().filter(p => playableInLab(p.meta)), [])
   const [familyId, setFamilyId] = useState(families[0]?.meta.id ?? "")
   const [pickedTheme, setPickedTheme] = useState("")
   const [pickedRole, setPickedRole] = useState(NO_ROLE)

--- a/src/app/dev/puzzleLabOptions.spec.ts
+++ b/src/app/dev/puzzleLabOptions.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import type { FamilyMeta } from "@/game/families/familyMeta"
-import { allowedDifficulties, themesFor } from "./puzzleLabOptions"
+import { allowedDifficulties, playableInLab, themesFor } from "./puzzleLabOptions"
 
 const meta = (overrides: Partial<FamilyMeta> = {}): FamilyMeta => ({
   id: "test",
@@ -29,5 +29,19 @@ describe(themesFor, () => {
 
   it("lists the family's own themes", () => {
     expect(themesFor(meta({ themes: ["stone", "nile"] }))).toEqual(["stone", "nile"])
+  })
+})
+
+describe(playableInLab, () => {
+  it("plays the puzzle rooms and the two boards a tomb serves", () => {
+    expect(playableInLab(meta())).toBe(true)
+    expect(playableInLab(meta({ tags: ["tomb-puzzle"] }))).toBe(true)
+    expect(playableInLab(meta({ tags: ["capstone"] }))).toBe(true)
+  })
+
+  it("leaves out what is not a board at all", () => {
+    // A trap, a shop, a chest and a gate are rooms rather than puzzles: nothing on the bench's pickers
+    // (tier, theme, role, seed) means anything to them.
+    for (const tags of [["trap"], ["shop"], ["treasure"], ["gate"]]) expect(playableInLab(meta({ tags }))).toBe(false)
   })
 })

--- a/src/app/dev/puzzleLabOptions.ts
+++ b/src/app/dev/puzzleLabOptions.ts
@@ -11,6 +11,23 @@ export const allowedDifficulties = (meta: FamilyMeta): Difficulty[] =>
 
 export const themesFor = (meta: FamilyMeta): string[] => meta.themes ?? [DEFAULT_THEME]
 
+/**
+ * Which families the bench can play: the plain puzzle rooms, and the two boards a tomb serves — a capstone
+ * crocodile and a tableau.
+ *
+ * The tomb pair are on the list because a family the bench cannot reach is a family nobody reviews: they were
+ * playable only by walking a real tomb to the floor that serves them, which is why they are the two that have
+ * had the least of it. Both generate without a tomb around them — a tableau falls back to a tier-pool draw
+ * when no floor is resolvable, which is the path the bench takes.
+ *
+ * **A tableau still needs its hieroglyphs**, and the bench does not grant them: filling a slot asks the save
+ * for a completed hieroglyph, so a tableau plays here only as far as the fragments already collected allow.
+ * That is enough to look at the board and not enough to solve one cold.
+ */
+const BENCH_TAGS = ["puzzle", "tomb-puzzle", "capstone"]
+
+export const playableInLab = (meta: FamilyMeta): boolean => meta.tags.some(tag => BENCH_TAGS.includes(tag))
+
 /** Stands for "whatever the site would have said" — the lab's way of picking no role at all. */
 export const NO_ROLE = "(no role)"
 

--- a/src/index.css
+++ b/src/index.css
@@ -88,6 +88,45 @@ body {
     }
   }
 
+  /* A beam that has come level rocking once before it settles — a scale finishing (balance-scale design doc
+     §9). Rotation only, and small: the pans hold the numbers the player just worked out, so a beam that
+     swings far enough to be dramatic swings the arithmetic off the screen with it. */
+  --animate-settle: settle 420ms ease-out;
+  @keyframes settle {
+    0% {
+      transform: rotate(0deg);
+    }
+    30% {
+      transform: rotate(-5deg);
+    }
+    65% {
+      transform: rotate(3deg);
+    }
+    100% {
+      transform: rotate(0deg);
+    }
+  }
+
+  /* The pans riding a settling beam. Same timing as `settle` and the opposite phase per side, so the pan a
+     beam-end drops goes down with it — a beam that rocks over pans nailed in place reads as a broken scale
+     rather than a settling one. `--bob` is which way this pan goes (1 down first, -1 up first), and it is
+     applied as `translate` rather than `transform` so it composes with the tilt the pans already carry. */
+  --animate-bob: bob 420ms ease-out;
+  @keyframes bob {
+    0% {
+      translate: 0 0;
+    }
+    30% {
+      translate: 0 calc(var(--bob, 1) * 5px);
+    }
+    65% {
+      translate: 0 calc(var(--bob, 1) * -3px);
+    }
+    100% {
+      translate: 0 0;
+    }
+  }
+
   /* A blossom arriving on a plant that has its water. Opacity alone: the flower appears, it does not
      inflate. */
   --animate-flower-in: flower-in 320ms ease-out;

--- a/src/mods/puzzle/app/balanceScale/BalanceBoard.tsx
+++ b/src/mods/puzzle/app/balanceScale/BalanceBoard.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx"
-import type { FC } from "react"
+import type { CSSProperties, FC } from "react"
 import type { BalanceLine } from "@/mods/puzzle/game/balanceScale/balanceStatus"
 import {
   hasTwin,
@@ -30,6 +30,8 @@ type Props = {
   pending?: { ref: EquationRef; glyph: Glyph }
   /** Which rows can answer that tap. */
   swapSources?: EquationRef[]
+  /** The scales that have had their turn in the completion run (`puzzle-screens.md` §3). */
+  celebrated?: ReadonlySet<number>
   /** Whether this board offers taking things off both pans, and trading a glyph. */
   moves: { cancelling: boolean; swapping: boolean }
   /** What to do next with the tapped glyph, or why nothing can be done with it. */
@@ -106,16 +108,14 @@ const PanItems: FC<ChipProps & { items: PanItem[]; pan: Pan }> = ({
   </>
 )
 
-const PanBox: FC<ChipProps & { items: PanItem[]; pan: Pan; translate: number; total?: number }> = ({
-  items,
-  pan,
-  translate,
-  total,
-  ...chips
-}) => (
+const PanBox: FC<
+  ChipProps & { items: PanItem[]; pan: Pan; translate: number; total?: number; settling?: boolean; bob: number }
+> = ({ items, pan, translate, total, settling, bob, ...chips }) => (
   <div
-    className="flex flex-1 flex-col items-center transition-transform duration-300"
-    style={{ transform: `translateY(${translate * DROP_PX}px)` }}
+    className={clsx("flex flex-1 flex-col items-center transition-transform duration-300", settling && "animate-bob")}
+    // Which way this pan rides the rock, read by the `bob` keyframes — the opposite sign to the pan across
+    // the beam, the same way their resting tilts are opposite.
+    style={{ transform: `translateY(${translate * DROP_PX}px)`, "--bob": bob } as CSSProperties}
   >
     <div className="flex min-h-11 w-full flex-wrap items-center justify-center gap-1 rounded-b-xl border-x-2 border-b-4 border-stone-500 bg-stone-800/70 p-1">
       <PanItems items={items} pan={pan} {...chips} />
@@ -128,12 +128,22 @@ const PanBox: FC<ChipProps & { items: PanItem[]; pan: Pan; translate: number; to
 type RowProps = ChipProps & {
   scale: Scale
   lit: boolean
+  /** This row is taking its turn in the completion run: its beam rocks once and comes level. */
+  settling?: boolean
   /** This row can answer the pending tap: tapping it writes the note. */
   offering: boolean
   onTapRow: () => void
 }
 
-const ScaleRow: FC<RowProps & { line: BalanceLine }> = ({ scale, line, lit, offering, onTapRow, ...chips }) => {
+const ScaleRow: FC<RowProps & { line: BalanceLine }> = ({
+  scale,
+  line,
+  lit,
+  offering,
+  settling,
+  onTapRow,
+  ...chips
+}) => {
   const drop = dropOf(line.status)
   return (
     <div
@@ -147,12 +157,23 @@ const ScaleRow: FC<RowProps & { line: BalanceLine }> = ({ scale, line, lit, offe
     >
       {/* The beam: the tilt is the feedback this whole family teaches with. */}
       <div
-        className="pointer-events-none absolute inset-x-4 top-2 h-1 rounded-full bg-stone-500 transition-transform duration-300"
+        className={clsx(
+          "pointer-events-none absolute inset-x-4 top-2 h-1 rounded-full bg-stone-500 transition-transform duration-300",
+          settling && "animate-settle"
+        )}
         style={{ transform: `rotate(${-drop * TILT_DEG}deg)` }}
       />
-      <PanBox items={scale.left} pan="left" translate={drop} total={line.left} {...chips} />
+      <PanBox items={scale.left} pan="left" translate={drop} total={line.left} settling={settling} bob={1} {...chips} />
       <span className="pt-4 text-stone-500">▲</span>
-      <PanBox items={scale.right} pan="right" translate={-drop} total={line.right} {...chips} />
+      <PanBox
+        items={scale.right}
+        pan="right"
+        translate={-drop}
+        total={line.right}
+        settling={settling}
+        bob={-1}
+        {...chips}
+      />
     </div>
   )
 }
@@ -195,6 +216,7 @@ export const BalanceBoard: FC<Props> = ({
   litRefs,
   pending,
   swapSources,
+  celebrated,
   swapPrompt,
   moves,
   onSelectGlyph,
@@ -219,7 +241,13 @@ export const BalanceBoard: FC<Props> = ({
   return (
     <div className="flex w-full max-w-[min(52vh,26rem)] flex-col gap-2 select-none">
       {scales.map((scale, index) => (
-        <ScaleRow key={index} scale={scale} line={lines[index]} {...rowProps({ kind: "scale", index }, scale)} />
+        <ScaleRow
+          key={index}
+          scale={scale}
+          line={lines[index]}
+          settling={celebrated?.has(index)}
+          {...rowProps({ kind: "scale", index }, scale)}
+        />
       ))}
 
       {notes.map((note, index) => (

--- a/src/mods/puzzle/app/balanceScale/BalancePuzzle.tsx
+++ b/src/mods/puzzle/app/balanceScale/BalancePuzzle.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState, type FC } from "react"
 import { useTranslation } from "react-i18next"
 import type { Difficulty } from "@/data/difficultyLevels"
+import { useCelebration } from "@/mods/core/app/useCelebration"
 import { PuzzleFamilyShell } from "@/mods/core/app/PuzzleFamilyShell"
 import { hintIdleDelay } from "@/mods/core/app/useHintAvailability"
 import { computeBalanceLines, isBalanceSolved } from "@/mods/puzzle/game/balanceScale/balanceStatus"
@@ -45,6 +46,21 @@ export const BalancePuzzle: FC<Props> = ({ puzzle, difficulty, onSolved, onCance
     [board, state.values, state.notes, solution, techniqueCap]
   )
 
+  /**
+   * The scales settle one at a time before the shell is told, top to bottom.
+   *
+   * The shell freezes the board and starts its banner the moment it hears "solved", so the celebration has to
+   * happen BEFORE that word is said (`puzzle-screens.md` §3) — the family reports the solve a beat later.
+   * Input is refused for that beat, or a weight changed mid-run would land a solve on a board that is no
+   * longer solved.
+   */
+  const finished = isBalanceSolved(glyphs, lines, state.values)
+  // One tick per scale, so the beams come level in the order they are read.
+  const celebration = useCelebration(finished, scales.length)
+  const celebrated = new Set(
+    Array.from({ length: Math.round(celebration.progress * scales.length) }, (_unused, index) => index)
+  )
+
   // Which scales and notes can answer the glyph the player tapped — recomputed rather than stored,
   // so the offer can never survive the board changing underneath it.
   const sources = useMemo(() => swapSources(board, state), [board, state])
@@ -53,7 +69,7 @@ export const BalancePuzzle: FC<Props> = ({ puzzle, difficulty, onSolved, onCance
     <PuzzleFamilyShell
       onSolved={onSolved}
       onCancel={onCancel}
-      solved={isBalanceSolved(glyphs, lines, state.values)}
+      solved={celebration.done}
       onReset={() => setState(createBalanceState(glyphs))}
       hint={hint && t(`balance.hint.${hint.key}`, hint.params)}
       idleMs={hintIdleDelay(difficulty)}
@@ -80,23 +96,28 @@ export const BalancePuzzle: FC<Props> = ({ puzzle, difficulty, onSolved, onCance
           pending={state.pending}
           moves={moves}
           swapSources={sources.map(source => source.ref)}
+          celebrated={celebrated}
           swapPrompt={
             state.pending &&
             t(sources.length ? "balance.swap.pick" : "balance.swap.none", { glyph: state.pending.glyph })
           }
           onSelectGlyph={glyph => {
+            if (finished) return // the board is finishing; nothing may change under the celebration
             reportInput()
             setState(prev => selectGlyph(prev, glyph))
           }}
           onPickWeight={value => {
+            if (finished) return
             reportInput()
             setState(prev => setWeight(prev, glyphs, value))
           }}
           onTapPiece={(ref, pan, index) => {
+            if (finished) return
             reportInput()
             setState(prev => tapPiece(prev, board, ref, pan, index))
           }}
           onTapRow={ref => {
+            if (finished) return
             const source = sources.find(
               candidate => candidate.ref.kind === ref.kind && candidate.ref.index === ref.index
             )
@@ -105,6 +126,7 @@ export const BalancePuzzle: FC<Props> = ({ puzzle, difficulty, onSolved, onCance
             setState(prev => applySwap(prev, source.note))
           }}
           onRemoveNote={index => {
+            if (finished) return
             reportInput()
             setState(prev => removeNote(prev, index))
           }}

--- a/src/mods/puzzle/app/balanceScale/celebration.spec.tsx
+++ b/src/mods/puzzle/app/balanceScale/celebration.spec.tsx
@@ -1,0 +1,100 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest"
+import { render, waitFor, within } from "@testing-library/react"
+import { act } from "react"
+import { BALANCE_CONFIG } from "@/mods/puzzle/game/balanceScale/balanceConfig"
+import { generateBalance, type BalancePuzzle } from "@/mods/puzzle/game/balanceScale/generateBalance"
+import { BalancePuzzle as BalanceScreen } from "./BalancePuzzle"
+
+// The shell scrolls a revealed hint into view; jsdom does not implement it.
+beforeAll(() => {
+  Element.prototype.scrollIntoView = () => {}
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+/**
+ * The two rows of controls under the board, told from the pieces standing in the pans by the size each is
+ * drawn at: the glyph row picks WHICH glyph is being weighed, the palette picks WHAT it weighs.
+ */
+const buttonsIn = (root: HTMLElement, marker: string) =>
+  within(root)
+    .getAllByRole("button")
+    .filter(button => button.className.includes(marker))
+
+const glyphsIn = (root: HTMLElement) => buttonsIn(root, "min-w-16")
+const weightsIn = (root: HTMLElement) => buttonsIn(root, "size-11")
+
+const settling = (root: HTMLElement) => root.querySelectorAll(".animate-settle").length
+// The pans ride the rock, one either side of every settling beam — a beam rocking over pans nailed in place
+// reads as a broken scale.
+const bobbing = (root: HTMLElement) => root.querySelectorAll(".animate-bob").length
+
+/** Gives every glyph the value the answer holds, which is the whole of a solve here. */
+const solve = (root: HTMLElement, puzzle: BalancePuzzle) =>
+  puzzle.glyphs.forEach((glyph, index) => {
+    act(() => glyphsIn(root)[index].click())
+    act(() => weightsIn(root)[puzzle.solution[glyph] - 1].click())
+  })
+
+const reducedMotion = (reduce: boolean) =>
+  vi.stubGlobal("matchMedia", (query: string) => ({
+    matches: reduce && query.includes("reduce"),
+    media: query,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  }))
+
+/**
+ * The board finishes itself before the shell hears the word "solved" (`puzzle-screens.md` §3).
+ *
+ * What that looks like here is the family's own instrument: a beam that has come level rocks once and
+ * settles, one scale at a time. The constraints are the shared ones — under a second, no input while it
+ * runs, and nothing at all under reduced motion.
+ */
+describe("the completion run", () => {
+  it("rocks the beams before the banner arrives, then reports the solve", async () => {
+    reducedMotion(false)
+    const puzzle = generateBalance(3, BALANCE_CONFIG.starter)
+    const { container } = render(
+      <BalanceScreen puzzle={puzzle} difficulty="starter" onSolved={() => {}} onCancel={() => {}} />
+    )
+    solve(container, puzzle)
+
+    // Mid-run: beams are settling one at a time, each with both its pans, and the banner has not landed.
+    await waitFor(() => expect(settling(container)).toBeGreaterThan(0))
+    expect(bobbing(container)).toBe(settling(container) * 2)
+    expect(within(container).queryByText(/⏱/)).toBeNull()
+
+    // And it does finish — the solve is reported, so the banner follows.
+    await waitFor(() => expect(within(container).getByText(/⏱/)).toBeDefined(), { timeout: 5000 })
+  })
+
+  it("refuses input while the board is finishing", async () => {
+    reducedMotion(false)
+    const puzzle = generateBalance(3, BALANCE_CONFIG.starter)
+    const { container } = render(
+      <BalanceScreen puzzle={puzzle} difficulty="starter" onSolved={() => {}} onCancel={() => {}} />
+    )
+    solve(container, puzzle)
+    // Re-weighting a glyph would un-solve a board whose win is already on its way, so the tap is dropped
+    // and the run still finishes.
+    const wrong = puzzle.solution[puzzle.glyphs[0]] === 1 ? 2 : 1
+    act(() => glyphsIn(container)[0].click())
+    act(() => weightsIn(container)[wrong - 1].click())
+    await waitFor(() => expect(within(container).getByText(/⏱/)).toBeDefined(), { timeout: 5000 })
+  })
+
+  /** A player who asked for less motion gets none of it — and no wait for an animation they will not see. */
+  it("skips the run entirely under prefers-reduced-motion", async () => {
+    reducedMotion(true)
+    const puzzle = generateBalance(3, BALANCE_CONFIG.starter)
+    const { container } = render(
+      <BalanceScreen puzzle={puzzle} difficulty="starter" onSolved={() => {}} onCancel={() => {}} />
+    )
+    solve(container, puzzle)
+    expect(settling(container) + bobbing(container)).toBe(0)
+    await waitFor(() => expect(within(container).getByText(/⏱/)).toBeDefined(), { timeout: 5000 })
+  })
+})

--- a/src/mods/puzzle/app/crocodile/plugin.tsx
+++ b/src/mods/puzzle/app/crocodile/plugin.tsx
@@ -129,7 +129,11 @@ const CrocodileComponent = ({ puzzle, onSolved }: { puzzle: CompareLevel; onSolv
   return (
     <div
       className={clsx(
-        "relative flex flex-1 flex-col-reverse items-center justify-center gap-4",
+        // A STAGE of its own height, because everything below is positioned against it: the prompt off its
+        // top, the chest and the crocodile stack off its bottom. `flex-1` was asking a parent for the room —
+        // and the puzzle shell shrink-wraps its board, so there was none: the stage collapsed to 0px and the
+        // whole scene piled up on one line.
+        "relative flex h-[60vh] min-h-96 w-full flex-col-reverse items-center justify-center gap-4",
         hasComparison && "bg-gradient-to-b from-transparent from-50% via-blue-200 via-51% to-blue-100"
       )}
     >
@@ -216,7 +220,9 @@ const CrocodileComponent = ({ puzzle, onSolved }: { puzzle: CompareLevel; onSolv
             <div
               key={index}
               className={clsx(
-                "absolute bottom-0 flex w-dvw max-w-md translate-y-0 scale-100 flex-col items-center transition-transform duration-400",
+                // As wide as the STAGE, not as the viewport: `w-dvw` reached past a modal narrower than the
+                // screen, and the two sums either side of the crocodile were clipped off at its edges.
+                "absolute bottom-0 flex w-full translate-y-0 scale-100 flex-col items-center transition-transform duration-400",
                 index - focus < 0 && "blur-xs"
               )}
               style={{

--- a/src/mods/puzzle/app/eclipse/EclipseBoard.tsx
+++ b/src/mods/puzzle/app/eclipse/EclipseBoard.tsx
@@ -25,6 +25,11 @@ type Props = {
   /** The skin this room was authored to wear; an unknown name draws the default pair. */
   theme?: string
   onTapCell: (cell: number) => void
+  /**
+   * How many diagonals of the completion run have arrived (`puzzle-screens.md` §3), counted from the top-left
+   * corner. Every square on a diagonal that has been reached is lit; unset means no run.
+   */
+  wave?: number
 }
 
 /**
@@ -155,13 +160,19 @@ const HATCH = {
 
 const linkKey = (link: Link) => `${link.a}-${link.b}`
 
-const markGlyph = (value: Mark | undefined, theme: string | undefined) => {
+const markGlyph = (value: Mark | undefined, theme: string | undefined, celebrating: boolean) => {
   if (!value) return null
   const Glyph = (theme && SKINS[theme] ? SKINS[theme] : SKINS.default)[value]
-  return <Glyph />
+  // The wrapper is what the run animates, so the swell stays inside the square rather than pushing the grid
+  // around: the glyph itself is sized off it either way.
+  return (
+    <span className={clsx("block size-full", celebrating && "animate-bloom")}>
+      <Glyph />
+    </span>
+  )
 }
 
-export const EclipseBoard: FC<Props> = ({ puzzle, state, highlighted, decided, focus, theme, onTapCell }) => {
+export const EclipseBoard: FC<Props> = ({ puzzle, state, highlighted, decided, focus, theme, wave, onTapCell }) => {
   const { size } = puzzle
   // Held back a beat: a tap on the way to the other mark is not a mistake (see the hook).
   const conflicts = useDelayedConflicts(state.marks, marks => eclipseConflicts(puzzle, { marks }))
@@ -177,6 +188,8 @@ export const EclipseBoard: FC<Props> = ({ puzzle, state, highlighted, decided, f
       >
         {state.marks.map((value, cell) => {
           const given = isGiven(puzzle, cell)
+          // The run sweeps top-left to bottom-right, so a square's turn is which diagonal it stands on.
+          const celebrating = wave !== undefined && rowOf(size, cell) + colOf(size, cell) < wave
           return (
             <button
               key={cell}
@@ -194,7 +207,7 @@ export const EclipseBoard: FC<Props> = ({ puzzle, state, highlighted, decided, f
                 cell === focus && "ring-4 ring-amber-300"
               )}
             >
-              {markGlyph(value, theme)}
+              {markGlyph(value, theme, celebrating)}
             </button>
           )
         })}

--- a/src/mods/puzzle/app/eclipse/EclipsePuzzle.tsx
+++ b/src/mods/puzzle/app/eclipse/EclipsePuzzle.tsx
@@ -2,6 +2,7 @@ import clsx from "clsx"
 import { useCallback, useMemo, useState, type FC } from "react"
 import { useTranslation } from "react-i18next"
 import type { Difficulty } from "@/data/difficultyLevels"
+import { useCelebration } from "@/mods/core/app/useCelebration"
 import { PuzzleFamilyShell } from "@/mods/core/app/PuzzleFamilyShell"
 import { hintIdleDelay } from "@/mods/core/app/useHintAvailability"
 import {
@@ -44,6 +45,22 @@ export const EclipsePuzzle: FC<Props> = ({ puzzle, difficulty, theme, onSolved, 
   )
 
   /**
+   * The board finishes itself before the shell is told, as one diagonal sweep across it.
+   *
+   * The shell freezes the board and starts its banner the moment it hears "solved", so the celebration has to
+   * happen BEFORE that word is said (`puzzle-screens.md` §3) — the family reports the solve a beat later, and
+   * input is refused for that beat, or a tap could change a mark and land the solve on a board that is no
+   * longer solved.
+   *
+   * One tick per DIAGONAL rather than per square: the sweep is what says "the whole board is right", and a
+   * board of forty-nine squares given a tick each would spend the run's whole second on a flicker.
+   */
+  const finished = eclipseSolved(puzzle, state)
+  const diagonals = puzzle.size * 2 - 1
+  const celebration = useCelebration(finished, diagonals)
+  const wave = finished ? Math.round(celebration.progress * diagonals) : undefined
+
+  /**
    * A function rather than a string, so the shell only reaches for the text once the hint is on screen.
    *
    * Two lines: the reason, then the move it asks for (`puzzle-screens.md` §4).
@@ -60,7 +77,7 @@ export const EclipsePuzzle: FC<Props> = ({ puzzle, difficulty, theme, onSolved, 
     <PuzzleFamilyShell
       onSolved={onSolved}
       onCancel={onCancel}
-      solved={eclipseSolved(puzzle, state)}
+      solved={celebration.done}
       onReset={() => setState(createEclipseState(puzzle))}
       hint={hintText}
       onHintRevealed={() => setAsked(true)}
@@ -77,7 +94,9 @@ export const EclipsePuzzle: FC<Props> = ({ puzzle, difficulty, theme, onSolved, 
             highlighted={hintVisible ? hint?.cells : undefined}
             decided={hintVisible ? hint?.decided : undefined}
             focus={hintVisible ? hint?.focus : undefined}
+            wave={wave}
             onTapCell={cell => {
+              if (finished) return // the board is finishing; nothing may change under the celebration
               reportInput()
               setState(cycleEclipseCell(puzzle, state, cell))
             }}
@@ -90,10 +109,10 @@ export const EclipsePuzzle: FC<Props> = ({ puzzle, difficulty, theme, onSolved, 
               reportInput()
               setState(undoEclipse(state))
             }}
-            disabled={!canUndoEclipse(state)}
+            disabled={!canUndoEclipse(state) || finished}
             className={clsx(
               "flex h-11 min-w-11 items-center justify-center gap-1 rounded border px-2 text-sm transition-colors",
-              canUndoEclipse(state)
+              canUndoEclipse(state) && !finished
                 ? "border-amber-700 bg-amber-950/60 text-amber-200"
                 : "border-stone-700 bg-stone-900 text-stone-600"
             )}

--- a/src/mods/puzzle/app/eclipse/celebration.spec.tsx
+++ b/src/mods/puzzle/app/eclipse/celebration.spec.tsx
@@ -1,0 +1,105 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest"
+import { render, waitFor, within } from "@testing-library/react"
+import { act } from "react"
+import { ECLIPSE_CONFIG } from "@/mods/puzzle/game/eclipse/eclipseConfig"
+import { generateEclipse, type EclipsePuzzleWithAnswer } from "@/mods/puzzle/game/eclipse/generateEclipse"
+import { EclipsePuzzle } from "./EclipsePuzzle"
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = () => {}
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+const cellsIn = (root: HTMLElement) =>
+  within(root)
+    .getAllByRole("button")
+    .filter(button => button.className.includes("aspect-square"))
+
+const swelling = (root: HTMLElement) => root.querySelectorAll(".animate-bloom").length
+
+/** One tap puts a sun in, a second a moon — so each square takes as many taps as the answer asks for. */
+const solve = (root: HTMLElement, puzzle: EclipsePuzzleWithAnswer) =>
+  puzzle.solution.forEach((mark, cell) => {
+    if (puzzle.given[cell] !== undefined) return
+    act(() => cellsIn(root)[cell].click())
+    if (mark === "moon") act(() => cellsIn(root)[cell].click())
+  })
+
+const reducedMotion = (reduce: boolean) =>
+  vi.stubGlobal("matchMedia", (query: string) => ({
+    matches: reduce && query.includes("reduce"),
+    media: query,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  }))
+
+/**
+ * The board finishes itself before the shell hears the word "solved" (`puzzle-screens.md` §3).
+ *
+ * Here it is one sweep across the grid, top-left corner to bottom-right, a diagonal at a time — so the run
+ * says "the whole board" rather than pointing at any square in it. The constraints are the shared ones: under
+ * a second, no input while it runs, nothing at all under reduced motion.
+ */
+describe("the completion run", () => {
+  it("sweeps the marks before the banner arrives, then reports the solve", { timeout: 120_000 }, async () => {
+    reducedMotion(false)
+    const puzzle = generateEclipse(4, ECLIPSE_CONFIG.starter)
+    const { container } = render(
+      <EclipsePuzzle puzzle={puzzle} difficulty="starter" onSolved={() => {}} onCancel={() => {}} />
+    )
+    solve(container, puzzle)
+
+    // Mid-run: the wave has reached part of the board but not all of it, and the banner has not landed.
+    await waitFor(() => expect(swelling(container)).toBeGreaterThan(0))
+    expect(swelling(container)).toBeLessThan(puzzle.size ** 2)
+    expect(within(container).queryByText(/⏱/)).toBeNull()
+
+    // And it does finish — the whole board is lit, the solve is reported, so the banner follows.
+    await waitFor(() => expect(within(container).getByText(/⏱/)).toBeDefined(), { timeout: 5000 })
+    expect(swelling(container)).toBe(puzzle.size ** 2)
+  })
+
+  it("runs the wave from the top-left corner", { timeout: 120_000 }, async () => {
+    reducedMotion(false)
+    const puzzle = generateEclipse(4, ECLIPSE_CONFIG.starter)
+    const { container } = render(
+      <EclipsePuzzle puzzle={puzzle} difficulty="starter" onSolved={() => {}} onCancel={() => {}} />
+    )
+    solve(container, puzzle)
+    // The first square to take its turn is the corner the sweep starts from; the far corner is the last.
+    await waitFor(() => expect(swelling(container)).toBeGreaterThan(0))
+    const cells = cellsIn(container)
+    expect(cells[0].querySelector(".animate-bloom")).not.toBeNull()
+    expect(cells[puzzle.size ** 2 - 1].querySelector(".animate-bloom")).toBeNull()
+  })
+
+  it("refuses input while the board is finishing", { timeout: 120_000 }, async () => {
+    reducedMotion(false)
+    const puzzle = generateEclipse(4, ECLIPSE_CONFIG.starter)
+    const { container } = render(
+      <EclipsePuzzle puzzle={puzzle} difficulty="starter" onSolved={() => {}} onCancel={() => {}} />
+    )
+    solve(container, puzzle)
+    // Cycling a mark would un-solve a board whose win is already on its way, so the tap is dropped and the
+    // run still finishes.
+    const open = puzzle.given.findIndex(given => given === undefined)
+    act(() => cellsIn(container)[open].click())
+    expect(within(container).getByRole<HTMLButtonElement>("button", { name: /↩/ }).disabled).toBe(true)
+    await waitFor(() => expect(within(container).getByText(/⏱/)).toBeDefined(), { timeout: 5000 })
+  })
+
+  /** A player who asked for less motion gets none of it — and no wait for an animation they will not see. */
+  it("skips the run entirely under prefers-reduced-motion", { timeout: 120_000 }, async () => {
+    reducedMotion(true)
+    const puzzle = generateEclipse(4, ECLIPSE_CONFIG.starter)
+    const { container } = render(
+      <EclipsePuzzle puzzle={puzzle} difficulty="starter" onSolved={() => {}} onCancel={() => {}} />
+    )
+    solve(container, puzzle)
+    expect(swelling(container)).toBe(0)
+    await waitFor(() => expect(within(container).getByText(/⏱/)).toBeDefined(), { timeout: 5000 })
+  })
+})

--- a/src/mods/puzzle/app/futoshiki/FutoshikiBoard.tsx
+++ b/src/mods/puzzle/app/futoshiki/FutoshikiBoard.tsx
@@ -19,6 +19,14 @@ type Props = {
   highlighted?: ReadonlySet<string>
   /** Constraint indices the current hint points at. */
   litSigns?: ReadonlySet<number>
+  /**
+   * Which number the completion run is on (`puzzle-screens.md` §3), or unset for no run.
+   *
+   * The whole board counts together: a square holding this number or lower has settled and shows its own
+   * digit, and every square still to come shows the count instead — so the board rolls 1, 2, 3 … and each
+   * number drops out of the roll as it is reached.
+   */
+  counted?: number
   onSelect: (row: number, col: number) => void
 }
 
@@ -169,6 +177,7 @@ export const FutoshikiBoard: FC<Props> = ({
   selected,
   highlighted,
   litSigns,
+  counted,
   onSelect,
 }) => {
   const { size } = puzzle
@@ -199,14 +208,16 @@ export const FutoshikiBoard: FC<Props> = ({
                   <NoteGrid notes={cell.notes} size={size} row={rowIndex} col={colIndex} stranded={stranded} />
                 ) : (
                   <span
-                    className={clsx("text-[58cqw] font-semibold", {
+                    className={clsx("inline-block text-[58cqw] font-semibold", {
                       // The digit takes the conflict colour too: forcing ink-white here was what
                       // swallowed the warning, since the square's own red never reached the number.
                       "text-stone-100": !cell.given && !conflicted,
                       "text-red-100": conflicted,
+                      // The number the roll has just settled on — see `counted`.
+                      "animate-bloom": counted !== undefined && cell.value <= counted,
                     })}
                   >
-                    {cell.value}
+                    {counted !== undefined && cell.value > counted ? counted : cell.value}
                   </span>
                 )}
               </button>

--- a/src/mods/puzzle/app/futoshiki/FutoshikiPuzzle.tsx
+++ b/src/mods/puzzle/app/futoshiki/FutoshikiPuzzle.tsx
@@ -17,6 +17,7 @@ import {
   undoFutoshikiMove,
 } from "@/mods/puzzle/game/futoshiki/futoshikiState"
 import { futoshikiConflicts, isFutoshikiSolved, strandedNotes } from "@/mods/puzzle/game/futoshiki/futoshikiStatus"
+import { useCelebration } from "@/mods/core/app/useCelebration"
 import { PuzzleFamilyShell } from "@/mods/core/app/PuzzleFamilyShell"
 import { hintIdleDelay } from "@/mods/core/app/useHintAvailability"
 import type { Difficulty } from "@/data/difficultyLevels"
@@ -50,6 +51,28 @@ export const FutoshikiPuzzle: FC<Props> = ({ puzzle, difficulty, onSolved, onCan
     [puzzle, state, solution, techniqueCap]
   )
 
+  /**
+   * The board finishes itself before the shell is told, by COUNTING UP: the whole grid rolls to 1, the squares
+   * that really are 1 swell and keep it, the rest roll on to 2, and so on to the width of the grid.
+   *
+   * The shell freezes the board and starts its banner the moment it hears "solved", so the celebration has to
+   * happen BEFORE that word is said (`puzzle-screens.md` §3) — the family reports the solve a beat later, and
+   * input is refused for that beat, or a number changed mid-run would land a solve on a board that is no
+   * longer solved.
+   *
+   * **A tick is a NUMBER, not a square**, and that is the family rather than a house style: what this board
+   * is about is order — every chevron is a claim about which of two numbers is bigger — so a count from 1 to n
+   * is the board reading its own answer back, in the order the signs argued for. A sweep across the grid would
+   * say nothing about order, and eclipse already owns that motion.
+   *
+   * **Read off `progress` rather than off `done`**, which is what keeps the reduced-motion case honest: a
+   * skipped run reports done with progress still at 0, so the count is simply never on and the board is never
+   * anything but the answer the player filled in.
+   */
+  const finished = isFutoshikiSolved(puzzle, values)
+  const celebration = useCelebration(finished, size)
+  const counted = celebration.progress > 0 ? Math.round(celebration.progress * size) : undefined
+
   const enterNumber = useCallback(
     (value: number) => {
       if (!selected) return
@@ -67,7 +90,7 @@ export const FutoshikiPuzzle: FC<Props> = ({ puzzle, difficulty, onSolved, onCan
     <PuzzleFamilyShell
       onSolved={onSolved}
       onCancel={onCancel}
-      solved={isFutoshikiSolved(puzzle, values)}
+      solved={celebration.done}
       onReset={() => {
         setState(createFutoshikiState(puzzle))
         clearSelection()
@@ -90,7 +113,9 @@ export const FutoshikiPuzzle: FC<Props> = ({ puzzle, difficulty, onSolved, onCan
             selected={selected}
             highlighted={hintVisible ? hint?.cells : undefined}
             litSigns={hintVisible ? hint?.constraints : undefined}
+            counted={counted}
             onSelect={(row, col) => {
+              if (finished) return // the board is finishing; nothing may change under the celebration
               reportInput()
               selectCell(row, col)
             }}
@@ -98,14 +123,15 @@ export const FutoshikiPuzzle: FC<Props> = ({ puzzle, difficulty, onSolved, onCan
           <FutoshikiPad
             size={size}
             pencil={pencil}
-            canUndo={canUndoFutoshiki(state)}
+            canUndo={canUndoFutoshiki(state) && !finished}
             exhausted={exhaustedNumbers(values, size)}
-            disabled={!selected}
+            disabled={!selected || finished}
             onNumber={value => {
               reportInput()
               enterNumber(value)
             }}
             onErase={() => {
+              if (finished) return
               reportInput()
               eraseCell()
             }}
@@ -114,6 +140,7 @@ export const FutoshikiPuzzle: FC<Props> = ({ puzzle, difficulty, onSolved, onCan
               togglePencil()
             }}
             onUndo={() => {
+              if (finished) return
               reportInput()
               setState(undoFutoshikiMove)
             }}

--- a/src/mods/puzzle/app/futoshiki/celebration.spec.tsx
+++ b/src/mods/puzzle/app/futoshiki/celebration.spec.tsx
@@ -1,0 +1,145 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest"
+import { render, waitFor, within } from "@testing-library/react"
+import { act } from "react"
+import { FUTOSHIKI_CONFIG } from "@/mods/puzzle/game/futoshiki/futoshikiConfig"
+import {
+  generateFutoshiki,
+  type FutoshikiPuzzle as FutoshikiPuzzleData,
+} from "@/mods/puzzle/game/futoshiki/generateFutoshiki"
+import { FutoshikiPuzzle } from "./FutoshikiPuzzle"
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = () => {}
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+const cellsIn = (root: HTMLElement) =>
+  within(root)
+    .getAllByRole("button")
+    .filter(button => button.className.includes("aspect-square"))
+
+/** The pad's number keys, told from the board's squares by not being square. */
+const padIn = (root: HTMLElement, value: number) =>
+  within(root)
+    .getAllByRole("button", { name: String(value) })
+    .filter(button => !button.className.includes("aspect-square"))[0]
+
+const swelling = (root: HTMLElement) => root.querySelectorAll(".animate-bloom").length
+
+/** Select a square, press the number the answer holds. Givens are already on the board. */
+const solve = (root: HTMLElement, puzzle: FutoshikiPuzzleData) =>
+  puzzle.solution.forEach((row, rowIndex) =>
+    row.forEach((value, colIndex) => {
+      if (puzzle.givens[rowIndex][colIndex] !== undefined) return
+      act(() => cellsIn(root)[rowIndex * puzzle.size + colIndex].click())
+      act(() => padIn(root, value).click())
+    })
+  )
+
+const reducedMotion = (reduce: boolean) =>
+  vi.stubGlobal("matchMedia", (query: string) => ({
+    matches: reduce && query.includes("reduce"),
+    media: query,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  }))
+
+/** What each square is showing, in board order — the roll makes this differ from the answer mid-run. */
+const shown = (root: HTMLElement) => cellsIn(root).map(cell => Number(cell.textContent))
+
+/**
+ * The board finishes itself before the shell hears the word "solved" (`puzzle-screens.md` §3).
+ *
+ * Here the run COUNTS UP: the whole grid rolls to 1, the squares that really are 1 keep it and swell, the rest
+ * roll on to 2, and so on — because order is what this family is about. The constraints are the shared ones:
+ * under a second, no input while it runs, nothing at all under reduced motion.
+ */
+describe("the completion run", () => {
+  it("counts the numbers up before the banner arrives, then reports the solve", { timeout: 120_000 }, async () => {
+    reducedMotion(false)
+    const puzzle = generateFutoshiki(4, 3, FUTOSHIKI_CONFIG.starter)
+    const { container } = render(
+      <FutoshikiPuzzle puzzle={puzzle} difficulty="starter" onSolved={() => {}} onCancel={() => {}} />
+    )
+    solve(container, puzzle)
+
+    // Mid-run: the low numbers have had their turn and the high ones have not, so part of the board is lit.
+    await waitFor(() => expect(swelling(container)).toBeGreaterThan(0))
+    expect(swelling(container)).toBeLessThan(puzzle.size ** 2)
+    expect(within(container).queryByText(/⏱/)).toBeNull()
+
+    // And it does finish — every number has counted, the solve is reported, so the banner follows.
+    await waitFor(() => expect(within(container).getByText(/⏱/)).toBeDefined(), { timeout: 5000 })
+    expect(swelling(container)).toBe(puzzle.size ** 2)
+  })
+
+  it("rolls the unsettled squares to the count while the settled ones keep their own number", async () => {
+    reducedMotion(false)
+    const puzzle = generateFutoshiki(4, 3, FUTOSHIKI_CONFIG.starter)
+    const { container } = render(
+      <FutoshikiPuzzle puzzle={puzzle} difficulty="starter" onSolved={() => {}} onCancel={() => {}} />
+    )
+    solve(container, puzzle)
+    // Mid-roll the board is NOT the answer: a square whose number has not come up yet shows the count, so
+    // every unsettled square shows the same digit.
+    await waitFor(() => expect(swelling(container)).toBeGreaterThan(0))
+    const answer = puzzle.solution.flat()
+    const board = shown(container)
+    const count = Math.max(...board.filter((value, cell) => value !== answer[cell]), 0)
+    expect(count).toBeGreaterThan(0) // the roll is on, so some square is showing the count rather than itself
+    board.forEach((value, cell) => expect(value).toBe(answer[cell] > count ? count : answer[cell]))
+  })
+
+  it("counts up rather than across: every square holding the same number takes its turn together", async () => {
+    reducedMotion(false)
+    const puzzle = generateFutoshiki(4, 3, FUTOSHIKI_CONFIG.starter)
+    const { container } = render(
+      <FutoshikiPuzzle puzzle={puzzle} difficulty="starter" onSolved={() => {}} onCancel={() => {}} />
+    )
+    solve(container, puzzle)
+    // Whatever the run has reached, it is a set of NUMBERS: a square is lit exactly when every square
+    // holding its number is, wherever on the board they stand.
+    await waitFor(() => expect(swelling(container)).toBeGreaterThan(0))
+    const lit = cellsIn(container).map(cell => !!cell.querySelector(".animate-bloom"))
+    const litValues = new Set(
+      puzzle.solution.flatMap((row, rowIndex) =>
+        row.filter((_value, colIndex) => lit[rowIndex * puzzle.size + colIndex])
+      )
+    )
+    expect(litValues.size).toBeGreaterThan(0)
+    puzzle.solution.forEach((row, rowIndex) =>
+      row.forEach((value, colIndex) => expect(lit[rowIndex * puzzle.size + colIndex]).toBe(litValues.has(value)))
+    )
+    // And it counts from the bottom: 1 is in, the grid's highest number is not yet.
+    expect(litValues.has(1)).toBe(true)
+    expect(litValues.has(puzzle.size)).toBe(false)
+  })
+
+  it("refuses input while the board is finishing", async () => {
+    reducedMotion(false)
+    const puzzle = generateFutoshiki(4, 3, FUTOSHIKI_CONFIG.starter)
+    const { container } = render(
+      <FutoshikiPuzzle puzzle={puzzle} difficulty="starter" onSolved={() => {}} onCancel={() => {}} />
+    )
+    solve(container, puzzle)
+    // The pad is shut and undo with it, so nothing can un-solve a board whose win is already on its way.
+    expect(padIn(container, 1).disabled).toBe(true)
+    expect(within(container).getByRole<HTMLButtonElement>("button", { name: /↩/ }).disabled).toBe(true)
+    await waitFor(() => expect(within(container).getByText(/⏱/)).toBeDefined(), { timeout: 5000 })
+  })
+
+  /** A player who asked for less motion gets none of it — and no wait for an animation they will not see. */
+  it("skips the run entirely under prefers-reduced-motion", async () => {
+    reducedMotion(true)
+    const puzzle = generateFutoshiki(4, 3, FUTOSHIKI_CONFIG.starter)
+    const { container } = render(
+      <FutoshikiPuzzle puzzle={puzzle} difficulty="starter" onSolved={() => {}} onCancel={() => {}} />
+    )
+    solve(container, puzzle)
+    expect(swelling(container)).toBe(0)
+    await waitFor(() => expect(within(container).getByText(/⏱/)).toBeDefined(), { timeout: 5000 })
+  })
+})

--- a/src/mods/puzzle/app/futoshiki/celebration.spec.tsx
+++ b/src/mods/puzzle/app/futoshiki/celebration.spec.tsx
@@ -24,7 +24,7 @@ const cellsIn = (root: HTMLElement) =>
 /** The pad's number keys, told from the board's squares by not being square. */
 const padIn = (root: HTMLElement, value: number) =>
   within(root)
-    .getAllByRole("button", { name: String(value) })
+    .getAllByRole<HTMLButtonElement>("button", { name: String(value) })
     .filter(button => !button.className.includes("aspect-square"))[0]
 
 const swelling = (root: HTMLElement) => root.querySelectorAll(".animate-bloom").length

--- a/src/mods/puzzle/app/starBattle/StarBattleBoard.tsx
+++ b/src/mods/puzzle/app/starBattle/StarBattleBoard.tsx
@@ -27,6 +27,8 @@ type Props = {
   decided?: ReadonlySet<number>
   /** The one square the current hint is ABOUT, drawn strongest of all. */
   focus?: number
+  /** The answers that have had their turn in the completion run, so far (`puzzle-screens.md` §3). */
+  celebrated?: ReadonlySet<number>
   onTapCell: (cell: number) => void
   /** A run of squares ruled out in one gesture — see the drag handlers below. */
   onSweepCells: (cells: number[]) => void
@@ -80,6 +82,7 @@ export const StarBattleBoard: FC<Props> = ({
   highlighted,
   decided,
   focus,
+  celebrated,
   onTapCell,
   onSweepCells,
 }) => {
@@ -209,7 +212,7 @@ export const StarBattleBoard: FC<Props> = ({
             )}
           >
             {value === "star" ? (
-              <span className={clsx("block size-full", skin.answer)}>
+              <span className={clsx("block size-full", skin.answer, celebrated?.has(cell) && skin.celebrate)}>
                 <skin.Glyph />
               </span>
             ) : value === "dark" || sweeping.includes(cell) ? (

--- a/src/mods/puzzle/app/starBattle/StarBattlePuzzle.tsx
+++ b/src/mods/puzzle/app/starBattle/StarBattlePuzzle.tsx
@@ -2,6 +2,7 @@ import clsx from "clsx"
 import { useCallback, useMemo, useState, type FC } from "react"
 import { useTranslation } from "react-i18next"
 import type { Difficulty } from "@/data/difficultyLevels"
+import { useCelebration } from "@/mods/core/app/useCelebration"
 import { PuzzleFamilyShell } from "@/mods/core/app/PuzzleFamilyShell"
 import { hintIdleDelay } from "@/mods/core/app/useHintAvailability"
 import {
@@ -47,6 +48,20 @@ export const StarBattlePuzzle: FC<Props> = ({ puzzle, difficulty, role, theme, o
   const hint = useMemo(() => (asked ? buildStarBattleHint(puzzle, state) : undefined), [asked, puzzle, state])
 
   /**
+   * The board finishes itself before the shell is told, one answer at a time.
+   *
+   * The shell freezes the board and starts its banner the moment it hears "solved", so the celebration has to
+   * happen BEFORE that word is said (`puzzle-screens.md` §3) — the family reports the solve a beat later.
+   * Input is refused for that beat, or a tap could clear a star mid-run and the solve would land on a board
+   * that is no longer solved.
+   */
+  const finished = starBattleSolved(puzzle, state)
+  // The answers in reading order, so the run lights them across the board the way it is read.
+  const stars = state.marks.flatMap((value, cell) => (value === "star" ? [cell] : []))
+  const celebration = useCelebration(finished, stars.length)
+  const celebrated = new Set(stars.slice(0, Math.round(celebration.progress * stars.length)))
+
+  /**
    * A function rather than a string, so the shell only reaches for the text once the hint is on screen.
    *
    * Two lines: the reason, then what to do about it. The blank line between them is why the shell keeps its
@@ -67,7 +82,7 @@ export const StarBattlePuzzle: FC<Props> = ({ puzzle, difficulty, role, theme, o
     <PuzzleFamilyShell
       onSolved={onSolved}
       onCancel={onCancel}
-      solved={starBattleSolved(puzzle, state)}
+      solved={celebration.done}
       onReset={() => setState(createStarBattleState(puzzle))}
       hint={hintText}
       onHintRevealed={() => setAsked(true)}
@@ -84,11 +99,14 @@ export const StarBattlePuzzle: FC<Props> = ({ puzzle, difficulty, role, theme, o
             highlighted={hintVisible ? hint?.cells : undefined}
             decided={hintVisible ? hint?.decided : undefined}
             focus={hintVisible ? hint?.focus : undefined}
+            celebrated={celebrated}
             onTapCell={cell => {
+              if (finished) return // the board is finishing; nothing may change under the celebration
               reportInput()
               setState(cycleStarBattleCell(state, cell))
             }}
             onSweepCells={cells => {
+              if (finished) return
               reportInput()
               setState(sweepStarBattleCells(state, cells))
             }}
@@ -101,10 +119,10 @@ export const StarBattlePuzzle: FC<Props> = ({ puzzle, difficulty, role, theme, o
               reportInput()
               setState(undoStarBattle(state))
             }}
-            disabled={!canUndoStarBattle(state)}
+            disabled={!canUndoStarBattle(state) || finished}
             className={clsx(
               "flex h-11 min-w-11 items-center justify-center gap-1 rounded border px-2 text-sm transition-colors",
-              canUndoStarBattle(state)
+              canUndoStarBattle(state) && !finished
                 ? "border-amber-700 bg-amber-950/60 text-amber-200"
                 : "border-stone-700 bg-stone-900 text-stone-600"
             )}

--- a/src/mods/puzzle/app/starBattle/celebration.spec.tsx
+++ b/src/mods/puzzle/app/starBattle/celebration.spec.tsx
@@ -1,0 +1,112 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest"
+import { render, waitFor, within } from "@testing-library/react"
+import { act } from "react"
+import { STAR_BATTLE_CONFIG } from "@/mods/puzzle/game/starBattle/starBattleConfig"
+import { generateStarBattle, type StarBattlePuzzleWithAnswer } from "@/mods/puzzle/game/starBattle/generateStarBattle"
+import { StarBattlePuzzle } from "./StarBattlePuzzle"
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = () => {}
+  Element.prototype.setPointerCapture = () => {}
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+const cellsIn = (root: HTMLElement) =>
+  within(root)
+    .getAllByRole("button")
+    .filter(button => button.className.includes("aspect-square"))
+
+// Either motion counts as "this answer had its turn": the sky blooms (a swell, since a star is a point of
+// light) and the flood plain flares (light only, since a sheaf swelling drags its plot with it).
+const celebrating = (root: HTMLElement) => root.querySelectorAll(".animate-flare, .animate-bloom").length
+
+/** Places every star the answer holds — a star is the second tap — which leaves the board solved. */
+const solve = (root: HTMLElement, puzzle: StarBattlePuzzleWithAnswer) =>
+  puzzle.solution.forEach((star, cell) => {
+    if (!star) return
+    act(() => cellsIn(root)[cell].click())
+    act(() => cellsIn(root)[cell].click())
+  })
+
+const reducedMotion = (reduce: boolean) =>
+  vi.stubGlobal("matchMedia", (query: string) => ({
+    matches: reduce && query.includes("reduce"),
+    media: query,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  }))
+
+/**
+ * The board finishes itself before the shell hears the word "solved" — the ordering constellation and
+ * lightbeam already run (`puzzle-screens.md` §3), on the family that shares constellation's two places.
+ *
+ * That ordering is the whole feature: the shell freezes the board and starts its banner on `solved`, so a
+ * celebration has to run first — and inside about a second, because the shell stops its solve-time clock at
+ * that same moment and that number is what PUZZLE_FAMILIES.md §3.2's budget is measured with.
+ */
+describe("the completion run", () => {
+  it("lights the answers before the banner arrives, then reports the solve", { timeout: 120_000 }, async () => {
+    reducedMotion(false)
+    const puzzle = generateStarBattle(4, STAR_BATTLE_CONFIG.starter)
+    const { container } = render(
+      <StarBattlePuzzle puzzle={puzzle} difficulty="starter" onSolved={() => {}} onCancel={() => {}} />
+    )
+    solve(container, puzzle)
+
+    // Mid-run: answers are finishing one at a time, and the banner has not landed.
+    await waitFor(() => expect(celebrating(container)).toBeGreaterThan(0))
+    expect(within(container).queryByText(/⏱/)).toBeNull()
+
+    // And it does finish — the solve is reported, so the banner follows.
+    await waitFor(() => expect(within(container).getByText(/⏱/)).toBeDefined(), { timeout: 5000 })
+  })
+
+  it("swells a star and only brightens a farmstead", { timeout: 120_000 }, () => {
+    reducedMotion(false)
+    const puzzle = generateStarBattle(4, STAR_BATTLE_CONFIG.starter)
+    const sky = render(
+      <StarBattlePuzzle puzzle={puzzle} difficulty="starter" onSolved={() => {}} onCancel={() => {}} />
+    )
+    const plain = render(
+      <StarBattlePuzzle puzzle={puzzle} difficulty="starter" theme="fields" onSolved={() => {}} onCancel={() => {}} />
+    )
+    solve(sky.container, puzzle)
+    solve(plain.container, puzzle)
+    return waitFor(() => {
+      expect(sky.container.querySelectorAll(".animate-bloom").length).toBeGreaterThan(0)
+      expect(plain.container.querySelectorAll(".animate-bloom")).toHaveLength(0)
+      expect(plain.container.querySelectorAll(".animate-flare").length).toBeGreaterThan(0)
+    })
+  })
+
+  it("refuses input while the board is finishing", { timeout: 120_000 }, async () => {
+    reducedMotion(false)
+    const puzzle = generateStarBattle(4, STAR_BATTLE_CONFIG.starter)
+    const { container } = render(
+      <StarBattlePuzzle puzzle={puzzle} difficulty="starter" onSolved={() => {}} onCancel={() => {}} />
+    )
+    solve(container, puzzle)
+    // A tap on a placed star would clear it, un-solving a board whose win is already on its way — so the
+    // run finishes and the banner still lands.
+    const starCell = puzzle.solution.findIndex(Boolean)
+    act(() => cellsIn(container)[starCell].click())
+    // Undo would take the last star back out, for the same reason.
+    expect(within(container).getByRole<HTMLButtonElement>("button", { name: /↩/ }).disabled).toBe(true)
+    await waitFor(() => expect(within(container).getByText(/⏱/)).toBeDefined(), { timeout: 5000 })
+  })
+
+  /** A player who asked for less motion gets none of it — and no wait for an animation they will not see. */
+  it("skips the run entirely under prefers-reduced-motion", { timeout: 120_000 }, async () => {
+    reducedMotion(true)
+    const puzzle = generateStarBattle(4, STAR_BATTLE_CONFIG.starter)
+    const { container } = render(
+      <StarBattlePuzzle puzzle={puzzle} difficulty="starter" onSolved={() => {}} onCancel={() => {}} />
+    )
+    solve(container, puzzle)
+    expect(celebrating(container)).toBe(0)
+    await waitFor(() => expect(within(container).getByText(/⏱/)).toBeDefined(), { timeout: 5000 })
+  })
+})

--- a/src/mods/puzzle/app/starBattle/skins.ts
+++ b/src/mods/puzzle/app/starBattle/skins.ts
@@ -58,6 +58,11 @@ export type StarBattleSkin = {
   evidence: string
   focus: string
   conflict: string
+  /** What an answer wears for its turn in the completion run (`puzzle-screens.md` §3), and it is a per-skin
+   *  choice rather than one house style: a STAR swelling as it brightens reads as catching the light, and the
+   *  same swell on a sheaf standing in a plot — a thing rooted in the ground — reads as the board twitching.
+   *  So the sky blooms and the flood plain only flares (see index.css). */
+  celebrate: string
 }
 
 const SKINS: Record<string, StarBattleSkin> = {
@@ -82,6 +87,8 @@ const SKINS: Record<string, StarBattleSkin> = {
     evidence: "ring-sky-300/60",
     focus: "ring-amber-300",
     conflict: "ring-red-500/80",
+    // Stars twinkle, size and all: a star is a point of light, so a swell IS the reading.
+    celebrate: "animate-bloom",
   },
   /**
    * **Farmsteads on the flood plain** (PUZZLE_FAMILIES.md §11.1, Water & Agriculture, and the family doc
@@ -118,6 +125,8 @@ const SKINS: Record<string, StarBattleSkin> = {
     evidence: "ring-sky-800/70",
     focus: "ring-emerald-950",
     conflict: "ring-red-800",
+    // Light only. A sheaf standing in a plot cannot swell without the plot appearing to move with it.
+    celebrate: "animate-flare",
   },
 }
 

--- a/src/mods/puzzle/app/sumplete/SumpleteBoard.tsx
+++ b/src/mods/puzzle/app/sumplete/SumpleteBoard.tsx
@@ -12,6 +12,11 @@ type Props = {
   highlighted?: ReadonlySet<string>
   /** The line the hint reasons about — lit so "this line still needs 6" points somewhere. */
   litLine?: { kind: "row" | "col"; index: number }
+  /**
+   * How many lines the completion run has checked off (`puzzle-screens.md` §3): the rows top to bottom first,
+   * then the columns left to right. Unset means no run.
+   */
+  checked?: number
   onToggle: (row: number, col: number) => void
 }
 
@@ -54,8 +59,10 @@ const lineCls = (line: SumpleteLine) =>
 
 // The target is white for contrast — it is the number the player reads on every glance. The live
 // total keeps the line's status colour, so over/under/exact still reads at a distance.
-const LineTarget: FC<{ line: SumpleteLine }> = ({ line }) => (
-  <div className={lineCls(line)}>
+const LineTarget: FC<{ line: SumpleteLine; checking?: boolean }> = ({ line, checking }) => (
+  // The run flares the target rather than the numbers, because the target IS the claim: a line that adds up
+  // is what this board wins by, and it is already the thing that turns green when it does.
+  <div className={clsx(lineCls(line), checking && "animate-flare")}>
     <span className="text-[min(5.5vw,1.35rem)] leading-none font-bold text-white">{line.target}</span>
     <span className="text-[min(3.4vw,0.8rem)] leading-none opacity-80">{line.total}</span>
   </div>
@@ -65,7 +72,7 @@ const LineTarget: FC<{ line: SumpleteLine }> = ({ line }) => (
 // plus its target column and row — has to fit a phone screen without pan or zoom
 // (docs/instructions/puzzle-screens.md §1). Width comes from the container rather than from `vw`, so
 // the modal's own padding can never push the board past the screen edge.
-export const SumpleteBoard: FC<Props> = ({ grid, cells, rows, cols, highlighted, litLine, onToggle }) => {
+export const SumpleteBoard: FC<Props> = ({ grid, cells, rows, cols, highlighted, litLine, checked, onToggle }) => {
   const size = grid.length
   const inLitLine = (row: number, col: number) =>
     litLine ? (litLine.kind === "row" ? litLine.index === row : litLine.index === col) : false
@@ -94,11 +101,13 @@ export const SumpleteBoard: FC<Props> = ({ grid, cells, rows, cols, highlighted,
               )}
             </button>
           ))}
-          <LineTarget line={rows[row]} />
+          {/* The rows are checked off first, so a row's turn is its own index. */}
+          <LineTarget line={rows[row]} checking={checked !== undefined && row < checked} />
         </div>
       ))}
       {cols.map((line, col) => (
-        <LineTarget key={col} line={line} />
+        // The columns follow the rows, so their turns run from `size` up.
+        <LineTarget key={col} line={line} checking={checked !== undefined && size + col < checked} />
       ))}
     </div>
   )

--- a/src/mods/puzzle/app/sumplete/SumpletePuzzle.tsx
+++ b/src/mods/puzzle/app/sumplete/SumpletePuzzle.tsx
@@ -6,6 +6,7 @@ import { buildSumpleteHint } from "@/mods/puzzle/app/sumplete/sumpleteHint"
 import { computeColLines, computeRowLines, isSumpleteSolved } from "@/mods/puzzle/game/sumplete/sumpleteStatus"
 import { createSumpleteState, toggleSumpleteCell } from "@/mods/puzzle/game/sumplete/sumpleteState"
 import type { SumpleteGrid } from "@/mods/puzzle/game/sumplete/generateSumplete"
+import { useCelebration } from "@/mods/core/app/useCelebration"
 import { PuzzleFamilyShell } from "@/mods/core/app/PuzzleFamilyShell"
 import { hintIdleDelay } from "@/mods/core/app/useHintAvailability"
 import type { Difficulty } from "@/data/difficultyLevels"
@@ -27,6 +28,27 @@ export const SumpletePuzzle: FC<Props> = ({ puzzle, difficulty, onSolved, onCanc
   const rows = computeRowLines(grid, state.cells, rowTargets)
   const cols = computeColLines(grid, state.cells, colTargets)
 
+  /**
+   * The board finishes itself before the shell is told, by checking its own sums off: the row targets flare
+   * top to bottom, then the column targets left to right.
+   *
+   * The shell freezes the board and starts its banner the moment it hears "solved", so the celebration has to
+   * happen BEFORE that word is said (`puzzle-screens.md` §3) — the family reports the solve a beat later, and
+   * input is refused for that beat, or a number toggled mid-run would land a solve on a board that is no
+   * longer solved.
+   *
+   * **A tick is a LINE, and what flares is the TARGET.** The targets are what this board wins by — every row
+   * and every column hitting its number — so a run down them is the board checking its own claim, in the two
+   * directions the claim is made in. Flaring the numbers instead would celebrate the arithmetic rather than
+   * the result, and the struck numbers are as much of the answer as the kept ones.
+   *
+   * Read off `progress` rather than `done`, so a run skipped for reduced motion never starts.
+   */
+  const finished = isSumpleteSolved(rows, cols)
+  const lines = grid.length * 2
+  const celebration = useCelebration(finished, lines)
+  const checked = celebration.progress > 0 ? Math.round(celebration.progress * lines) : undefined
+
   const hint = useMemo(
     () => buildSumpleteHint({ grid, rowTargets, colTargets }, state.cells, solution, techniqueCap),
     [grid, rowTargets, colTargets, state.cells, solution, techniqueCap]
@@ -36,7 +58,7 @@ export const SumpletePuzzle: FC<Props> = ({ puzzle, difficulty, onSolved, onCanc
     <PuzzleFamilyShell
       onSolved={onSolved}
       onCancel={onCancel}
-      solved={isSumpleteSolved(rows, cols)}
+      solved={celebration.done}
       onReset={() => setState(createSumpleteState(grid.length))}
       // Two lines: the reason, then the move it asks for (`puzzle-screens.md` §4).
       hint={
@@ -60,7 +82,9 @@ export const SumpletePuzzle: FC<Props> = ({ puzzle, difficulty, onSolved, onCanc
           cols={cols}
           highlighted={hintVisible ? hint?.cells : undefined}
           litLine={hintVisible ? hint?.line : undefined}
+          checked={checked}
           onToggle={(row, col) => {
+            if (finished) return // the board is finishing; nothing may change under the celebration
             reportInput()
             toggle(row, col)
           }}

--- a/src/mods/puzzle/app/sumplete/celebration.spec.tsx
+++ b/src/mods/puzzle/app/sumplete/celebration.spec.tsx
@@ -1,0 +1,106 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest"
+import { render, waitFor, within } from "@testing-library/react"
+import { act } from "react"
+import { SUMPLETE_CONFIG } from "@/mods/puzzle/game/sumplete/sumpleteConfig"
+import { generateSumplete, type SumpleteGrid } from "@/mods/puzzle/game/sumplete/generateSumplete"
+import { SumpletePuzzle } from "./SumpletePuzzle"
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = () => {}
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+const cellsIn = (root: HTMLElement) =>
+  within(root)
+    .getAllByRole("button")
+    .filter(button => button.className.includes("aspect-square"))
+
+const flaring = (root: HTMLElement) => root.querySelectorAll(".animate-flare").length
+
+/** One tap crosses a number out, and crossing out the ones the answer drops is the whole solve. */
+const solve = (root: HTMLElement, puzzle: SumpleteGrid) =>
+  puzzle.solution.forEach((row, rowIndex) =>
+    row.forEach((keep, colIndex) => {
+      if (keep) return
+      act(() => cellsIn(root)[rowIndex * puzzle.grid.length + colIndex].click())
+    })
+  )
+
+const reducedMotion = (reduce: boolean) =>
+  vi.stubGlobal("matchMedia", (query: string) => ({
+    matches: reduce && query.includes("reduce"),
+    media: query,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  }))
+
+/**
+ * The board finishes itself before the shell hears the word "solved" (`puzzle-screens.md` §3).
+ *
+ * Here the run checks the sums off: the row targets flare top to bottom, then the column targets left to
+ * right — the board making its own claim in the two directions the claim is made in. The constraints are the
+ * shared ones: under a second, no input while it runs, nothing at all under reduced motion.
+ */
+describe("the completion run", () => {
+  it("checks the targets off before the banner arrives, then reports the solve", { timeout: 120_000 }, async () => {
+    reducedMotion(false)
+    const puzzle = generateSumplete(SUMPLETE_CONFIG.starter.size, 4, SUMPLETE_CONFIG.starter)
+    const { container } = render(
+      <SumpletePuzzle puzzle={puzzle} difficulty="starter" onSolved={() => {}} onCancel={() => {}} />
+    )
+    solve(container, puzzle)
+
+    // Mid-run: some targets have been checked off and some have not, and the banner has not landed.
+    const targets = puzzle.grid.length * 2
+    await waitFor(() => expect(flaring(container)).toBeGreaterThan(0))
+    expect(flaring(container)).toBeLessThan(targets)
+    expect(within(container).queryByText(/⏱/)).toBeNull()
+
+    // And it does finish — every line is checked, the solve is reported, so the banner follows.
+    await waitFor(() => expect(within(container).getByText(/⏱/)).toBeDefined(), { timeout: 5000 })
+    expect(flaring(container)).toBe(targets)
+  })
+
+  it("runs the rows before the columns", { timeout: 120_000 }, async () => {
+    reducedMotion(false)
+    const puzzle = generateSumplete(SUMPLETE_CONFIG.starter.size, 4, SUMPLETE_CONFIG.starter)
+    const { container } = render(
+      <SumpletePuzzle puzzle={puzzle} difficulty="starter" onSolved={() => {}} onCancel={() => {}} />
+    )
+    solve(container, puzzle)
+    // The first row's target is checked off first; the last column's is last, so it is still waiting.
+    await waitFor(() => expect(flaring(container)).toBeGreaterThan(0))
+    const flared = [...container.querySelectorAll(".animate-flare")]
+    const all = [...container.querySelectorAll("[class*='aspect-square']")].filter(node => node.tagName === "DIV")
+    expect(flared[0]).toBe(all[0]) // the first row's target
+    expect(flared).not.toContain(all[all.length - 1]) // the last column's target
+  })
+
+  it("refuses input while the board is finishing", { timeout: 120_000 }, async () => {
+    reducedMotion(false)
+    const puzzle = generateSumplete(SUMPLETE_CONFIG.starter.size, 4, SUMPLETE_CONFIG.starter)
+    const { container } = render(
+      <SumpletePuzzle puzzle={puzzle} difficulty="starter" onSolved={() => {}} onCancel={() => {}} />
+    )
+    solve(container, puzzle)
+    // Toggling a number would un-solve a board whose win is already on its way, so the tap is dropped and
+    // the run still finishes.
+    act(() => cellsIn(container)[0].click())
+    await waitFor(() => expect(within(container).getByText(/⏱/)).toBeDefined(), { timeout: 5000 })
+  })
+
+  /** A player who asked for less motion gets none of it — and no wait for an animation they will not see. */
+  it("skips the run entirely under prefers-reduced-motion", { timeout: 120_000 }, async () => {
+    reducedMotion(true)
+    const puzzle = generateSumplete(SUMPLETE_CONFIG.starter.size, 4, SUMPLETE_CONFIG.starter)
+    const { container } = render(
+      <SumpletePuzzle puzzle={puzzle} difficulty="starter" onSolved={() => {}} onCancel={() => {}} />
+    )
+    solve(container, puzzle)
+    expect(flaring(container)).toBe(0)
+    await waitFor(() => expect(within(container).getByText(/⏱/)).toBeDefined(), { timeout: 5000 })
+  })
+})


### PR DESCRIPTION
Five puzzle families gain a completion run, and the puzzle lab gains the two boards a tomb serves — which is how the crocodile's layout bug surfaced.

## The runs

Each is drawn from the family's own instrument rather than one house style (`puzzle-screens.md` §3, `useCelebration.ts` supplies only the clock):

| Family | What it does |
| --- | --- |
| **star battle** | lights its answers in reading order — the sky swells (a star is a point of light), the flood plain only brightens (a sheaf is rooted in soil) |
| **balance scale** | rocks each beam level with its pans riding it, top to bottom |
| **eclipse** | sweeps one diagonal at a time, corner to far corner — a tick is a diagonal, so a 49-square wizard board reads as a wave rather than a flicker |
| **futoshiki** | counts up: the grid rolls to 1, the squares that really are 1 keep it and swell, the rest roll on to 2 |
| **sumplete** | checks its own sums off — row targets top to bottom, then column targets left to right |

All five report the solve a beat later, refuse every input while the run plays, and read the run off the clock's `progress` rather than its `done`. That last one is the reduced-motion fix: a skipped run reports done with progress still at 0, so the run never starts and the board is never anything but the answer the player filled in.

No new CSS beyond one `settle`/`bob` pair for the balance beam and its pans — the rest reuse `animate-bloom` and `animate-flare`.

## Puzzle lab

`playableInLab` admits `tomb-puzzle` and `capstone` alongside `puzzle`, so the crocodile capstone and the tableau can be played without walking a real tomb to the floor that serves them. Neither needs a tomb around it to generate. **A tableau still needs its hieroglyphs** — filling a slot asks the save for a completed one, and the lab grants nothing, so it plays only as far as collected fragments allow.

## Crocodile fix

Playing it in the lab showed it drawing on top of itself, in play as much as on the bench:

- Its scene is entirely absolutely positioned but asked a parent for its height with `flex-1`. The puzzle shell shrink-wraps a board, so there was none — the stage measured 0×0 and prompt, chest and crocodiles landed on one line.
- The crocodile row was `w-dvw`, which reached past a modal narrower than the screen and clipped the sum either side of the crocodile.

Both now size to the room they are in.

## Testing

- A `celebration.spec.tsx` per family: run-before-banner, the family's own motion, input refused, reduced-motion skipped. Two are mutation-checked (dropping balance scale's guard and swapping sumplete's row/column order both fail).
- The crocodile fix is layout only, so it was checked in the browser with measured boxes at 390×760 and 360×640, junior through wizard: sums inside the stage at every tier, no horizontal overflow. jsdom has no layout engine to test it against.
- Full suite: 202 files, 2319 tests green. Lint 0 errors, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016TDausBqovq27A8D5njK8s