### PR TITLE
The farmland board asks for farmsteads, so it draws one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- The farmland star grid asked for farmsteads and drew a sheaf of grain, so the board looked like it wanted plants sown. It now draws a farmstead: a domed mud-brick house with its doorway.
+
 ## 0.38.2 - 2026-08-23
+
+### Fixed
+
+- The crocodile capstone no longer draws on top of itself. Its scene had no height of its own, so the prompt, the chest and the crocodiles all landed on one line; the sums either side of the crocodile were also cut off at the edges of the room. Both are now sized to the room they are in.
 
 ### Changed
 

--- a/docs/game-design/puzzles/star-battle.md
+++ b/docs/game-design/puzzles/star-battle.md
@@ -480,7 +480,7 @@ Three constraints, each of them the interesting part rather than the animation:
 - **`prefers-reduced-motion` skips it whole**, animation and wait together.
 
 **What the motion IS belongs to the place, and the two differ.** A star is a point of light, so it swells as
-it brightens and the size is part of the reading. A sheaf standing in a plot is rooted in the ground, and the
+it brightens and the size is part of the reading. A farmstead standing in a plot is set in the ground, and the
 same swell there reads as the plot moving with it — so the flood plain brightens only. The same split
 constellation draws between its sky and its basins, for the same reason.
 
@@ -608,7 +608,9 @@ Candidates, none built:
 | Fields  | irrigation channels | holdings  | two households cannot share a well |
 
 **Fields is built** (`app/starBattle/skins.ts`): daylight on tilled earth, the channels
-between holdings drawn as the water they are, and a bound sheaf standing where a star would.
+between holdings drawn as the water they are, and a domed farmstead standing where a star would — a dwelling,
+because the rules are about dwellings: two of them touching would share one well, which is a thing a household
+does and a crop does not.
 Every sentence under the board is its own — the goal, both rules and all thirty-odd hint
 lines — because a shared template with a noun in a slot breaks on the first locale that
 inflects around it (`puzzle-screens.md` §4.3), and `goalWording.spec.ts` holds a farm to

