### PR TITLE
Every room gets a puzzle no other room has

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated the crocodile puzzle to new standards.
 
+### Fixed
+
+- No two rooms in the world hand out the same puzzle any more. Rooms used to pick a board at random from
+  their difficulty's supply, so the same one turned up in several rooms of a journey; each room is now
+  dealt a board of its own.
+
 ## 0.39.0 - 2026-08-25
 
 ### Added

--- a/docs/instructions/puzzle-screens.md
+++ b/docs/instructions/puzzle-screens.md
@@ -342,10 +342,31 @@ mean it was accepted, so `grade` is the only thing that can tell the difference.
 instead (sumplete, futoshiki, lightbeam) are already telling you by returning at all, and grade
 re-checks the ladder and records what it demanded.
 
-**A room's seed indexes the list rather than seeding the generator.** `hashString(journeyId + edgeId)`
-is unchanged; `seeds[seed % seeds.length]` picks the entry. So the offline pass only ever enumerates
-_configurations_, never the rooms a player can reach — reassembling a floor or regenerating the world
-cannot invalidate a list.
+**A room is dealt its entry rather than drawing one.** Every room in the world takes a _different_ entry
+of its list: `src/game/seeds/boardIndex.ts` walks the world by journey → level → floor → chain → room,
+hands each room the next ordinal in whichever bucket it draws from, and the assembler stamps that onto
+the cell as `boardIndex`. `seeds[boardIndex]` is the board.
+
+Dealing rather than drawing is what makes a repeat impossible. Indexing the list by a hash of the room
+(`seeds[hashString(journeyId + edgeId) % seeds.length]`, what this replaced) is an independent draw per
+room, and independent draws collide: n rooms over a list of L repeat about n²/2L times whatever the hash
+does. Fourteen junior balance rooms over a fourteen-board list served one board three times and left five
+unused, and a player met the same scales in three pyramids of one journey. Dealing repeats nothing while
+the list covers the bucket — the invariant `seedFloor` already fails the build on.
+
+Two consequences worth knowing:
+
+- **The walk is by level, not by authored site** (`src/data/worldLevels.ts`). A tomb has one authored site
+  and re-enters it once per level, re-carved each time; counting the site once had every level of that
+  tomb serving the identical board.
+- **Ordinals are positional.** Insert a room early in a bucket and every later room in it shifts along
+  one, so the puzzle waiting in an unvisited room can change when the world is re-authored. A room the
+  player already solved is remembered as explored, not as a board, so nothing they finished moves.
+
+The offline pass still only ever enumerates _configurations_, never the rooms a player can reach —
+reassembling a floor or regenerating the world cannot invalidate a list. Where no assignment reaches a
+room — a story, a spec, the site builder, anything outside the baked world — it falls back to
+`seeds[hashString(journeyId + edgeId) % seeds.length]`, which is fine for a one-off board.
 
 A miss always falls through to live generation. That is not a failure path: it is how a tier being
 tuned still yields boards with no build step in the way, and how a lab `variant` (which changes the
@@ -358,9 +379,10 @@ else — seconds rather than the ten minutes a whole artifact takes, and a diff 
 every other family's rooms a different board. `--rebuild` re-searches everything, for when the generator
 itself changed and what shipped was proven under code that no longer exists.
 
-The surplus is the point: a room picks by `seed % seeds.length` off an arbitrary hash, so a list sized to its demand exactly repeats a board for
-certain while leaving another unused. `yarn seeds-info` reports coverage and what each tier's boards
-demand — the honest difficulty signal §5 names, which nothing else measures per board.
+The surplus is headroom for re-authoring, not variety: dealing already spends a bucket exactly once per
+room, so a list holding its floor repeats nothing. What the surplus buys is that moving rooms between
+buckets — which ordinary authoring does constantly — does not immediately push one past its list.
+`yarn seeds-info` reports coverage and what each tier's boards demand — the honest difficulty signal §5 names, which nothing else measures per board.
 `src/mods/puzzleSeeds.spec.ts` fails the build when a bucket is missing, orphaned, thinner than its
 target, or no longer grades.
 

--- a/scripts/puzzleSeeds.ts
+++ b/scripts/puzzleSeeds.ts
@@ -24,7 +24,7 @@ import { writeFileSync } from "node:fs"
 import { dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
 import { Worker } from "node:worker_threads"
-import { generatedWorldConfigs } from "../src/data/generatedWorld"
+import { worldLevelSites } from "../src/data/worldLevels"
 import { puzzleSeeds } from "../src/data/puzzleSeeds"
 import type { Grade } from "../src/game/families/familyMeta"
 import type { FoundSeed } from "../src/game/seeds/findSeeds"
@@ -58,7 +58,7 @@ const CHUNK = 500
 const only = flag("family")?.split(",")
 const rebuild = argv.includes("--rebuild")
 
-const allDemands = enumerateConfigs(generatedWorldConfigs, ALL_FAMILY_META)
+const allDemands = enumerateConfigs(worldLevelSites, ALL_FAMILY_META)
 const demands = allDemands.filter(demand => !only || only.includes(demand.familyId))
 const targetFor = (demand: ConfigDemand) => seedTarget(demand, CAP)
 const describe = (demand: ConfigDemand) => `${demand.familyId}/${demand.difficulty} (${demand.rooms} rooms)`

--- a/src/app/PyramidExpedition.tsx
+++ b/src/app/PyramidExpedition.tsx
@@ -272,6 +272,7 @@ export const PyramidExpedition: FC<{
             key={`${activeJourney.journeyId}-${activeJourney.levelNr}-${activeJourney.completionCount}`}
             journeyId={activeJourney.journeyId}
             siteConfig={pyramidJourney.siteConfigs[activeJourney.levelNr - 1] ?? pyramidJourney.siteConfigs[0]}
+            levelIndex={activeJourney.levelNr - 1}
             seed={activeJourney.randomSeed + activeJourney.levelNr}
             onSiteComplete={flow.interiorComplete}
             onCancel={flow.leaveInterior}

--- a/src/app/SiteMap/SiteMapScreen.spec.tsx
+++ b/src/app/SiteMap/SiteMapScreen.spec.tsx
@@ -85,6 +85,7 @@ describe(SiteMapScreen, () => {
       <SiteMapScreen
         journeyId="test-journey"
         siteConfig={[floorConfig]}
+        levelIndex={0}
         seed={1}
         onSiteComplete={onSiteComplete}
         onCancel={() => {}}

--- a/src/app/SiteMap/SiteMapScreen.tsx
+++ b/src/app/SiteMap/SiteMapScreen.tsx
@@ -40,12 +40,16 @@ import "@/mods/registerModApps"
 type Props = {
   journeyId: string
   siteConfig: SiteConfig
+  /** Which level of the journey this is (levelNr - 1) — the address its rooms draw their boards by
+   * (src/game/seeds/boardIndex.ts). A tomb re-enters one authored site per level, so the level is what
+   * separates those visits, not the site. */
+  levelIndex: number
   seed: number
   onSiteComplete: () => void
   onCancel: () => void
 }
 
-export const SiteMapScreen = ({ journeyId, siteConfig, seed, onSiteComplete, onCancel }: Props) => {
+export const SiteMapScreen = ({ journeyId, siteConfig, levelIndex, seed, onSiteComplete, onCancel }: Props) => {
   const { t } = useTranslation(["common", "inventory", "sellables"])
   const journeys = useJourneys()
   const progression = useProgression()
@@ -73,7 +77,8 @@ export const SiteMapScreen = ({ journeyId, siteConfig, seed, onSiteComplete, onC
     allEdges,
     journeyState?.position,
     detectorLevels.corridor,
-    foundCorridors
+    foundCorridors,
+    levelIndex
   )
 
   const corridors = useCorridorDetection({

--- a/src/app/SiteMap/boardIndexes.ts
+++ b/src/app/SiteMap/boardIndexes.ts
@@ -1,0 +1,19 @@
+import { worldLevelSites } from "@/data/worldLevels"
+import { buildBoardIndexes, type ResolveBoardIndex } from "@/game/seeds/boardIndex"
+import { ALL_FAMILY_META } from "@/mods/allFamilyMeta"
+import { resolveEncounter } from "@/app/families/familyRegistry"
+
+// The whole world's board assignment, built once on first use (a few thousand entries) and kept for the
+// session — every floor assembled after that is a map lookup.
+let indexes: ReturnType<typeof buildBoardIndexes> | null = null
+
+/**
+ * The board assignment for one floor of one site, in the form the assembler wants: it knows a room's
+ * chain and position along it, this closure knows which floor of which site that chain belongs to.
+ */
+export const boardIndexesForFloor =
+  (journeyId: string, levelIndex: number, floorIndex: number): ResolveBoardIndex =>
+  (familyId, address) => {
+    indexes ??= buildBoardIndexes(worldLevelSites, ALL_FAMILY_META, resolveEncounter)
+    return indexes(journeyId, levelIndex, floorIndex, familyId, address)
+  }

--- a/src/app/SiteMap/useAssembledFloor.ts
+++ b/src/app/SiteMap/useAssembledFloor.ts
@@ -4,6 +4,7 @@ import { completeCell } from "@/game/gridNavigation"
 import type { Direction, FloorConfig, FloorGrid, GridCell } from "@/game/siteTypes"
 import { resolveEncounter, getFamilyPlugin } from "@/app/families/familyRegistry"
 import type { ResolveKeyRequirements } from "@/game/siteAssembler"
+import { boardIndexesForFloor } from "./boardIndexes"
 
 // A node's own key requirements, resolved from whichever family declares them (a tableau's
 // hieroglyphs, etc.) — the same dispatch world-gen uses, but off the app-side family registry so
@@ -135,7 +136,10 @@ export const useAssembledFloor = (
   exploredSections: Record<string, string[]>,
   position: string | null | undefined,
   detectionLevel = 0,
-  revealedSections?: ReadonlySet<string>
+  revealedSections?: ReadonlySet<string>,
+  // Which level of the journey this floor belongs to, so its rooms can be dealt their boards
+  // (src/game/seeds/boardIndex.ts). Unset outside the baked world — stories, specs, the builder.
+  levelIndex?: number
 ): {
   grid: FloorGrid | null
   explorerPos: readonly [number, number]
@@ -147,9 +151,12 @@ export const useAssembledFloor = (
     const result = assembleFloor(journeyId, floorConfig, seed + currentFloor, resolveEncounter, {
       resolveKeyRequirements,
       floorRef: { journeyId, floorIndex: currentFloor },
+      ...(levelIndex !== undefined
+        ? { resolveBoardIndex: boardIndexesForFloor(journeyId, levelIndex, currentFloor) }
+        : {}),
     })
     return result.success ? result.grid : null
-  }, [journeyId, floorConfig, seed, currentFloor])
+  }, [journeyId, floorConfig, seed, currentFloor, levelIndex])
 
   const effectiveExplored = useMemo(() => {
     if (!baseGrid) return exploredSections

--- a/src/app/SiteMap/useEncounter.ts
+++ b/src/app/SiteMap/useEncounter.ts
@@ -70,6 +70,7 @@ export const useEncounter = ({
       reward: cell?.type === "room" ? cell.reward : undefined,
       stock: cell?.type === "room" ? cell.stock : undefined,
       pathIndex: cell?.type === "room" ? cell.pathIndex : undefined,
+      boardIndex: cell?.type === "room" ? cell.boardIndex : undefined,
       encounterArgs: cell?.type === "room" ? cell.encounterArgs : undefined,
       // The skin this room was authored to wear (docs/instructions/puzzle-screens.md §2). Core carries the
       // name and reads nothing into it; unset means every family draws its default.

--- a/src/app/SiteMap/worldFloorAssembly.spec.ts
+++ b/src/app/SiteMap/worldFloorAssembly.spec.ts
@@ -3,6 +3,12 @@ import { assembleFloor, type ResolveKeyRequirements } from "@/game/siteAssembler
 import { resolveEncounter, getFamilyPlugin } from "@/app/families/familyRegistry"
 import { journeys } from "@/data/journeys"
 import { floorAssemblySeed, persistentInteriorSeed } from "@/game/siteSeed"
+import { configHash } from "@/game/seeds/configHash"
+import { puzzleSeeds } from "@/data/puzzleSeeds"
+import { hashString } from "@/support/hashString"
+import { boardIndexesForFloor } from "./boardIndexes"
+import { encodeEdge } from "./useAssembledFloor"
+import type { Difficulty } from "@/data/difficultyLevels"
 import type { FloorConfig, FloorGrid } from "@/game/siteTypes"
 // Populate the family registry, exactly as the app does — a room resolves its family through it.
 import "@/mods/registerModApps"
@@ -11,7 +17,14 @@ import "@/mods/registerModApps"
 const resolveKeyRequirements: ResolveKeyRequirements = (familyId, ctx) =>
   getFamilyPlugin(familyId)?.meta.resolveKeyRequirements?.(ctx)
 
-type Floor = { label: string; config: FloorConfig; seed: number; floorIndex: number; journeyId: string }
+type Floor = {
+  label: string
+  config: FloorConfig
+  seed: number
+  floorIndex: number
+  journeyId: string
+  levelIndex: number
+}
 
 // Every floor a player can be sent into, at the exact seed the runtime will use.
 // Mirrors PyramidExpedition: one site per level number (1-based), falling back to the first
@@ -24,7 +37,8 @@ const allFloors = (): Floor[] => {
     if (!siteConfigs?.length) continue
     const siteSeed = persistentInteriorSeed(journey.id)
     for (let levelNr = 1; levelNr <= journey.levelCount; levelNr++) {
-      const site = siteConfigs[levelNr - 1] ?? siteConfigs[0]
+      const levelIndex = levelNr - 1
+      const site = siteConfigs[levelIndex] ?? siteConfigs[0]
       site.forEach((config, floorIndex) => {
         floors.push({
           label: `${journey.id} level ${levelNr} floor ${floorIndex}`,
@@ -32,6 +46,7 @@ const allFloors = (): Floor[] => {
           seed: floorAssemblySeed(siteSeed, levelNr, floorIndex),
           floorIndex,
           journeyId: journey.id,
+          levelIndex,
         })
       })
     }
@@ -315,4 +330,81 @@ describe("what a world-spec setting may and may not move", () => {
     },
     120_000
   )
+})
+
+// Boards are DEALT, not drawn: every room in the world takes a different entry of its family's seed
+// list (src/game/seeds/boardIndex.ts). The scheme it replaced indexed the list by a hash of the room's
+// identity — an independent draw per room, so a journey with fourteen balance rooms over a fourteen-board
+// list handed one board out three times and left five boards unused, and a player met the same puzzle in
+// pyramid 1, pyramid 2 and pyramid 3. This is the sweep that says it cannot happen again: it assembles
+// the world the runtime assembles and asks which board every room actually serves.
+describe("no two rooms in the world serve the same board", () => {
+  // What a room really builds: the family's own list entry, or its identity hash where a bucket has no
+  // list yet (generatePuzzle's fallback, which draws with replacement and so may legitimately repeat).
+  const boardOf = (
+    familyId: string,
+    difficulty: Difficulty | undefined,
+    boardIndex: number | undefined,
+    seed: number
+  ): { bucket: string; board: string; listed: boolean } | null => {
+    const seedable = getFamilyPlugin(familyId)?.meta.seedable
+    if (!seedable) return null
+    const bucket = configHash(seedable.resolveOptions({ difficulty }))
+    const list = puzzleSeeds[bucket]
+    if (!list?.length) return { bucket, board: `unlisted:${seed}`, listed: false }
+    return { bucket, board: String(list[(boardIndex ?? seed) % list.length]), listed: true }
+  }
+
+  const seedableRooms = () =>
+    allFloors().flatMap(floor => {
+      const result = assembleFloor(floor.journeyId, floor.config, floor.seed, resolveEncounter, {
+        resolveKeyRequirements,
+        floorRef: { journeyId: floor.journeyId, floorIndex: floor.floorIndex },
+        resolveBoardIndex: boardIndexesForFloor(floor.journeyId, floor.levelIndex, floor.floorIndex),
+      })
+      if (!result.success) return []
+      return result.grid.cells.flatMap((row, r) =>
+        row.flatMap((cell, c) => {
+          if (cell.type !== "room" || !cell.family) return []
+          const difficulty = cell.difficulty ?? floor.config.difficulty
+          const seed = hashString(floor.journeyId + encodeEdge(floor.floorIndex, r, c))
+          const board = boardOf(cell.family, difficulty, cell.boardIndex, seed)
+          return board ? [{ ...board, dealt: cell.boardIndex !== undefined, label: ` / at ,` }] : []
+        })
+      )
+    })
+
+  it("deals every listed room its own board", () => {
+    const rooms = seedableRooms()
+    expect(rooms.length).toBeGreaterThan(1000)
+
+    // A room the assignment never reached falls back to its own hash, which is the very thing this
+    // replaced — so a gap in the walk has to fail here, not quietly draw with replacement.
+    const undealt = rooms.filter(room => !room.dealt).map(room => room.label)
+    expect(undealt.slice(0, 10), ` room(s) were dealt no board`).toEqual([])
+
+    const byBoard = new Map<string, string[]>()
+    for (const room of rooms.filter(r => r.listed))
+      byBoard.set(`${room.bucket}#${room.board}`, [...(byBoard.get(`${room.bucket}#${room.board}`) ?? []), room.label])
+    const shared = [...byBoard.entries()].filter(([, where]) => where.length > 1)
+
+    expect(
+      shared.map(([board, where]) => `${board}: ${where.join(" || ")}`),
+      `${shared.length} board(s) served to more than one room`
+    ).toEqual([])
+  }, 120_000)
+
+  // The invariant the dealing rests on, stated on its own so a bucket that outgrows its list fails here
+  // with the bucket named, rather than as a pile of shared boards. `yarn generate-seeds` is the fix.
+  it("keeps every bucket's rooms within its list", () => {
+    const overSubscribed = new Map<string, number>()
+    for (const room of seedableRooms().filter(r => r.listed))
+      overSubscribed.set(room.bucket, (overSubscribed.get(room.bucket) ?? 0) + 1)
+
+    const tooSmall = [...overSubscribed.entries()]
+      .filter(([bucket, rooms]) => rooms > (puzzleSeeds[bucket]?.length ?? 0))
+      .map(([bucket, rooms]) => `${bucket}: ${rooms} rooms over a ${puzzleSeeds[bucket]?.length ?? 0}-seed list`)
+
+    expect(tooSmall, "run `yarn generate-seeds`").toEqual([])
+  }, 120_000)
 })

--- a/src/app/families/familyRegistry.ts
+++ b/src/app/families/familyRegistry.ts
@@ -35,6 +35,10 @@ export type FamilyContext = {
   // (e.g. a tableau's `{ runNr }`), carried from the assembled cell. The tableau family reads both
   // to re-derive the exact authored TableauLevel world-gen placed fragments for. Opaque to core.
   pathIndex?: number
+  // Which entry of this room's seed list to build (src/game/seeds/boardIndex.ts) — dealt at assembly so
+  // no two rooms in the world serve the same board. Unset outside the baked world; generatePuzzle then
+  // falls back to indexing the list by the room's own hash.
+  boardIndex?: number
   encounterArgs?: unknown
   // A shop node's stock: the reward slots the mods placed into this node's `rewards[]` (currency
   // pieces + consumables). The fez-shop family renders these as its buyable list. Entries may be

--- a/src/data/worldLevels.ts
+++ b/src/data/worldLevels.ts
@@ -1,0 +1,24 @@
+import type { SiteConfig } from "@/game/siteTypes"
+import { generatedWorldConfigs } from "./generatedWorld"
+import { PYRAMID_STRUCTURES, TOMB_STRUCTURES } from "./journeyStructure"
+
+/**
+ * Which site each of a journey's levels sends the player into — one entry per level, not per authored
+ * site. A journey with a site per level maps one to one; a tomb has a single site and every one of its
+ * levels re-enters it, re-carved at that level's own seed.
+ *
+ * Levels rather than sites is what anything counting the world's rooms has to walk: a tomb's one authored
+ * balance room is a room the player meets once per level, and counting the site once had every level of
+ * that tomb serving the identical board.
+ */
+export const worldLevelSites: Record<string, SiteConfig[]> = Object.fromEntries(
+  [...PYRAMID_STRUCTURES, ...TOMB_STRUCTURES]
+    .filter(({ id }) => generatedWorldConfigs[id]?.length)
+    .map(({ id, levelCount }) => [
+      id,
+      Array.from(
+        { length: levelCount },
+        (_unused, level) => generatedWorldConfigs[id][level] ?? generatedWorldConfigs[id][0]
+      ),
+    ])
+)

--- a/src/game/families/familyMeta.ts
+++ b/src/game/families/familyMeta.ts
@@ -71,6 +71,10 @@ export type FamilyMeta = {
 export type FamilyGenerationCtx = {
   difficulty?: Difficulty
   variant?: string
+  /** Which entry of the resolved bucket's seed list to build (src/game/seeds/boardIndex.ts). Reaches
+   * generatePuzzle, never `resolveOptions`'s result — the bucket key is the options, so which board a
+   * room draws cannot change which list it draws from. */
+  boardIndex?: number
 }
 
 // What solving an admitted board taught the offline pass. Reported by the CLI so a designer tuning a

--- a/src/game/seeds/boardIndex.ts
+++ b/src/game/seeds/boardIndex.ts
@@ -1,0 +1,97 @@
+import type { FamilyMeta } from "@/game/families/familyMeta"
+import type { EncounterResolution, ResolveEncounter } from "@/game/siteAssembler"
+import type { FloorConfig, SiteConfig, SubSection } from "@/game/siteTypes"
+import { configHash } from "./configHash"
+
+/**
+ * Where a room sits in the AUTHORING — which chain, and which room along it. Not a maze position:
+ * a floor re-carves whenever its seed moves, but the chains it was authored from do not, so this is
+ * what stays put across a re-carve.
+ */
+export type RoomAddress = { section: string; pathIndex: number }
+
+/** What the assembler asks for a room, once it knows which family the room actually resolved to. */
+export type ResolveBoardIndex = (familyId: string, address: RoomAddress) => number | undefined
+
+/**
+ * Which entry of its family's seed list each room in the world draws (`docs/instructions/puzzle-screens.md`
+ * §6.1). Every room in one list's bucket gets a DIFFERENT entry — the whole point, since the previous
+ * scheme indexed the list by a hash of the room's identity and so drew with replacement: 14 rooms over a
+ * 14-board list handed some board out three times and left five unused. Dealing instead of drawing makes
+ * a repeat impossible while the list covers the bucket, which is exactly the invariant `seedFloor` in
+ * enumerateConfigs.ts already fails the build on.
+ *
+ * Ordinals are assigned world-wide rather than per journey, so no two rooms anywhere serve the same board.
+ * They are also positional: insert a room early in a bucket and every later room in it shifts along one.
+ * That costs nothing at play time (a room the player has already solved is remembered as explored, not as
+ * a board) but it does mean the puzzle waiting in an unvisited room can change when the world is
+ * re-authored.
+ */
+export type BoardIndexes = (
+  journeyId: string,
+  levelIndex: number,
+  floorIndex: number,
+  familyId: string,
+  address: RoomAddress
+) => number | undefined
+
+const addressKey = (
+  journeyId: string,
+  levelIndex: number,
+  floorIndex: number,
+  familyId: string,
+  { section, pathIndex }: RoomAddress
+): string => `${journeyId}|${levelIndex}|${floorIndex}|${section}|${pathIndex}|${familyId}`
+
+/**
+ * One floor's chains, addressed exactly as the assembler addresses them: the main path, then each side
+ * section, then that section's own sub-sections. Nesting stops one level down because that is as deep as
+ * the assembler carves — anything deeper is authored but never built, and must not consume a board.
+ */
+const chainsOf = (floor: FloorConfig): Array<{ section: SubSection | FloorConfig; address: string }> => [
+  { section: floor, address: "main" },
+  ...floor.sideSections.flatMap((side, i) => [
+    { section: side, address: `s${i}` },
+    ...(side.sideSections ?? []).map((sub, j) => ({ section: sub, address: `s${i}.${j}` })),
+  ]),
+]
+
+/** `world` is keyed by journey and indexed by LEVEL, not by authored site (src/data/worldLevels.ts) — a
+ * tomb re-enters its one site once per level, and each of those visits is a room of its own. */
+export const buildBoardIndexes = (
+  world: Record<string, SiteConfig[]>,
+  families: FamilyMeta[],
+  resolveEncounter: ResolveEncounter
+): BoardIndexes => {
+  const byId = new Map(families.map(family => [family.id, family]))
+  const nextInBucket = new Map<string, number>()
+  const indexes = new Map<string, number>()
+
+  // Sorted so the walk cannot ride on the generated file's key order.
+  for (const journeyId of Object.keys(world).sort())
+    world[journeyId].forEach((levelSite, levelIndex) =>
+      levelSite.forEach((floor, floorIndex) => {
+        for (const { section, address } of chainsOf(floor))
+          for (let pathIndex = 0; pathIndex < section.pathPuzzles; pathIndex++) {
+            // The assembler's own resolution, injected — an authored tag, an "any of these" pool, or
+            // nothing at all must land on the same family here as it does when the floor is built.
+            const { familyId }: EncounterResolution = resolveEncounter(
+              section.encountersByIndex?.[pathIndex] ?? section.encounter,
+              "puzzle"
+            )
+            const seedable = byId.get(familyId)?.seedable
+            if (!seedable) continue
+            const bucket = configHash(seedable.resolveOptions({ difficulty: section.difficulty }))
+            const ordinal = nextInBucket.get(bucket) ?? 0
+            nextInBucket.set(bucket, ordinal + 1)
+            indexes.set(
+              addressKey(journeyId, levelIndex, floorIndex, familyId, { section: address, pathIndex }),
+              ordinal
+            )
+          }
+      })
+    )
+
+  return (journeyId, levelIndex, floorIndex, familyId, address) =>
+    indexes.get(addressKey(journeyId, levelIndex, floorIndex, familyId, address))
+}

--- a/src/game/seeds/enumerateConfigs.ts
+++ b/src/game/seeds/enumerateConfigs.ts
@@ -15,12 +15,12 @@ export type ConfigDemand = {
 /**
  * Two numbers, and keeping them apart is what stops ordinary authoring from forcing a regeneration.
  *
- * `seedTarget` is what the offline pass AIMS for: half again the rooms that draw from the bucket. A
- * room picks its board by `roomSeed % seeds.length` from an arbitrary hash, so a list sized to its
- * demand exactly still hands one board out twice while leaving another unused. The surplus is what
- * makes a repeat unlikely instead of certain.
+ * `seedTarget` is what the offline pass AIMS for: half again the rooms that draw from the bucket. The
+ * surplus is not variety — boards are dealt, one per room (boardIndex.ts), so a list holding its floor
+ * repeats nothing. It is headroom, so that moving rooms between buckets doesn't push one past its list.
  *
- * `seedFloor` is what the shipped artifact must CLEAR, and it is the demand itself. The gap between
+ * `seedFloor` is what the shipped artifact must CLEAR, and it is the demand itself — and since a room
+ * is dealt an entry rather than drawing one, clearing it is exactly what makes a repeat impossible. The gap between
  * them is deliberate headroom: re-authoring a journey moves room counts around constantly, and a
  * bucket filled to 1.5× its old demand still covers the new one unless that demand grew by half. So
  * the build goes red when the lists genuinely cannot cover the world — a family added, a family

--- a/src/game/seeds/generatePuzzle.ts
+++ b/src/game/seeds/generatePuzzle.ts
@@ -9,10 +9,14 @@ const VERIFIED_ATTEMPTS = 1
  * Builds a family's board for one encounter, from its list where there is one
  * (`docs/instructions/puzzle-screens.md` §6.1).
  *
- * `seed` stays what it has always been — a hash of the room's identity — but it indexes the list
- * rather than seeding the generator. That is what keeps the offline pass tractable: it has to
- * enumerate the configurations that exist, never the rooms a player can reach, so reassembling a floor
- * or regenerating the world cannot invalidate a list.
+ * Which entry a room takes is dealt to it by `ctx.boardIndex` (src/game/seeds/boardIndex.ts), so no two
+ * rooms in the world take the same one. `seed` — a hash of the room's identity — is the fallback for a
+ * site outside the baked world (a story, a spec, the builder), and it draws WITH replacement: fine for
+ * one-off boards, which is why the real world does not use it.
+ *
+ * Either way the seed indexes the list rather than seeding the generator. That is what keeps the offline
+ * pass tractable: it has to enumerate the configurations that exist, never the rooms a player can reach,
+ * so reassembling a floor or regenerating the world cannot invalidate a list.
  */
 export const generatePuzzle = <T>(meta: FamilyMeta, seed: number, ctx: FamilyGenerationCtx): T => {
   const { seedable } = meta
@@ -23,5 +27,5 @@ export const generatePuzzle = <T>(meta: FamilyMeta, seed: number, ctx: FamilyGen
   // which is what every family did before there were lists. Slower, never wrong, and it is what keeps
   // the puzzle lab usable while a tier is being tuned.
   if (!listed?.length) return seedable.generate(seed, options) as T
-  return seedable.generate(listed[seed % listed.length], options, VERIFIED_ATTEMPTS) as T
+  return seedable.generate(listed[(ctx.boardIndex ?? seed) % listed.length], options, VERIFIED_ATTEMPTS) as T
 }

--- a/src/game/siteAssembler.ts
+++ b/src/game/siteAssembler.ts
@@ -13,6 +13,7 @@ import type {
   SideSection,
   DecorationKind,
 } from "./siteTypes"
+import type { ResolveBoardIndex } from "./seeds/boardIndex"
 import { validateSite } from "./siteValidator"
 
 // Resolves an authored `encounter` (exact family id, or tag(s)) to a concrete family id
@@ -363,6 +364,10 @@ const spreadContentIndices = (count: number, startIdx: number, totalLen: number)
 export type AssembleFloorKeyRequirements = {
   resolveKeyRequirements?: ResolveKeyRequirements
   floorRef?: { journeyId: string; floorIndex: number }
+  /** Which seed-list entry each room draws, by its authored address — injected for the same reason
+   * resolveEncounter is: this module knows a floor's chains, never which world they belong to.
+   * Absent (stories, specs, the builder) leaves rooms unstamped and they index by their own hash. */
+  resolveBoardIndex?: ResolveBoardIndex
 }
 
 export const assembleFloor = (
@@ -372,8 +377,11 @@ export const assembleFloor = (
   resolveEncounter: ResolveEncounter = defaultResolveEncounter,
   keyRequirements: AssembleFloorKeyRequirements = {}
 ): AssemblerResult => {
-  const { resolveKeyRequirements = defaultResolveKeyRequirements, floorRef = { journeyId: siteId, floorIndex: 0 } } =
-    keyRequirements
+  const {
+    resolveKeyRequirements = defaultResolveKeyRequirements,
+    floorRef = { journeyId: siteId, floorIndex: 0 },
+    resolveBoardIndex,
+  } = keyRequirements
   const treasureChest = resolveEncounter("treasure-chest", "treasure-chest")
   const fezShop = resolveEncounter("fez-shop", "fez-shop")
   const keyGate = resolveEncounter("key-gate", "key-gate")
@@ -1124,11 +1132,13 @@ export const assembleFloor = (
           pathIndex: k,
           encounterArgs: config.encounterArgs,
         })
+        const boardIndex = resolveBoardIndex?.(family.familyId, { section: "main", pathIndex: k })
         roomSpecs.set(posKey(r, c), {
           roomType: "encounter",
           family: family.familyId,
           tags: family.tags,
           pathIndex: k,
+          ...(boardIndex !== undefined ? { boardIndex } : {}),
           ...(config.encounterArgs !== undefined ? { encounterArgs: config.encounterArgs } : {}),
           difficulty: config.difficulty,
           ...(config.theme !== undefined ? { theme: config.theme } : {}),
@@ -1206,6 +1216,7 @@ export const assembleFloor = (
           pathIndex: pi,
           encounterArgs: section.encounterArgs,
         })
+        const boardIndex = resolveBoardIndex?.(family.familyId, { section: `s${sectionIdx}`, pathIndex: pi })
         roomSpecs.set(posKey(r, c), {
           roomType: "encounter",
           // Never inherits the floor's own tableau encounter — tableaus consume hieroglyph
@@ -1214,6 +1225,7 @@ export const assembleFloor = (
           family: family.familyId,
           tags: family.tags,
           pathIndex: pi,
+          ...(boardIndex !== undefined ? { boardIndex } : {}),
           ...(section.encounterArgs !== undefined ? { encounterArgs: section.encounterArgs } : {}),
           difficulty: section.difficulty,
           ...(section.theme !== undefined ? { theme: section.theme } : {}),
@@ -1256,7 +1268,16 @@ export const assembleFloor = (
     }
 
     // Sub-section nodes
-    for (const { subSection, cells, keyNodeId, isKeyHost, keyHostColor, keyHostColors } of subSectionGroups) {
+    for (const {
+      subSection,
+      cells,
+      keyNodeId,
+      isKeyHost,
+      keyHostColor,
+      keyHostColors,
+      parentSectionIdx,
+      subSectionIdx,
+    } of subSectionGroups) {
       const isFloorKeyGate = subSection.gate?.type === "floor-key"
       const isTombKeyGate = subSection.gate?.type === "tomb-key"
       let contentStart = 0
@@ -1304,6 +1325,10 @@ export const assembleFloor = (
           pathIndex: pi,
           encounterArgs: subSection.encounterArgs,
         })
+        const boardIndex = resolveBoardIndex?.(family.familyId, {
+          section: `s${parentSectionIdx}.${subSectionIdx}`,
+          pathIndex: pi,
+        })
         roomSpecs.set(posKey(r, c), {
           roomType: "encounter",
           // Same reasoning as the side-section case above: never inherits the floor's
@@ -1311,6 +1336,7 @@ export const assembleFloor = (
           family: family.familyId,
           tags: family.tags,
           pathIndex: pi,
+          ...(boardIndex !== undefined ? { boardIndex } : {}),
           ...(subSection.encounterArgs !== undefined ? { encounterArgs: subSection.encounterArgs } : {}),
           difficulty: subSection.difficulty,
           ...(subSection.theme !== undefined ? { theme: subSection.theme } : {}),

--- a/src/game/siteTypes.ts
+++ b/src/game/siteTypes.ts
@@ -67,6 +67,11 @@ export type RoomCell = {
   // family re-deriving which TableauLevel it presents from journeyId + the section's own
   // encounterArgs.runNr + this index, not from floor position).
   pathIndex?: number
+  // Which entry of its family's seed list this room draws (see src/game/seeds/boardIndex.ts). Every
+  // room drawing from one list gets a different entry, so no two rooms in the world serve the same
+  // board. Unset where the site isn't part of the baked world (stories, specs, the builder), and the
+  // room falls back to indexing the list by its own hash.
+  boardIndex?: number
   // The authored encounter args for this room's family (e.g. a tableau's `{ runNr }`), carried
   // from the FloorConfig/SideSection so the play-time family can re-derive exactly what world-gen
   // resolved (which authored TableauLevel this is). Opaque to core; each family reads it via its

--- a/src/mods/puzzleSeeds.spec.ts
+++ b/src/mods/puzzleSeeds.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { puzzleSeeds } from "@/data/puzzleSeeds"
-import { generatedWorldConfigs } from "@/data/generatedWorld"
+import { worldLevelSites } from "@/data/worldLevels"
 import { enumerateConfigs, seedFloor } from "@/game/seeds/enumerateConfigs"
 import { generatePuzzle } from "@/game/seeds/generatePuzzle"
 import { ALL_FAMILY_META } from "@/mods/allFamilyMeta"
@@ -9,7 +9,7 @@ import { ALL_FAMILY_META } from "@/mods/allFamilyMeta"
 // time falls back to generating live — so this does not protect correctness. It protects the reason
 // the lists exist: a dial moved, the key moved with it, and the top tier is quietly back to searching
 // on the player's phone.
-const demands = enumerateConfigs(generatedWorldConfigs, ALL_FAMILY_META)
+const demands = enumerateConfigs(worldLevelSites, ALL_FAMILY_META)
 
 describe("shipped puzzle seeds", () => {
   it("covers every configuration the baked world asks a seedable family for", () => {


### PR DESCRIPTION
A player reported meeting the same balance puzzle several times in Valley of the Artisans (junior_2), pyramid 3. It reproduces, and it wasn't bad luck.

## The bug

A room built its board with `listed[hashString(journeyId + edgeId) % listed.length]` — an independent draw per room, from a list sized at roughly its demand. Independent draws collide: n rooms over a list of L repeat about n²/2L times no matter how good the hash is.

In the released world, junior_2 had 14 balance rooms over a 14-board list:

```
L1F0 #2   L1F0 #5   L1F0 #9   L1F0 #0   L1F2 #1
L2F2 #2   L3F0 #9   L3F0 #10  L3F0 #1   L3F0 #2
L3F2 #7   L4F2 #3   L5F2 #6   L6F2 #9
```

Board #2 three times, #9 three times, #1 twice — and pyramid 3 alone holds four balance rooms, three of which repeat a board from pyramid 1 or 2.

Measured over the whole baked world, the distribution was doing exactly what uniform draws predict — 400 repeat rooms observed of 1514 against 388 expected, 137 within a single journey against 122 expected. Nothing was skewed. The lottery itself was the bug, so growing the lists wasn't a fix: zero repeats by list size alone needs L ≈ n², about 200 boards for balance/junior and ~13,700 for twin-stars/wizard.

## The fix

Deal instead of draw. `src/game/seeds/boardIndex.ts` walks the world by journey → level → floor → chain → room and hands each room the next ordinal in whichever bucket it draws from. The assembler stamps that on the cell as `boardIndex` (injected as a resolver, the same way `resolveEncounter` is, so the assembler still knows nothing about which world a floor belongs to), and `generatePuzzle` builds `listed[boardIndex]`.

A repeat is then impossible while a list covers its bucket — which is exactly the invariant `seedFloor` already fails the build on.

| | repeat rooms world-wide | within one journey |
|---|---|---|
| before | 400 of 1514 | 137 |
| after | **0** | **0** |

Rooms outside the baked world — stories, specs, the site builder — are dealt nothing and fall back to the old hash indexing, which is fine for a one-off board.

## Level, not site

The first run of the new sweep failed on two rooms, and it was a real bug rather than a test artifact: a tomb has **one** authored site and re-enters it once per level, so addressing rooms by site had every level of `junior_treasure_tomb` serving the same balance board (and `expert_treasure_tomb` the same twin-stars).

`src/data/worldLevels.ts` is the level view — one entry per level, falling back to site 0 the way the runtime does — and both the demand count (`enumerateConfigs`, via `scripts/puzzleSeeds.ts` and `puzzleSeeds.spec.ts`) and the dealing walk it. World room count went 1506 → 1514. Every bucket still clears its floor, so **no seeds were regenerated** and no board any player has already seen moved for that reason.

## What re-authoring costs

Ordinals are positional: insert a room early in a bucket and every later room in it shifts along one, so the puzzle waiting in an *unvisited* room can change when the world is re-authored. A room the player already solved is remembered as explored, not as a board, so nothing they finished moves. If a themed push grows a bucket past its list, the build names the bucket and `yarn generate-seeds` refills it.

## Tests

Two sweeps in `worldFloorAssembly.spec.ts` (`yarn verify-floors`), over the world as the runtime assembles it:

- no board is served to more than one room, and no room goes undealt (a gap in the walk would silently fall back to the old draw — this fails instead)
- no bucket's rooms outgrow its list, named individually so the fix is obvious

Full suite green: 2558 tests.

## Docs

`docs/instructions/puzzle-screens.md` §6.1 rewritten — its "the surplus is what makes a repeat unlikely instead of certain" was the wrong math, and the surplus is now correctly described as headroom for re-authoring rather than variety. Same correction in `enumerateConfigs.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019LeUJbFYDCac81dLfboMtd