### PR TITLE
Sudoku: a roll that reads as a roll on a phone

### DIFF
--- a/docs/game-design/puzzles/sudoku.md
+++ b/docs/game-design/puzzles/sudoku.md
@@ -297,6 +297,16 @@ the solved board is the reward and the banner sits over it readable
 before the player had looked at it. The run is a wave crossing the register and leaving
 it as the player filled it in.
 
+**A roll goes two thirds up its chamber and no further**, and it takes the whole second
+the shell allows rather than the eight tenths the value run needs. Both are the same
+lesson, and both are read off a phone rather than off a still: what a roll has to show
+is an EDGE travelling, and it shows nothing where it has arrived. Taken to the head of
+its chamber the sheet covers every square in it, so the chamber becomes a flat
+rectangle — six of those blinking in and out is a board coming apart rather than a
+register being filed. Run at the value run's pace, the edges cross too fast to be read
+as edges at all. Stopping short keeps a strip of writing under every roll for the whole
+of its travel.
+
 The sheets are a layer laid OVER the grid rather than the squares moving: six squares
 each scaling about their own middle is six squares shrinking, not one sheet rolling.
 What a taken-up chamber uncovers is the board's own ground, the table the sheet lay on.

--- a/docs/game-design/puzzles/sudoku.md
+++ b/docs/game-design/puzzles/sudoku.md
@@ -297,15 +297,11 @@ the solved board is the reward and the banner sits over it readable
 before the player had looked at it. The run is a wave crossing the register and leaving
 it as the player filled it in.
 
-**A roll goes two thirds up its chamber and no further**, and it takes the whole second
-the shell allows rather than the eight tenths the value run needs. Both are the same
-lesson, and both are read off a phone rather than off a still: what a roll has to show
-is an EDGE travelling, and it shows nothing where it has arrived. Taken to the head of
-its chamber the sheet covers every square in it, so the chamber becomes a flat
-rectangle — six of those blinking in and out is a board coming apart rather than a
-register being filed. Run at the value run's pace, the edges cross too fast to be read
-as edges at all. Stopping short keeps a strip of writing under every roll for the whole
-of its travel.
+**A roll goes two thirds up its chamber, and the run takes the full second the shell
+allows.** What a roll shows is an edge travelling, and it shows nothing where it has
+arrived: taken to the head of its chamber the sheet covers every square in it, and six
+flat rectangles blinking in and out is a board coming apart rather than a register being
+filed.
 
 The sheets are a layer laid OVER the grid rather than the squares moving: six squares
 each scaling about their own middle is six squares shrinking, not one sheet rolling.