--- a/src/i18n/plurals.spec.ts
+++ b/src/i18n/plurals.spec.ts
@@ -111,13 +111,13 @@ describe("plural forms in the shipped locales", () => {
    */
   it.each([
     ["starBattle.hint.fields.groupTight.region", "en", 2, "This holding is down to 2 plots."],
-    ["starBattle.hint.fields.onlyWay.region", "en", 2, "There is only one way to fit 2 🌾 on this holding."],
-    ["starBattle.hint.fields.action.place", "en", 2, "Raise a 🌾 on each hatched plot."],
+    ["starBattle.hint.fields.onlyWay.region", "en", 2, "There is only one way to fit 2 🛖 on this holding."],
+    ["starBattle.hint.fields.action.place", "en", 2, "Raise a 🛖 on each hatched plot."],
     ["starBattle.hint.fields.groupTight.region", "nl", 2, "Dit stuk land heeft nog 2 akkers over."],
-    ["starBattle.hint.fields.onlyWay.region", "nl", 2, "Er is maar één manier om 2 🌾 op dit stuk land te zetten."],
-    ["starBattle.hint.fields.action.place", "nl", 2, "Zet een 🌾 op elke gearceerde akker."],
+    ["starBattle.hint.fields.onlyWay.region", "nl", 2, "Er is maar één manier om 2 🛖 op dit stuk land te zetten."],
+    ["starBattle.hint.fields.action.place", "nl", 2, "Zet een 🛖 op elke gearceerde akker."],
   ])("renders %s in %s for %i as %s", (key, lng, count, expected) => {
-    expect(t(lng, key, { count, token: "🌾" })).toBe(expected)
+    expect(t(lng, key, { count, token: "🛖" })).toBe(expected)
   })
 
   it.each([

--- a/src/mods/puzzle/app/starBattle/celebration.spec.tsx
+++ b/src/mods/puzzle/app/starBattle/celebration.spec.tsx
@@ -20,7 +20,7 @@ const cellsIn = (root: HTMLElement) =>
     .filter(button => button.className.includes("aspect-square"))
 
 // Either motion counts as "this answer had its turn": the sky blooms (a swell, since a star is a point of
-// light) and the flood plain flares (light only, since a sheaf swelling drags its plot with it).
+// light) and the flood plain flares (light only, since a farmstead swelling drags its plot with it).
 const celebrating = (root: HTMLElement) => root.querySelectorAll(".animate-flare, .animate-bloom").length
 
 /** Places every star the answer holds — a star is the second tap — which leaves the board solved. */

--- a/src/mods/puzzle/app/starBattle/glyphs.tsx
+++ b/src/mods/puzzle/app/starBattle/glyphs.tsx
@@ -21,21 +21,30 @@ export const Star: FC = () => (
 )
 
 /**
- * The answer over farmland: a sheaf standing in a plot.
+ * The answer over farmland: a farmstead standing in a plot — a domed mud-brick granary with its doorway.
  *
- * A building would be the literal reading of "farmstead" and it is the wrong one — at 30px a little house is
- * a box, and a box is what an empty square already looks like. A sheaf is bound at the waist and splayed at
- * both ends, so it keeps a shape nothing else on this board has.
+ * **It is a dwelling and not a crop, because the words are about dwellings**: the rules say no two may touch
+ * since that close they would share one well, and a well is something a household draws from. A board that drew
+ * a plant here would be asking the player to sow rather than to settle, and every sentence around it says
+ * settle.
+ *
+ * A square little house would be the obvious drawing and it is the wrong one — at 30px a house is a box, and a
+ * box is what an empty square already looks like. A dome over an arched door keeps a curve nothing else on
+ * this board has: the answer is round where a star is spiky and the player's own mark is a dot.
  */
-export const Sheaf: FC = () => (
+export const Farmstead: FC = () => (
   <svg viewBox="-50 -50 100 100" className="size-full" aria-hidden focusable="false">
-    <g fill="none" stroke="currentColor" strokeWidth={9} strokeLinecap="round">
-      {/* Three stalks fanning out of one binding, and the ears that make them grain rather than grass. */}
-      <path d="M 0 40 L 0 -34" />
-      <path d="M 0 24 C -16 6, -22 -12, -22 -30" />
-      <path d="M 0 24 C 16 6, 22 -12, 22 -30" />
-      {/* The band. Drawn heavier, because it is what says these are gathered rather than growing. */}
-      <path d="M -15 22 L 15 22" strokeWidth={11} />
+    <g fill="none" stroke="currentColor" strokeWidth={9} strokeLinecap="round" strokeLinejoin="round">
+      {/* The dome, closed along its own base so the shape reads as solid rather than as an arch. It fills the
+          square nearly top to bottom: drawn shorter it read as a mound with a notch in it rather than as
+          somewhere anybody lives. */}
+      <path d="M -31 34 A 34 46 0 0 1 31 34 Z" />
+      {/* The doorway, which is what makes the dome a building rather than a hill. Wide enough to still be a
+          door at 30px, where a slit closes up. */}
+      <path d="M -12 34 L -12 2 A 12 12 0 0 1 12 2 L 12 34" />
+      {/* The ground it stands on. Drawn heavier than the rest, because it is what sets the farmstead IN the
+          plot rather than floating in it. */}
+      <path d="M -38 34 L 38 34" strokeWidth={11} />
     </g>
   </svg>
 )

--- a/src/mods/puzzle/app/starBattle/skins.ts
+++ b/src/mods/puzzle/app/starBattle/skins.ts
@@ -1,5 +1,5 @@
 import type { FC } from "react"
-import { Sheaf, Star } from "./glyphs"
+import { Farmstead, Star } from "./glyphs"
 
 /**
  * What each of this mechanic's places looks like, and how a room works out which place it is.
@@ -60,7 +60,7 @@ export type StarBattleSkin = {
   conflict: string
   /** What an answer wears for its turn in the completion run (`puzzle-screens.md` §3), and it is a per-skin
    *  choice rather than one house style: a STAR swelling as it brightens reads as catching the light, and the
-   *  same swell on a sheaf standing in a plot — a thing rooted in the ground — reads as the board twitching.
+   *  same swell on a farmstead standing in a plot — a building set in the ground — reads as the board twitching.
    *  So the sky blooms and the flood plain only flares (see index.css). */
   celebrate: string
 }
@@ -98,7 +98,7 @@ const SKINS: Record<string, StarBattleSkin> = {
    *
    * **Daylight, which is the deliberate opposite of the sky the same board wears by default** — you work a
    * field under the sun. Everything follows from the ground being LIGHT: the walls are the water in the
-   * channels between holdings, the sheaf is dark against the soil rather than glowing on it, and the hint
+   * channels between holdings, the farmstead is dark against the soil rather than glowing on it, and the hint
    * rings are drawn in ink instead of light.
    *
    * Worn by both families on this board. Two households to a holding is the fiction the place was written
@@ -109,7 +109,7 @@ const SKINS: Record<string, StarBattleSkin> = {
    */
   fields: {
     name: "fields",
-    token: "🌾",
+    token: "🛖",
     // Tilled earth, and the ruled-out square is ground already in somebody's shadow.
     cell: "bg-[#e0c896]",
     spent: "bg-[#c9ac74]",
@@ -118,14 +118,14 @@ const SKINS: Record<string, StarBattleSkin> = {
     wall: "rgb(3 105 161 / 0.9)",
     // A furrow inside one holding: countable, but nothing to reason from.
     seam: "rgb(120 53 15 / 0.35)",
-    Glyph: Sheaf,
+    Glyph: Farmstead,
     answer: "text-emerald-900",
     dark: "text-stone-700/70",
     hatch: "rgba(120,53,15,0.4)",
     evidence: "ring-sky-800/70",
     focus: "ring-emerald-950",
     conflict: "ring-red-800",
-    // Light only. A sheaf standing in a plot cannot swell without the plot appearing to move with it.
+    // Light only. A farmstead standing in a plot cannot swell without the plot appearing to move with it.
     celebrate: "animate-flare",
   },
 }


### PR DESCRIPTION
Playing the farmland face of the star grid showed the words and the picture disagreeing: every sentence under the board is about **dwellings** — "no two farmsteads may touch, that close they would share one well" — while the glyph was a bound sheaf of grain, so the board read as asking the player to sow.

The fiction is the documented one (§11.3), and the rules are built on it: a well is something a household draws from, not a crop. So the drawing is what gives.

- `Sheaf` → `Farmstead`: a domed mud-brick house with an arched doorway, stroked the same way.
- Hint token `🌾` → `🛖`, so "Raise a 🛖 on each hatched plot" matches what is drawn.
- All ~40 strings unchanged, in both languages. `plurals.spec` fixtures follow the new token.

A square little house was the obvious drawing and the wrong one: at 30px a house is a box, and a box is what an empty square already looks like. A dome over a door keeps a curve nothing else on this board has — the star is spiky, the player's own mark is a dot.

## Testing

Layout and legibility, so it was checked in the browser (puzzle lab, star-battle + `agriculture` role) at 390×760: starter's 70px cells and wizard's 44px, where it still reads as a building. The first draft sat too low and read as a mound with a notch in it, so it stands taller now.

`yarn check-types`, lint and the i18n + star-battle suites (100 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016TDausBqovq27A8D5njK8s