--- a/src/index.css
+++ b/src/index.css
@@ -129,10 +129,8 @@ body {
     0% {
       translate: 0 106%;
     }
-    /* **Two thirds up, and no further.** Taken to the head of the chamber the sheet covers every square
-       in it, and a covered chamber is a flat rectangle — six of those blinking in and out is a board
-       coming apart rather than a register being rolled. Stopping short keeps a strip of writing under
-       the roll the whole way, which is the thing that says a sheet is being taken up. */
+    /* Two thirds up, and no further: a chamber taken all the way is a flat rectangle, and the strip of
+       writing left under the roll is what says a sheet is being taken up (design doc §9.1). */
     55% {
       translate: 0 34%;
     }

--- a/src/index.css
+++ b/src/index.css
@@ -124,15 +124,17 @@ body {
 
      `translate` rather than `transform`, so an element's resting offset is what it returns to when the
      animation is over — here that is "rolled clear of the chamber", i.e. covering nothing at all. */
-  --animate-furl: furl 420ms ease-in-out;
+  --animate-furl: furl 520ms ease-in-out;
   @keyframes furl {
     0% {
       translate: 0 106%;
     }
-    /* Stopping a hair short of the head of the chamber, so the roll itself is still whole at the top of
-       its travel: a roll drawn ON the edge is a roll with half of it cut off by the chamber above. */
+    /* **Two thirds up, and no further.** Taken to the head of the chamber the sheet covers every square
+       in it, and a covered chamber is a flat rectangle — six of those blinking in and out is a board
+       coming apart rather than a register being rolled. Stopping short keeps a strip of writing under
+       the roll the whole way, which is the thing that says a sheet is being taken up. */
     55% {
-      translate: 0 4%;
+      translate: 0 34%;
     }
     100% {
       translate: 0 106%;

--- a/src/mods/puzzle/app/sudoku/SudokuPuzzle.tsx
+++ b/src/mods/puzzle/app/sudoku/SudokuPuzzle.tsx
@@ -93,7 +93,11 @@ export const SudokuPuzzle: FC<Props> = ({ puzzle, difficulty, role, theme, onSol
   // six values and six chambers — but they are asked for separately, because they are different claims
   // and a grid cut another way would separate them.
   const ticks = skin.scroll ? boxCount(puzzle) : size
-  const celebration = useCelebration(finished, ticks)
+  // A roll asks for the whole second the shell allows, where a value only needs its flare: what a roll
+  // has to show is an EDGE travelling, and six of them crossing a phone-sized board in eight tenths of a
+  // second read as squares blinking rather than as sheets being taken up. One second is the ceiling
+  // (`useCelebration.ts`), not a preference — the shell's solve-time clock stops when it hears "solved".
+  const celebration = useCelebration(finished, ticks, skin.scroll ? 1000 : undefined)
   const reached = celebration.progress > 0 ? Math.round(celebration.progress * ticks) : undefined
   const counted = skin.scroll ? undefined : reached
   const rolled = skin.scroll ? reached : undefined

--- a/src/mods/puzzle/app/sudoku/SudokuPuzzle.tsx
+++ b/src/mods/puzzle/app/sudoku/SudokuPuzzle.tsx
@@ -93,10 +93,8 @@ export const SudokuPuzzle: FC<Props> = ({ puzzle, difficulty, role, theme, onSol
   // six values and six chambers — but they are asked for separately, because they are different claims
   // and a grid cut another way would separate them.
   const ticks = skin.scroll ? boxCount(puzzle) : size
-  // A roll asks for the whole second the shell allows, where a value only needs its flare: what a roll
-  // has to show is an EDGE travelling, and six of them crossing a phone-sized board in eight tenths of a
-  // second read as squares blinking rather than as sheets being taken up. One second is the ceiling
-  // (`useCelebration.ts`), not a preference — the shell's solve-time clock stops when it hears "solved".
+  // A roll asks for the whole second `useCelebration` allows, where a value only needs its flare: an
+  // edge has to be slow enough to be read as one crossing (design doc §9.1).
   const celebration = useCelebration(finished, ticks, skin.scroll ? 1000 : undefined)
   const reached = celebration.progress > 0 ? Math.round(celebration.progress * ticks) : undefined
   const counted = skin.scroll ? undefined : reached

--- a/src/mods/puzzle/app/sudoku/SudokuScrolls.tsx
+++ b/src/mods/puzzle/app/sudoku/SudokuScrolls.tsx
@@ -60,13 +60,18 @@ export const SudokuScrolls: FC<Props> = ({ puzzle, scroll, board, rolled }) => (
             // the roll would sit inside the foot of the chamber, a pale band across a board that is
             // supposed to be finished and whole.
             className={clsx("absolute inset-0 animate-furl", board)}
-            style={{ translate: "0 106%", boxShadow: `inset 0 6px 10px -2px ${scroll.shade}` }}
+            style={{ translate: "0 106%", boxShadow: `inset 0 10px 14px -4px ${scroll.shade}` }}
           >
             <div
               // The roll itself, straddling the edge it has reached: half over the bare table it has
               // uncovered, half over the sheet it is about to take up.
-              className="absolute inset-x-0 top-0 h-[7%] min-h-1.5 -translate-y-1/2 rounded-full"
-              style={{ background: scroll.roll, boxShadow: `0 -2px 6px ${scroll.shade}` }}
+              className="absolute inset-x-0 top-0 h-[11%] min-h-2 -translate-y-1/2 rounded-full"
+              style={{
+                background: scroll.roll,
+                // Cast both ways: onto the sheet it has not reached, and onto the bare table behind it.
+                // A roll with a shadow on one side only is a shape lying flat on the board.
+                boxShadow: `0 -3px 7px ${scroll.shade}, 0 4px 6px -2px ${scroll.shade}`,
+              }}
             />
           </div>
         </div>

--- a/src/mods/puzzle/app/sudoku/SudokuScrolls.tsx
+++ b/src/mods/puzzle/app/sudoku/SudokuScrolls.tsx
@@ -68,8 +68,7 @@ export const SudokuScrolls: FC<Props> = ({ puzzle, scroll, board, rolled }) => (
               className="absolute inset-x-0 top-0 h-[11%] min-h-2 -translate-y-1/2 rounded-full"
               style={{
                 background: scroll.roll,
-                // Cast both ways: onto the sheet it has not reached, and onto the bare table behind it.
-                // A roll with a shadow on one side only is a shape lying flat on the board.
+                // Cast both ways, or the roll is a shape lying flat on the board.
                 boxShadow: `0 -3px 7px ${scroll.shade}, 0 4px 6px -2px ${scroll.shade}`,
               }}
             />


### PR DESCRIPTION
The scroll run looked right in a still and wrong on a phone. I filmed it at 390px on the real clock rather than judging it from a paused story, and the reason is visible in the frames: most of them catch a chamber taken all the way up, and **a fully covered chamber is a flat rectangle**. Six of those blinking in and out read as the board coming apart, not as a register being filed.

Three changes, all the same lesson — what a roll has to show is an **edge travelling**, and it shows nothing where it has arrived.

- **The roll goes two thirds up its chamber and no further**, so a strip of writing stays under it for the whole of its travel and no chamber ever becomes a blank block.
- **Slower**: 520ms per roll instead of 420, and the run takes the full second the shell allows rather than eight tenths, so the edges cross slowly enough to be read as edges. One second is `useCelebration`'s ceiling, not a preference — the shell's solve-time clock stops when it hears "solved", so this costs 0.2s on a measured solve.
- **A thicker roll that casts a shadow both ways**, onto the sheet it has not reached and onto the table behind it. A shadow on one side only is a shape lying flat on the board.

The value run on the carved face is untouched — it flares in place, so it has nothing to travel.

## Checks

- `yarn test` — 222 files / 2564 tests pass
- `yarn check-types` — clean
- `yarn lint` — 0 errors (19 pre-existing warnings)
- filmed before and after at 390px, frames ~100ms apart across the whole run

`docs/game-design/puzzles/sudoku.md` §9.1 records both rules and where they came from — read off a phone rather than off a still.

No changelog entry: the sudoku family is still held back from the generated world, so this is lab-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4sQwAwD74fbSEJ6YTkYxS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4sQwAwD74fbSEJ6YTkYxS)_